### PR TITLE
Avoid confusion with the "." being a dot operator

### DIFF
--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -27,7 +27,7 @@ For more information, see <doc:testing-asynchronous-code>.
 ### Validate your code's result
 
 To validate that your code produces an expected value, use
-``expect(_:_:sourceLocation:)``. ``expect(_:_:sourceLocation:)`` captures the
+``expect(_:_:sourceLocation:)``. This macro captures the
 expression you pass, and provides detailed information when the code doesn't
 satisfy the expectation.
 


### PR DESCRIPTION
… by replacing the second reference of the function with "this macro".

resolves rdar://129020874

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
