### PR TITLE
remove unnecessary references to external documentation

### DIFF
--- a/Sources/Testing/Testing.docc/AddingTags.md
+++ b/Sources/Testing/Testing.docc/AddingTags.md
@@ -52,8 +52,7 @@ declared in different files, modules, or other contexts, the testing library
 treats them as equivalent.
 
 If it's important for a tag to be distinguished from similar tags declared
-elsewhere in a package or project (or its dependencies), use
- [reverse-DNS naming](https://en.wikipedia.org/wiki/Reverse_domain_name_notation)
+elsewhere in a package or project (or its dependencies), use reverse-DNS naming
 to create a unique Swift symbol name for your tag:
 
 ```swift

--- a/Sources/Testing/Testing.docc/ParameterizedTesting.md
+++ b/Sources/Testing/Testing.docc/ParameterizedTesting.md
@@ -121,7 +121,7 @@ and so forth.
 Assuming there are five cases in the `Food` enumeration, this test function
 will, when run, be invoked 500 times (5 x 100) with every possible combination
 of food and order size. These combinations are referred to as the collections'
-[Cartesian product](https://en.wikipedia.org/wiki/Cartesian_product).
+Cartesian product.
 
 To avoid the combinatoric semantics shown above, use
 [`zip()`](https://developer.apple.com/documentation/swift/zip(_:_:)):


### PR DESCRIPTION

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
