### PR TITLE
[WIP] Enable support for the `@_section` experimental attribute.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -126,6 +126,8 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("AccessLevelOnImport"),
       .enableUpcomingFeature("InternalImportsByDefault"),
 
+      .enableExperimentalFeature("SymbolLinkageMarkers"),
+
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
 
       .define("SWT_NO_FILE_IO", .when(platforms: [.wasi])),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -125,6 +125,8 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("AccessLevelOnImport"),
       .enableUpcomingFeature("InternalImportsByDefault"),
 
+      .enableExperimentalFeature("SymbolLinkageMarkers"),
+
       .define("SWT_TARGET_OS_APPLE", .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])),
 
       .define("SWT_NO_FILE_IO", .when(platforms: [.wasi])),

--- a/Sources/_TestingInternals/include/Discovery.h
+++ b/Sources/_TestingInternals/include/Discovery.h
@@ -40,6 +40,36 @@ SWT_EXTERN void swt_enumerateTypesWithNamesContaining(
   SWTTypeEnumerator body
 ) SWT_SWIFT_NAME(swt_enumerateTypes(withNamesContaining:_:_:));
 
+/// A function type for functions that produce tests.
+///
+/// This type is fully defined by the Swift module as `__TestGetter`. See the
+/// declaration of that type for more information.
+typedef void (*SWTTestGetter)(void *_Nonnull);
+
+/// The type of callback that is called by `swt_enumerateTestGetters()`.
+///
+/// - Parameters:
+///   - fp: The underlying function pointer to the Swift function that gets the
+///     associated test.
+///   - context: An arbitrary pointer passed by the caller to
+///     `swt_enumerateTestGetters()`.
+typedef void (* SWTTestGetterEnumerator)(SWTTestGetter fp, void *_Null_unspecified context);
+
+/// Enumerate all types known to Swift found in the current process.
+///
+/// - Parameters:
+///   - nameFilter: If not `nullptr`, a filtering function that checks if a type
+///     name is valid before realizing the type.
+///   - body: A function to invoke. `context` is passed to it along with a
+///     type metadata pointer (which can be bitcast to `Any.Type`.)
+///   - context: An arbitrary pointer to pass to `body`.
+///
+/// This function may enumerate the same type more than once (for instance, if
+/// it is present in an image's metadata table multiple times, or if it is an
+/// Objective-C class implemented in Swift.) Callers are responsible for
+/// deduping type metadata pointers passed to `body`.
+SWT_EXTERN void swt_enumerateTestGetters(void *_Null_unspecified context, SWTTestGetterEnumerator body);
+
 SWT_ASSUME_NONNULL_END
 
 #endif


### PR DESCRIPTION
This PR enables support for `@_used` and `@_section` to allow embedding test data directly into its own section in a binary. This means we don't have to look up synthesized test types at runtime.

Limitations:

1. Test clients must enable support for the experimental `"SymbolLinkageMarkers"` feature.
1. The `@_section` attribute currently doesn't support application to constants of function type, thinking they are non-constant.
1. We will need to make a change to the Swift runtime on Linux/Windows to add the new section to `MetadataSections` (or alternatively, the experimental feature needs to provide a different way to discover sections at runtime.) See https://github.com/apple/swift/pull/71509.

:warning: Do not merge: this is a proof-of-concept and work-in-progress.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
