### PR TITLE
Fix a typo in the documentation for `TimeLimitTrait`.

### DIFF
--- a/Sources/Testing/Testing.docc/LimitingExecutionTime.md
+++ b/Sources/Testing/Testing.docc/LimitingExecutionTime.md
@@ -23,7 +23,7 @@ complete effectively, consider setting a time limit for it so that it's marked a
 ``Trait/timeLimit(_:)`` trait as an upper bound:
 
 ```swift
-@Test(.timeLimit(.seconds(60 * 60))
+@Test(.timeLimit(.minutes(60))
 func serve100CustomersInOneHour() async {
   for _ in 0 ..< 100 {
     let customer = await Customer.next()


### PR DESCRIPTION
Takes `.seconds()`, not `.minutes()` as of #391.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
