### PR TITLE
Configure CMake rules to install content into toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,4 +28,12 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_Swift_LANGUAGE_VERSION 6)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
+if(NOT SWIFT_SYSTEM_NAME)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(SWIFT_SYSTEM_NAME macosx)
+  else()
+    set(SWIFT_SYSTEM_NAME "$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+  endif()
+endif()
+
 add_subdirectory(Sources)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -11,6 +11,15 @@ include(ExternalProject)
 if(NOT SwiftTesting_MACRO_MAKE_PROGRAM)
   set(SwiftTesting_MACRO_MAKE_PROGRAM ${CMAKE_MAKE_PROGRAM})
 endif()
+if(NOT SwiftTesting_MACRO_Swift_COMPILER)
+  set(SwiftTesting_MACRO_Swift_COMPILER ${CMAKE_Swift_COMPILER})
+endif()
+if(NOT SwiftTesting_MACRO_AR)
+  set(SwiftTesting_MACRO_AR ${CMAKE_AR})
+endif()
+if(NOT SwiftTesting_MACRO_RANLIB)
+  set(SwiftTesting_MACRO_RANLIB ${CMAKE_RANLIB})
+endif()
 
 find_package(SwiftSyntax CONFIG GLOBAL)
 if(SwiftSyntax_FOUND)
@@ -23,13 +32,25 @@ ExternalProject_Add(TestingMacros
   PREFIX "tm"
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/TestingMacros"
   CMAKE_ARGS
+    -DCMAKE_Swift_COMPILER=${SwiftTesting_MACRO_Swift_COMPILER}
+    -DCMAKE_AR=${SwiftTesting_MACRO_AR}
+    -DCMAKE_RANLIB=${SwiftTesting_MACRO_RANLIB}
     -DCMAKE_MAKE_PROGRAM=${SwiftTesting_MACRO_MAKE_PROGRAM}
     -DSwiftTesting_BuildMacrosAsExecutables=${SwiftTesting_BuildMacrosAsExecutables}
     -DSwiftSyntax_DIR=${SwiftSyntax_DIR}
-  INSTALL_COMMAND "")
+    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>)
 ExternalProject_Get_Property(TestingMacros BINARY_DIR)
+ExternalProject_Get_Property(TestingMacros INSTALL_DIR)
 
 include(AvailabilityDefinitions)
 include(CompilerSettings)
 add_subdirectory(_TestingInternals)
 add_subdirectory(Testing)
+
+if(SwiftTesting_BuildMacrosAsExecutables)
+  install(PROGRAMS "${INSTALL_DIR}/lib/libTestingMacros.dylib"
+    # TODO: Finalize the install path
+    ARCHIVE DESTINATION lib/swift/host/plugins
+    LIBRARY DESTINATION lib/swift/host/plugins
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -47,7 +47,7 @@ include(CompilerSettings)
 add_subdirectory(_TestingInternals)
 add_subdirectory(Testing)
 
-if(SwiftTesting_BuildMacrosAsExecutables)
+if(NOT SwiftTesting_BuildMacrosAsExecutables)
   install(PROGRAMS "${INSTALL_DIR}/lib/libTestingMacros.dylib"
     # TODO: Finalize the install path
     ARCHIVE DESTINATION lib/swift/host/plugins

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -50,7 +50,5 @@ add_subdirectory(Testing)
 if(NOT SwiftTesting_BuildMacrosAsExecutables)
   install(PROGRAMS "${INSTALL_DIR}/lib/libTestingMacros.dylib"
     # TODO: Finalize the install path
-    ARCHIVE DESTINATION lib/swift/host/plugins
-    LIBRARY DESTINATION lib/swift/host/plugins
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    DESTINATION lib/swift/host/plugins)
 endif()

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -48,7 +48,18 @@ add_subdirectory(_TestingInternals)
 add_subdirectory(Testing)
 
 if(NOT SwiftTesting_BuildMacrosAsExecutables)
-  install(PROGRAMS "${INSTALL_DIR}/lib/libTestingMacros.dylib"
+  # Hardcode the known library names based on system name as a workaround since
+  # TestingMacros uses `ExternalProject` and we cannot directly query the
+  # properties of its targets here.
+  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    set(SwiftTesting_TestingMacrosLibraryName "libTestingMacros.dylib")
+  elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    set(SwiftTesting_TestingMacrosLibraryName "libTestingMacros.so")
+  else()
+    message(FATAL_ERROR "Unable to determine the library name for TestingMacros based on system name: ${CMAKE_SYSTEM_NAME}")
+  endif()
+
+  install(PROGRAMS "${INSTALL_DIR}/lib/${SwiftTesting_TestingMacrosLibraryName}"
     # TODO: Finalize the install path
     DESTINATION lib/swift/host/plugins)
 endif()

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -97,7 +97,8 @@ target_link_libraries(Testing PRIVATE
 add_dependencies(Testing
   TestingMacros)
 target_compile_options(Testing PRIVATE
-  -enable-library-evolution)
+  -enable-library-evolution
+  -emit-module-interface -emit-module-interface-path $<TARGET_PROPERTY:Testing,Swift_MODULE_DIRECTORY>/Testing.swiftinterface)
 
 if(SwiftTesting_BuildMacrosAsExecutables)
   if(CMAKE_HOST_WIN32)
@@ -110,3 +111,10 @@ else()
   target_compile_options(Testing PUBLIC
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-plugin-path ${BINARY_DIR}>")
 endif()
+
+# TODO: @rpath-relative install name
+# This may or may not involve the `-(no-)toolchain-stdlib-rpath` Swift flag.
+
+include(SwiftModuleInstallation)
+# TODO: Finalize the install path
+_swift_testing_install_target(Testing)

--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -58,6 +58,13 @@ if(SwiftTesting_BuildMacrosAsExecutables)
   target_compile_definitions(TestingMacros PRIVATE SWT_NO_LIBRARY_MACRO_PLUGINS)
 else()
   add_library(TestingMacros SHARED)
+
+  # Install the macro plugin to the default location.
+  #
+  # This is not the plugin's actual, final install location -- it's only
+  # relative to this external project's install dir. The final location is
+  # determined by the "outer" project.
+  install(TARGETS TestingMacros DESTINATION "")
 endif()
 
 target_sources(TestingMacros PRIVATE

--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -64,7 +64,7 @@ else()
   # This is not the plugin's actual, final install location -- it's only
   # relative to this external project's install dir. The final location is
   # determined by the "outer" project.
-  install(TARGETS TestingMacros DESTINATION "")
+  install(TARGETS TestingMacros)
 endif()
 
 target_sources(TestingMacros PRIVATE

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -6,6 +6,8 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+set(CMAKE_CXX_SCAN_FOR_MODULES 0)
+
 include(LibraryVersion)
 add_library(_TestingInternals STATIC
   Discovery.cpp

--- a/cmake/modules/SwiftModuleInstallation.cmake
+++ b/cmake/modules/SwiftModuleInstallation.cmake
@@ -1,0 +1,64 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2024 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+# Returns the os name in a variable
+#
+# Usage:
+#   get_swift_host_os(result_var_name)
+#
+#
+# Sets ${result_var_name} with the converted OS name derived from
+# CMAKE_SYSTEM_NAME.
+function(get_swift_host_os result_var_name)
+  set(${result_var_name} ${SWIFT_SYSTEM_NAME} PARENT_SCOPE)
+endfunction()
+
+function(_swift_testing_install_target module)
+  get_swift_host_os(swift_os)
+  get_target_property(type ${module} TYPE)
+
+  if(type STREQUAL STATIC_LIBRARY)
+    set(swift swift_static)
+  else()
+    set(swift swift)
+  endif()
+
+  install(TARGETS ${module}
+    ARCHIVE DESTINATION lib/${swift}/${swift_os}
+    LIBRARY DESTINATION lib/${swift}/${swift_os}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  if(type STREQUAL EXECUTABLE)
+    return()
+  endif()
+
+  get_target_property(module_name ${module} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${module})
+  endif()
+
+  if(NOT SwiftTesting_MODULE_TRIPLE)
+    set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+    if(CMAKE_Swift_COMPILER_TARGET)
+      list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
+    endif()
+    execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+    string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+    set(SwiftTesting_MODULE_TRIPLE "${module_triple}" CACHE STRING "swift module triple used for installed swiftmodule and swiftinterface files")
+    mark_as_advanced(SwiftTesting_MODULE_TRIPLE)
+  endif()
+
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftdoc)
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftmodule)
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftinterface
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftinterface)
+endfunction()


### PR DESCRIPTION
This includes several changes to the CMake rules to support _installing_ built content into a toolchain.

### Motivation:

This is necessary to support including swift-testing in Swift 6 toolchains.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
