### PR TITLE
Enable libc++ hardening.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -156,6 +156,8 @@ extension Array where Element == PackageDescription.CXXSetting {
   /// Analogous to project-level build settings in an Xcode project.
   static var packageSettings: Self {
     [
+      // Enable libc++ hardened mode as outlined here: https://libcxx.llvm.org/Hardening.html
+      .define("_LIBCPP_HARDENING_MODE", to: "_LIBCPP_HARDENING_MODE_EXTENSIVE"),
       .define("_SWT_TESTING_LIBRARY_VERSION", to: #""unknown (Swift 5.10 toolchain)""#),
     ]
   }

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -156,6 +156,9 @@ extension Array where Element == PackageDescription.CXXSetting {
   static var packageSettings: Self {
     var result = Self()
 
+    // Enable libc++ hardened mode as outlined here: https://libcxx.llvm.org/Hardening.html
+    result.append(.define("_LIBCPP_HARDENING_MODE", to: "_LIBCPP_HARDENING_MODE_EXTENSIVE"))
+
     // Capture the testing library's version as a C++ string constant.
     if let git = Context.gitInformation {
       let testingLibraryVersion = if let tag = git.currentTag {

--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -28,3 +28,7 @@ endif()
 if(CMAKE_SYSTEM_NAME IN_LIST "iOS;watchOS;tvOS;visionOS;WASI")
   add_compile_definitions("SWT_NO_EXIT_TESTS")
 endif()
+
+# Enable libc++ hardened mode as outlined here: https://libcxx.llvm.org/Hardening.html
+add_compile_definitions(
+  "$<$<COMPILE_LANGUAGE:CXX>:_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE>")


### PR DESCRIPTION
This PR enables libc++ hardening to help us catch C++ issues. (We don't know of any such issues, but we would have fixed them if we did!)

For more information, see https://libcxx.llvm.org/Hardening.html.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
