### PR TITLE
remove undesired backticks from article reference causing curation issues

### DIFF
--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -76,7 +76,7 @@ the test when the code doesn't satisfy a requirement, use
 
 ### Confirming that asynchronous events occur
 
-- ``<doc:testing-asynchronous-code>
+- <doc:testing-asynchronous-code>
 - ``confirmation(_:expectedCount:fileID:filePath:line:column:_:)``
 - ``Confirmation``
 


### PR DESCRIPTION

resolves rdar://128705150

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
