### PR TITLE
Fix issues building for 32-bit Windows.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -27,7 +27,7 @@ var EXIT_NO_TESTS_FOUND: CInt {
 #if SWT_TARGET_OS_APPLE || os(Linux) || os(WASI)
   EX_UNAVAILABLE
 #elseif os(Windows)
-  ERROR_NOT_FOUND
+  CInt(ERROR_NOT_FOUND)
 #else
 #warning("Platform-specific implementation missing: value for EXIT_NO_TESTS_FOUND unavailable")
   return 2 // We're assuming that EXIT_SUCCESS = 0 and EXIT_FAILURE = 1.

--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -218,7 +218,7 @@ func wait(for processHandle: HANDLE) async throws -> ExitCondition {
   }
 
   // FIXME: handle SEH/VEH uncaught exceptions.
-  return .exitCode(CInt(bitPattern: status))
+  return .exitCode(CInt(bitPattern: .init(status)))
 }
 #endif
 #endif

--- a/Tests/TestingTests/Support/CErrorTests.swift
+++ b/Tests/TestingTests/Support/CErrorTests.swift
@@ -26,14 +26,14 @@ struct CErrorTests {
 struct Win32ErrorTests {
   @Test("Win32Error.description property",
     arguments: [
-      (ERROR_OUTOFMEMORY, "Not enough memory resources are available to complete this operation."),
-      (ERROR_INVALID_ACCESS, "The access code is invalid."),
-      (ERROR_ARITHMETIC_OVERFLOW, "Arithmetic result exceeded 32 bits."),
+      (DWORD(ERROR_OUTOFMEMORY), "Not enough memory resources are available to complete this operation."),
+      (DWORD(ERROR_INVALID_ACCESS), "The access code is invalid."),
+      (DWORD(ERROR_ARITHMETIC_OVERFLOW), "Arithmetic result exceeded 32 bits."),
       (999_999_999, "An unknown error occurred (999999999)."),
     ]
   )
-  fileprivate func errorDescription(errorCode: CInt, expectedMessage: String) {
-    let description = String(describing: Win32Error(rawValue: DWORD(errorCode)))
+  fileprivate func errorDescription(errorCode: DWORD, expectedMessage: String) {
+    let description = String(describing: Win32Error(rawValue: errorCode))
     #expect(!description.isEmpty)
     #expect(expectedMessage == description)
   }


### PR DESCRIPTION
This PR fixes some integer type mismatches that cause build failures on 32-bit Windows.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
