### PR TITLE
[WIP] Add tools-specific `Issue` kind that can be used by third-party test libraries.

### DIFF
--- a/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedIssue.swift
+++ b/Sources/Testing/EntryPoints/ABIv0/Encoded/ABIv0.EncodedIssue.swift
@@ -22,13 +22,49 @@ extension ABIv0 {
     /// The location in source where this issue occurred, if available.
     var sourceLocation: SourceLocation?
 
+    /// Any tool-specific context about the issue including the name of the tool
+    /// that recorded it.
+    ///
+    /// When decoding using `JSONDecoder`, the value of this property is set to
+    /// `nil`. Tools that need access to their context values should not use
+    /// ``ABIv0/EncodedIssue`` to decode issues.
+    var toolContext: (any Issue.Kind.ToolContext)?
+
     init(encoding issue: borrowing Issue) {
       isKnown = issue.isKnown
       sourceLocation = issue.sourceLocation
+      if case let .recordedByTool(toolContext) = issue.kind {
+        self.toolContext = toolContext
+      }
     }
   }
 }
 
 // MARK: - Codable
 
-extension ABIv0.EncodedIssue: Codable {}
+extension ABIv0.EncodedIssue: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case isKnown
+    case sourceLocation
+    case toolContext
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(isKnown, forKey: .isKnown)
+    try container.encode(sourceLocation, forKey: .sourceLocation)
+    if let toolContext {
+      func encodeToolContext(_ toolContext: some Issue.Kind.ToolContext) throws {
+        try container.encode(toolContext, forKey: .toolContext)
+      }
+      try encodeToolContext(toolContext)
+    }
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    isKnown = try container.decode(Bool.self, forKey: .isKnown)
+    sourceLocation = try container.decode(SourceLocation.self, forKey: .sourceLocation)
+    toolContext = nil // not decoded
+  }
+}

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -115,6 +115,32 @@ extension Issue {
     let issue = Issue(kind: .unconditional, comments: Array(comment), sourceContext: sourceContext)
     return issue.record()
   }
+
+  /// Record an issue on behalf of a tool or library.
+  ///
+  /// - Parameters:
+  ///   - comment: A comment describing the expectation.
+  ///   - toolContext: Any tool-specific context about the issue including the
+  ///     name of the tool that recorded it.
+  ///   - sourceLocation: The source location to which the issue should be
+  ///     attributed.
+  ///
+  /// - Returns: The issue that was recorded.
+  ///
+  /// Test authors do not generally need to use this function. Rather, a tool
+  /// or library based on the testing library can use it to record a
+  /// domain-specific issue and to propagatre additional information about that
+  /// issue to other layers of the testing library's infrastructure.
+  @_spi(Experimental)
+  @discardableResult public static func record(
+    _ comment: Comment? = nil,
+    context toolContext: some Issue.Kind.ToolContext,
+    sourceLocation: SourceLocation = #_sourceLocation
+  ) -> Self {
+    let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
+    let issue = Issue(kind: .recordedByTool(toolContext), comments: Array(comment), sourceContext: sourceContext)
+    return issue.record()
+  }
 }
 
 // MARK: - Recording issues for errors


### PR DESCRIPTION
This PR adds a new `Issue` kind, `.recordedByTool`, that takes a custom payload provided by a third-party tool or library (e.g. Nimble). This case can then be used to distinguish issues specific to tools while also providing sufficient infrastructural support to allow those tools to distinguish issues they created at later stages of the testing workflow. (If this sounds abstract, it is—the proposed API is meant to be used in a fairly arbitrary fashion by an open set of third-party tools and libraries.)

Resolves #490.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
