### PR TITLE
Remove the curation of Extended Modules: Swift from Documenation.md

### DIFF
--- a/Sources/Testing/Testing.docc/Documentation.md
+++ b/Sources/Testing/Testing.docc/Documentation.md
@@ -65,7 +65,3 @@ concurrency, and parameterize test functions across wide ranges of inputs.
 ### Test customization
 
 - <doc:Traits>
-
-### Extended modules
-
-- ``Swift``


### PR DESCRIPTION

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
