### PR TITLE
Updates to Documentation.md to conform style

### DIFF
--- a/Sources/Testing/Testing.docc/Documentation.md
+++ b/Sources/Testing/Testing.docc/Documentation.md
@@ -46,7 +46,7 @@ concurrency, and parameterize test functions across wide ranges of inputs.
 - ``Test``
 - ``Suite(_:_:)``
 
-### Parameterized tests
+### Test parameterization
 
 - <doc:ParameterizedTesting>
 - ``Test(_:_:arguments:)-8kn7a`` <!-- @attached(peer) macro Test<C>(_ displayName: String? = nil, _ traits: any TestTrait..., arguments collection: C) where C : Collection, C : Sendable, C.Element : Sendable -->


### PR DESCRIPTION
Update topic section names.
Adding symbols alongside top level articles under topic groups.

Part 1 of changes for rdar://119702877

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
