### PR TITLE
Migrate URLs in documentation/comments/etc. from /apple/ to /swiftlang/.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,12 @@ discussion prior to being accepted.
 
 To learn how to write tests using the testing library, rather than how to
 contribute to the testing library itself, see
-[Getting Started](https://github.com/apple/swift-testing/tree/main/Sources/Testing/Testing.docc/TemporaryGettingStarted.md).
+[Getting Started](https://github.com/swiftlang/swift-testing/tree/main/Sources/Testing/Testing.docc/TemporaryGettingStarted.md).
 
 ## Reporting issues
 
 Issues are tracked using the testing library's
-[GitHub Issue Tracker](https://github.com/apple/swift-testing/issues).
+[GitHub Issue Tracker](https://github.com/swiftlang/swift-testing/issues).
 
 Fill in the fields of the relevant template form offered on that page when
 creating new issues. For bug report issues, please include a minimal example
@@ -34,7 +34,7 @@ hosting service.
 ## Setting up the development environment
 
 First, clone the Swift Testing repository from
-[https://github.com/apple/swift-testing](https://github.com/apple/swift-testing).
+[https://github.com/swiftlang/swift-testing](https://github.com/swiftlang/swift-testing).
 
 If you're preparing to make a contribution, you should fork the repository first
 and clone the fork which will make opening PRs easier.
@@ -142,7 +142,7 @@ test --help` to view the usage documentation.
 
 ## Creating Pull Requests (PRs)
 
-1. Fork [https://github.com/apple/swift-testing](https://github.com/apple/swift-testing).
+1. Fork [https://github.com/swiftlang/swift-testing](https://github.com/swiftlang/swift-testing).
 1. Clone a working copy of your fork.
 1. Create a new branch.
 1. Make your code changes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 FROM swiftlang/swift:nightly-main-jammy
 
 # Set up the current build user in the same way done in the Swift.org CI system:
-# https://github.com/apple/swift-docker/blob/main/swift-ci/master/ubuntu/22.04/Dockerfile
+# https://github.com/swiftlang/swift-docker/blob/main/swift-ci/master/ubuntu/22.04/Dockerfile
 
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user

--- a/Documentation/CMake.md
+++ b/Documentation/CMake.md
@@ -8,7 +8,7 @@ Add Swift Testing to your project using the standard `FetchContent` or
 ```cmake
 include(FetchContent)
 FetchContent_Declare(SwiftTesting
-  GIT_REPOSITORY https://github.com/apple/swift-testing.git
+  GIT_REPOSITORY https://github.com/swiftlang/swift-testing.git
   GIT_TAG main)
 FetchContent_MakeAvailable(SwiftTesting)
 ```

--- a/Documentation/Proposals/0000-proposal-template.md
+++ b/Documentation/Proposals/0000-proposal-template.md
@@ -3,10 +3,10 @@
 * Proposal: [SWT-NNNN](NNNN-filename.md)
 * Authors: [Author 1](https://github.com/author1), [Author 2](https://github.com/author2)
 * Status: **Awaiting implementation** or **Awaiting review**
-* Bug: _if applicable_ [apple/swift-testing#NNNNN](https://github.com/apple/swift-testing/issues/NNNNN)
-* Implementation: [apple/swift-testing#NNNNN](https://github.com/apple/swift-testing/pull/NNNNN)
+* Bug: _if applicable_ [swiftlang/swift-testing#NNNNN](https://github.com/swiftlang/swift-testing/issues/NNNNN)
+* Implementation: [swiftlang/swift-testing#NNNNN](https://github.com/swiftlang/swift-testing/pull/NNNNN)
 * Previous Proposal: _if applicable_ [SWT-XXXX](XXXX-filename.md)
-* Previous Revision: _if applicable_ [1](https://github.com/apple/swift-testing/blob/...commit-ID.../Documentation/Proposals/NNNN-filename.md)
+* Previous Revision: _if applicable_ [1](https://github.com/swiftlang/swift-testing/blob/...commit-ID.../Documentation/Proposals/NNNN-filename.md)
 * Review: ([pitch](https://forums.swift.org/...))
 
 When filling out this template, you should delete or replace all of the text
@@ -146,7 +146,7 @@ the current proposal. It's important to make focused, self-contained proposals
 that can be incrementally implemented and reviewed, but it's also good when
 proposals feel "complete" rather than leaving significant gaps in their design.
 An an example from the Swift project, when
-[SE-0193](https://github.com/apple/swift-evolution/blob/main/proposals/0193-cross-module-inlining-and-specialization.md)
+[SE-0193](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0193-cross-module-inlining-and-specialization.md)
 introduced the `@inlinable` attribute, it also included the `@usableFromInline`
 attribute so that declarations used in inlinable functions didn't have to be
 `public`. This was a relatively small addition to the proposal which avoided

--- a/Documentation/Proposals/0001-refactor-bug-inits.md
+++ b/Documentation/Proposals/0001-refactor-bug-inits.md
@@ -3,7 +3,7 @@
 * Proposal: [SWT-0001](0001-refactor-bug-inits.md)
 * Authors: [Jonathan Grynspan](https://github.com/grynspan)
 * Status: **Accepted**
-* Implementation: [apple/swift-testing#401](https://github.com/apple/swift-testing/pull/401)
+* Implementation: [swiftlang/swift-testing#401](https://github.com/swiftlang/swift-testing/pull/401)
 * Review: ([pitch](https://forums.swift.org/t/pitch-dedicated-bug-functions-for-urls-and-ids/71842)), ([acceptance](https://forums.swift.org/t/swt-0001-dedicated-bug-functions-for-urls-and-ids/71842/2))
 
 ## Introduction

--- a/Documentation/Proposals/0002-json-abi.md
+++ b/Documentation/Proposals/0002-json-abi.md
@@ -3,8 +3,8 @@
 * Proposal: [SWT-0002](0002-json-abi.md)
 * Authors: [Jonathan Grynspan](https://github.com/grynspan)
 * Status: **Accepted**
-* Implementation: [apple/swift-testing#383](https://github.com/apple/swift-testing/pull/383),
-  [apple/swift-testing#402](https://github.com/apple/swift-testing/pull/402)
+* Implementation: [swiftlang/swift-testing#383](https://github.com/swiftlang/swift-testing/pull/383),
+  [swiftlang/swift-testing#402](https://github.com/swiftlang/swift-testing/pull/402)
 * Review: ([pitch](https://forums.swift.org/t/pitch-a-stable-json-based-abi-for-tools-integration/72627)), ([acceptance](https://forums.swift.org/t/pitch-a-stable-json-based-abi-for-tools-integration/72627/4))
 
 ## Introduction

--- a/Documentation/Proposals/0003-make-serialized-trait-api.md
+++ b/Documentation/Proposals/0003-make-serialized-trait-api.md
@@ -4,7 +4,7 @@
 * Authors: [Dennis Weissmann](https://github.com/dennisweissmann)
 * Status: **Accepted**
 * Implementation: 
-[apple/swift-testing#535](https://github.com/apple/swift-testing/pull/535)
+[swiftlang/swift-testing#535](https://github.com/swiftlang/swift-testing/pull/535)
 * Review: 
 ([pitch](https://forums.swift.org/t/pitch-make-serialized-trait-public-api/73147)),
 ([acceptance](https://forums.swift.org/t/pitch-make-serialized-trait-public-api/73147/5))

--- a/Documentation/Proposals/0004-constrain-the-granularity-of-test-time-limit-durations.md
+++ b/Documentation/Proposals/0004-constrain-the-granularity-of-test-time-limit-durations.md
@@ -5,7 +5,7 @@
 * Authors: [Dennis Weissmann](https://github.com/dennisweissmann)
 * Status: **Accepted**
 * Implementation: 
-[apple/swift-testing#534](https://github.com/apple/swift-testing/pull/534)
+[swiftlang/swift-testing#534](https://github.com/swiftlang/swift-testing/pull/534)
 * Review: 
 ([pitch](https://forums.swift.org/t/pitch-constrain-the-granularity-of-test-time-limit-durations/73146)),
 ([acceptance](https://forums.swift.org/t/pitch-constrain-the-granularity-of-test-time-limit-durations/73146/3))

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -13,36 +13,36 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 ## API and usage guides
 
 The detailed documentation for Swift Testing can be found on the
-[Swift Package Index](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing).
+[Swift Package Index](https://swiftpackageindex.com/swiftlang/swift-testing/main/documentation/testing).
 There, you can delve into comprehensive guides, tutorials, and API references to
 make the most out of this package.
 
-This documentation is generated using [DocC](https://github.com/apple/swift-docc)
+This documentation is generated using [DocC](https://github.com/swiftlang/swift-docc)
 and is derived from symbol documentation in this project's source code as well
 as supplemental content located in the
-[`Sources/Testing/Testing.docc/`](https://github.com/apple/swift-testing/tree/main/Sources/Testing/Testing.docc)
+[`Sources/Testing/Testing.docc/`](https://github.com/swiftlang/swift-testing/tree/main/Sources/Testing/Testing.docc)
 directory.
 
 ## Vision document
 
-The [Vision document](https://github.com/apple/swift-evolution/blob/main/visions/swift-testing.md)
+The [Vision document](https://github.com/swiftlang/swift-evolution/blob/main/visions/swift-testing.md)
 for Swift Testing offers a comprehensive discussion of the project's design
 principles and goals. 
 
 ## Development and contribution
 
-- The top-level [`README`](https://github.com/apple/swift-testing/blob/main/README.md)
+- The top-level [`README`](https://github.com/swiftlang/swift-testing/blob/main/README.md)
   gives a high-level overview of the project, shows current CI status, lists the
   support status of various platforms, and more.
-- [Contributing](https://github.com/apple/swift-testing/blob/main/CONTRIBUTING.md)
+- [Contributing](https://github.com/swiftlang/swift-testing/blob/main/CONTRIBUTING.md)
   provides guidance for developing and making project contributions.
-- [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md)
+- [Style Guide](https://github.com/swiftlang/swift-testing/blob/main/Documentation/StyleGuide.md)
   describes this project's guidelines for code and documentation style.
-- [SPI groups in Swift Testing](https://github.com/apple/swift-testing/blob/main/Documentation/SPI.md)
+- [SPI groups in Swift Testing](https://github.com/swiftlang/swift-testing/blob/main/Documentation/SPI.md)
   describes when and how the testing library uses Swift SPI.
 
 ## Project maintenance
 
-- The [Releases](https://github.com/apple/swift-testing/blob/main/Documentation/Releases.md)
+- The [Releases](https://github.com/swiftlang/swift-testing/blob/main/Documentation/Releases.md)
   document describes the process of creating and publishing a new release of
   Swift Testing — a task which may be performed by project administrators.

--- a/Documentation/Releases.md
+++ b/Documentation/Releases.md
@@ -49,8 +49,8 @@ be updated so that the release can be used as a package dependency:
    update the line:
 
     ```diff
-    -  .package(url: "https://github.com/apple/swift-testing.git", branch: "main"),
-    +  .package(url: "https://github.com/apple/swift-testing.git", from: "x.y.z"),
+    -  .package(url: "https://github.com/swiftlang/swift-testing.git", branch: "main"),
+    +  .package(url: "https://github.com/swiftlang/swift-testing.git", from: "x.y.z"),
     ```
 
 The repository's local state is now updated. To commit it to your branch, run
@@ -94,7 +94,7 @@ git tag x.y.z
 git push -u origin x.y.z
 ```
 
-The release is now live and publicly visible [here](https://github.com/apple/swift-testing/tags).
+The release is now live and publicly visible [here](https://github.com/swiftlang/swift-testing/tags).
 Developers using Swift Package Manager and listing Swift Testing as a dependency
 will automatically update to it.
 

--- a/Documentation/StyleGuide.md
+++ b/Documentation/StyleGuide.md
@@ -140,12 +140,12 @@ Begin topic group headings inside types with a noun or noun phrase.
 
 The macro target of this package produces a number of different compile-time
 diagnostics. These diagnostics should be written according to the Swift style
-guide for compiler diagnostics [here](https://github.com/apple/swift/blob/main/docs/Diagnostics.md).
+guide for compiler diagnostics [here](https://github.com/swiftlang/swift/blob/main/docs/Diagnostics.md).
 
 ### Documentation
 
 Documentation for the testing library should follow the
-[Swift Book style guide](https://github.com/apple/swift-book/blob/main/Style.md)
+[Swift Book style guide](https://github.com/swiftlang/swift-book/blob/main/Style.md)
 and [Apple Style Guide](https://support.apple.com/guide/applestyleguide/) as
 contextually appropriate.
 

--- a/Documentation/Vision.md
+++ b/Documentation/Vision.md
@@ -7,7 +7,7 @@ automated testing to identify software defects. Better APIs and tools for
 testing can greatly improve a platform’s quality. Below, we propose a new API
 direction for testing in Swift.
 
-Click [here](https://github.com/apple/swift-evolution/blob/main/visions/swift-testing.md)
+Click [here](https://github.com/swiftlang/swift-evolution/blob/main/visions/swift-testing.md)
 to view the complete vision document for Swift Testing, which has been accepted
 by the Swift Language Steering Group and is now hosted in the
-[swift-evolution](https://github.com/apple/swift-evolution) repository.
+[swift-evolution](https://github.com/swiftlang/swift-evolution) repository.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4,7 +4,7 @@
 
 Please visit the Swift Testing web site for more information:
 
-  * https://github.com/apple/swift-testing
+  * https://github.com/swiftlang/swift-testing
 
 Copyright (c) 2023 Apple Inc. and the Swift project authors
 

--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
   ///
   /// These leverage a pseudo-experimental feature in the Swift compiler for
   /// setting availability definitions, which was added in
-  /// [apple/swift#65218](https://github.com/apple/swift/pull/65218).
+  /// [swift#65218](https://github.com/swiftlang/swift/pull/65218).
   private static var availabilityMacroSettings: Self {
     [
       .enableExperimentalFeature("AvailabilityMacro=_mangledTypeNameAPI:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0"),

--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ incrementally, at your own pace.
 > for details about stable release plans.
 
 Detailed documentation for Swift Testing can be found on the
-[Swift Package Index](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing).
+[Swift Package Index](https://swiftpackageindex.com/swiftlang/swift-testing/main/documentation/testing).
 There, you can delve into comprehensive guides, tutorials, and API references to
 make the most out of this package. To try it yourself, see
-[Getting Started](https://swiftpackageindex.com/apple/swift-testing/main/documentation/testing/temporarygettingstarted).
+[Getting Started](https://swiftpackageindex.com/swiftlang/swift-testing/main/documentation/testing/temporarygettingstarted).
 
 Other documentation resources for this project can be found in the
-[README](https://github.com/apple/swift-testing/blob/main/Documentation/README.md) 
+[README](https://github.com/swiftlang/swift-testing/blob/main/Documentation/README.md) 
 of the `Documentation/` subdirectory.

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -559,7 +559,7 @@ private func _writeJSONLine(_ json: UnsafeRawBufferPointer, to file: borrowing F
   if _slowPath(json.contains(where: isASCIINewline)) {
 #if DEBUG
     let message = Event.ConsoleOutputRecorder.warning(
-      "JSON encoder produced one or more newline characters while encoding an event to JSON. Please file a bug report at https://github.com/apple/swift-testing/issues/new",
+      "JSON encoder produced one or more newline characters while encoding an event to JSON. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new",
       options: .for(.stderr)
     )
 #if SWT_TARGET_OS_APPLE

--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -27,7 +27,7 @@ extension Test {
         // that of the Swift Clock API, so we don't use `SuspendingClock`
         // directly on them and instead derive a value from platform-specific
         // API. SuspendingClock corresponds to CLOCK_UPTIME_RAW on Darwin.
-        // SEE: https://github.com/apple/swift/blob/main/stdlib/public/Concurrency/Clock.cpp
+        // SEE: https://github.com/swiftlang/swift/blob/main/stdlib/public/Concurrency/Clock.cpp
         var uptime = timespec()
         _ = clock_gettime(CLOCK_UPTIME_RAW, &uptime)
         return TimeValue(uptime)

--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -76,7 +76,7 @@ extension TimeValue: Codable {}
 extension TimeValue: CustomStringConvertible {
   var description: String {
 #if os(WASI)
-    // BUG: https://github.com/apple/swift/issues/72398
+    // BUG: https://github.com/swiftlang/swift/issues/72398
     return String(describing: Duration(self))
 #else
     let (secondsFromAttoseconds, attosecondsRemaining) = attoseconds.quotientAndRemainder(dividingBy: 1_000_000_000_000_000_000)

--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -32,7 +32,7 @@ private func _blockAndWait(for pid: pid_t) throws -> ExitCondition {
       case .init(CLD_KILLED), .init(CLD_DUMPED):
         return .signal(siginfo.si_status)
       default:
-        throw SystemError(description: "Unexpected siginfo_t value. Please file a bug report at https://github.com/apple/swift-testing/issues/new and include this information: \(String(reflecting: siginfo))")
+        throw SystemError(description: "Unexpected siginfo_t value. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new and include this information: \(String(reflecting: siginfo))")
       }
     } else if case let errorCode = swt_errno(), errorCode != EINTR {
       throw CError(rawValue: errorCode)
@@ -164,7 +164,7 @@ func wait(for pid: pid_t) async throws -> ExitCondition {
       // we add this continuation to the dictionary, then it will simply loop
       // and report the status again.
       let oldContinuation = childProcessContinuations.updateValue(continuation, forKey: pid)
-      assert(oldContinuation == nil, "Unexpected continuation found for PID \(pid). Please file a bug report at https://github.com/apple/swift-testing/issues/new")
+      assert(oldContinuation == nil, "Unexpected continuation found for PID \(pid). Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
 
       // Wake up the waiter thread if it is waiting for more child processes.
       _ = pthread_cond_signal(_waitThreadNoChildrenCondition)

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -139,7 +139,7 @@ private func _callBinaryOperator<T, U, R>(
   // nonescaping closure, but our use cases are safe (e.g. `true && false`) and
   // we cannot force one function or the other to be escaping. Use
   // withoutActuallyEscaping() to tell the compiler that what we're doing is
-  // okay. SEE: https://github.com/apple/swift-evolution/blob/main/proposals/0176-enforce-exclusive-access-to-memory.md#restrictions-on-recursive-uses-of-non-escaping-closures
+  // okay. SEE: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0176-enforce-exclusive-access-to-memory.md#restrictions-on-recursive-uses-of-non-escaping-closures
   var rhsValue: U?
   let result: R = withoutActuallyEscaping(rhs) { rhs in
     op(lhs, {

--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -184,19 +184,19 @@ extension TypeInfo {
 extension TypeInfo {
   /// Whether or not the described type is a Swift `enum` type.
   ///
-  /// Per the [Swift mangling ABI](https://github.com/apple/swift/blob/main/docs/ABI/Mangling.rst),
+  /// Per the [Swift mangling ABI](https://github.com/swiftlang/swift/blob/main/docs/ABI/Mangling.rst),
   /// enumeration types are mangled as `"O"`.
   ///
   /// - Bug: We use the internal Swift standard library function
   ///   `_mangledTypeName()` to derive this information. We should use supported
-  ///   API instead. ([swift-#69147](https://github.com/apple/swift/issues/69147))
+  ///   API instead. ([swift-#69147](https://github.com/swiftlang/swift/issues/69147))
   var isSwiftEnumeration: Bool {
     mangledName?.last == "O"
   }
 
   /// Whether or not the described type is imported from C, C++, or Objective-C.
   ///
-  /// Per the [Swift mangling ABI](https://github.com/apple/swift/blob/main/docs/ABI/Mangling.rst),
+  /// Per the [Swift mangling ABI](https://github.com/swiftlang/swift/blob/main/docs/ABI/Mangling.rst),
   /// types imported from C-family languages are placed in a single flat `__C`
   /// module. That module has a standardized mangling of `"So"`. The presence of
   /// those characters at the start of a type's mangled name indicates that it
@@ -204,7 +204,7 @@ extension TypeInfo {
   ///
   /// - Bug: We use the internal Swift standard library function
   ///   `_mangledTypeName()` to derive this information. We should use supported
-  ///   API instead. ([swift-#69146](https://github.com/apple/swift/issues/69146))
+  ///   API instead. ([swift-#69146](https://github.com/swiftlang/swift/issues/69146))
   var isImportedFromC: Bool {
     guard let mangledName, mangledName.count > 2 else {
       return false

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -75,7 +75,7 @@ public struct Backtrace: Sendable {
         initializedCount = Int(RtlCaptureStackBackTrace(0, ULONG(addresses.count), addresses.baseAddress!, nil))
 #elseif os(WASI)
         // SEE: https://github.com/WebAssembly/WASI/issues/159
-        // SEE: https://github.com/apple/swift/pull/31693
+        // SEE: https://github.com/swiftlang/swift/pull/31693
         initializedCount = 0
 #else
 #warning("Platform-specific implementation missing: backtraces unavailable")
@@ -122,7 +122,7 @@ extension Backtrace {
     /// - Bug: On Windows, the weak reference to this object triggers a
     ///   crash. To avoid said crash, we'll keep a strong reference to the
     ///   object (abandoning memory until the process exits.)
-    ///   ([swift-#62985](https://github.com/apple/swift/issues/62985))
+    ///   ([swift-#62985](https://github.com/swiftlang/swift/issues/62985))
 #if os(Windows)
     var errorObject: (any AnyObject & Sendable)?
 #else

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -122,7 +122,7 @@ public struct Test: Sendable {
         // error (because the test cannot be run.) If an error was thrown, a
         // `Runner.Plan` is expected to record issue for the test, rather than
         // attempt to run it, and thus never access this property.
-        preconditionFailure("Attempting to access test cases with invalid state. Please file a bug report at https://github.com/apple/swift-testing/issues/new and include this information: \(String(reflecting: testCasesState))")
+        preconditionFailure("Attempting to access test cases with invalid state. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new and include this information: \(String(reflecting: testCasesState))")
       }
       return testCases
     }

--- a/Sources/Testing/Testing.docc/BugIdentifiers.md
+++ b/Sources/Testing/Testing.docc/BugIdentifiers.md
@@ -46,7 +46,7 @@ convenience, you can also directly pass an integer as a bug's identifier using
 | `.bug(id: 12345)` | None |
 | `.bug(id: "12345")` | None |
 | `.bug("https://www.example.com?id=12345", id: "12345")` | None |
-| `.bug("https://github.com/apple/swift/pull/12345")` | [GitHub Issues for the Swift project](https://github.com/apple/swift/issues) |
+| `.bug("https://github.com/swiftlang/swift/pull/12345")` | [GitHub Issues for the Swift project](https://github.com/swiftlang/swift/issues) |
 | `.bug("https://bugs.webkit.org/show_bug.cgi?id=12345")` | [WebKit Bugzilla](https://bugs.webkit.org/) |
 | `.bug(id: "FB12345")` | Apple Feedback Assistant | <!-- SEE ALSO: rdar://104582015 -->
 <!--

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -358,7 +358,7 @@ their equivalents in the testing library:
 The testing library doesn’t provide an equivalent of
 [`XCTAssertEqual(_:_:accuracy:_:file:line:)`](https://developer.apple.com/documentation/xctest/3551607-xctassertequal).
 To compare two numeric values within a specified accuracy, 
-use `isApproximatelyEqual()` from [swift-numerics](https://github.com/swiftlang/swift-numerics).
+use `isApproximatelyEqual()` from [swift-numerics](https://github.com/apple/swift-numerics).
 
 ### Continue or halt after test failures
 

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -358,7 +358,7 @@ their equivalents in the testing library:
 The testing library doesn’t provide an equivalent of
 [`XCTAssertEqual(_:_:accuracy:_:file:line:)`](https://developer.apple.com/documentation/xctest/3551607-xctassertequal).
 To compare two numeric values within a specified accuracy, 
-use `isApproximatelyEqual()` from [swift-numerics](https://github.com/apple/swift-numerics).
+use `isApproximatelyEqual()` from [swift-numerics](https://github.com/swiftlang/swift-numerics).
 
 ### Continue or halt after test failures
 
@@ -369,7 +369,7 @@ XCTest stops an affected test by throwing an Objective-C exception at the
 time the failure occurs.
 
 - Note: `continueAfterFailure` isn't fully supported when using the
-  [swift-corelibs-xctest](https://github.com/apple/swift-corelibs-xctest)
+  [swift-corelibs-xctest](https://github.com/swiftlang/swift-corelibs-xctest)
   library on non-Apple platforms.
 
 The behavior of an exception thrown through a Swift stack frame is undefined. If

--- a/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
+++ b/Sources/Testing/Testing.docc/TemporaryGettingStarted.md
@@ -24,7 +24,7 @@ of, tests written using XCTest. This document describes how to start using the
 testing library to write and run tests.
 
 To learn how to contribute to Swift Testing, see
-[Contributing to Swift Testing](https://github.com/apple/swift-testing/blob/main/CONTRIBUTING.md).
+[Contributing to Swift Testing](https://github.com/swiftlang/swift-testing/blob/main/CONTRIBUTING.md).
 
 ### Downloading a development toolchain
 
@@ -52,7 +52,7 @@ dependency:
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/apple/swift-testing.git", branch: "main"),
+  .package(url: "https://github.com/swiftlang/swift-testing.git", branch: "main"),
 ],
 ```
 

--- a/Sources/Testing/Traits/Comment+Macro.swift
+++ b/Sources/Testing/Traits/Comment+Macro.swift
@@ -38,7 +38,7 @@ extension Trait where Self == Comment {
   }
 
   /// Construct a comment related to a test from a single-line
-  /// [Markup](https://github.com/apple/swift/blob/main/docs/DocumentationComments.md)
+  /// [Markup](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)
   /// comment near it.
   ///
   /// - Parameters:
@@ -53,7 +53,7 @@ extension Trait where Self == Comment {
   }
 
   /// Construct a comment related to a test from a
-  /// [Markup](https://github.com/apple/swift/blob/main/docs/DocumentationComments.md)
+  /// [Markup](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)
   /// block comment near it.
   ///
   /// - Parameters:

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -42,11 +42,11 @@ public struct Comment: RawRepresentable, Sendable {
     /// starting with `/*` and ending with `*/`.
     case block
 
-    /// This comment came from a single-line [Markup](https://github.com/apple/swift/blob/main/docs/DocumentationComments.md)
+    /// This comment came from a single-line [Markup](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)
     /// comment in the test's source code starting with `///`.
     case documentationLine
 
-    /// This comment came from a block [Markup](https://github.com/apple/swift/blob/main/docs/DocumentationComments.md)
+    /// This comment came from a block [Markup](https://github.com/swiftlang/swift/blob/main/docs/DocumentationComments.md)
     /// comment in the test's source code starting with `/**` and ending with
     /// `*/`.
     case documentationBlock

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -340,11 +340,11 @@ extension ExitTestConditionMacro {
     var arguments = argumentList(of: macro, in: context)
     let expectedExitConditionIndex = arguments.firstIndex { $0.label?.tokenKind == .identifier("exitsWith") }
     guard let expectedExitConditionIndex else {
-      fatalError("Could not find the exit condition for this exit test. Please file a bug report at https://github.com/apple/swift-testing/issues/new")
+      fatalError("Could not find the exit condition for this exit test. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
     }
     let trailingClosureIndex = arguments.firstIndex { $0.label?.tokenKind == _trailingClosureLabel.tokenKind }
     guard let trailingClosureIndex else {
-      fatalError("Could not find the body argument to this exit test. Please file a bug report at https://github.com/apple/swift-testing/issues/new")
+      fatalError("Could not find the body argument to this exit test. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
     }
 
     let bodyArgumentExpr = arguments[trailingClosureIndex].expression

--- a/Sources/TestingMacros/Support/Additions/DeclGroupSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/DeclGroupSyntaxAdditions.swift
@@ -18,7 +18,7 @@ extension DeclGroupSyntax {
     } else if let extensionDecl = `as`(ExtensionDeclSyntax.self) {
       return extensionDecl.extendedType
     }
-    fatalError("Unexpected DeclGroupSyntax type \(Swift.type(of: self)). Please file a bug report at https://github.com/apple/swift-testing/issues/new")
+    fatalError("Unexpected DeclGroupSyntax type \(Swift.type(of: self)). Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
   }
 
   /// Check whether or not this instance includes a given type name in its

--- a/Sources/TestingMacros/Support/CRC32.swift
+++ b/Sources/TestingMacros/Support/CRC32.swift
@@ -11,7 +11,7 @@
 /// The precomputed CRC-32 lookup table.
 ///
 /// This table is used by the ``crc32(_:)`` function below. It is borrowed from
-/// the [Swift standard library](https://github.com/apple/swift/blob/main/stdlib/public/Backtracing/Elf.swift).
+/// the [Swift standard library](https://github.com/swiftlang/swift/blob/main/stdlib/public/Backtracing/Elf.swift).
 private let _crc32Table: [UInt32] = [
   0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
   0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
@@ -66,7 +66,7 @@ private let _crc32Table: [UInt32] = [
 /// - Returns: The CRC-32 code computed for `bytes`.
 ///
 /// A starting value of `0` is assumed. This function is adapted from the
-/// [Swift standard library](https://github.com/apple/swift/blob/main/stdlib/public/Backtracing/Elf.swift).
+/// [Swift standard library](https://github.com/swiftlang/swift/blob/main/stdlib/public/Backtracing/Elf.swift).
 func crc32(_ bytes: some Sequence<UInt8>) -> UInt32 {
   ~bytes.reduce(~0) { crcValue, byte in
     _crc32Table[Int(UInt8(truncatingIfNeeded: crcValue) ^ byte)] ^ (crcValue >> 8)

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -74,7 +74,7 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   /// - Returns: The name of the macro as understood by a developer, such as
   ///   `"'@Test'"`. Include single quotes.
   private static func _macroName(_ attribute: AttributeSyntax) -> String {
-    // SEE: https://github.com/apple/swift/blob/main/docs/Diagnostics.md?plain=1#L44
+    // SEE: https://github.com/swiftlang/swift/blob/main/docs/Diagnostics.md?plain=1#L44
     "'\(attribute.attributeNameText)'"
   }
 

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -191,7 +191,7 @@ public:
 
 // This environment does not have a dynamic linker/loader. Therefore, there is
 // only one image (this one) with Swift code in it.
-// SEE: https://github.com/apple/swift/tree/main/stdlib/public/runtime/ImageInspectionStatic.cpp
+// SEE: https://github.com/swiftlang/swift/tree/main/stdlib/public/runtime/ImageInspectionStatic.cpp
 
 extern "C" const char sectionBegin __asm("section$start$__TEXT$__swift5_types");
 extern "C" const char sectionEnd __asm("section$end$__TEXT$__swift5_types");

--- a/Sources/_TestingInternals/include/Defines.h
+++ b/Sources/_TestingInternals/include/Defines.h
@@ -36,7 +36,7 @@
 ///
 /// - Bug: The value provided to the compiler (`_SWT_TESTING_LIBRARY_VERSION`)
 ///   is not visible in Swift, so this second macro is needed.
-///   ((#43521)[https://github.com/apple/swift/issues/43521])
+///   ((#43521)[https://github.com/swiftlang/swift/issues/43521])
 #if defined(_SWT_TESTING_LIBRARY_VERSION)
 #define SWT_TESTING_LIBRARY_VERSION _SWT_TESTING_LIBRARY_VERSION
 #else

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -439,12 +439,12 @@ struct TestDeclarationMacroTests {
       #"@Test(.bug("rdar:12345")) func f() {}"#,
       #"@Test(.bug("rdar://12345")) func f() {}"#,
       #"@Test(.bug(id: "FB12345")) func f() {}"#,
-      #"@Test(.bug("https://github.com/apple/swift-testing/issues/12345")) func f() {}"#,
-      #"@Test(.bug("https://github.com/apple/swift-testing/issues/12345", id: "12345")) func f() {}"#,
-      #"@Test(.bug("https://github.com/apple/swift-testing/issues/12345", id: 12345)) func f() {}"#,
-      #"@Test(Bug.bug("https://github.com/apple/swift-testing/issues/12345")) func f() {}"#,
-      #"@Test(Testing.Bug.bug("https://github.com/apple/swift-testing/issues/12345")) func f() {}"#,
-      #"@Test(Bug.bug("https://github.com/apple/swift-testing/issues/12345", "here's what happened...")) func f() {}"#,
+      #"@Test(.bug("https://github.com/swiftlang/swift-testing/issues/12345")) func f() {}"#,
+      #"@Test(.bug("https://github.com/swiftlang/swift-testing/issues/12345", id: "12345")) func f() {}"#,
+      #"@Test(.bug("https://github.com/swiftlang/swift-testing/issues/12345", id: 12345)) func f() {}"#,
+      #"@Test(Bug.bug("https://github.com/swiftlang/swift-testing/issues/12345")) func f() {}"#,
+      #"@Test(Testing.Bug.bug("https://github.com/swiftlang/swift-testing/issues/12345")) func f() {}"#,
+      #"@Test(Bug.bug("https://github.com/swiftlang/swift-testing/issues/12345", "here's what happened...")) func f() {}"#,
     ]
   )
   func validBugIdentifiers(input: String) throws {

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -306,7 +306,7 @@ struct EventRecorderTests {
 #if canImport(Foundation) || canImport(FoundationXML)
   @Test(
     "JUnitXMLRecorder outputs valid XML",
-    .bug("https://github.com/apple/swift-testing/issues/254")
+    .bug("https://github.com/swiftlang/swift-testing/issues/254")
   )
   func junitXMLIsValid() async throws {
     let stream = Stream()


### PR DESCRIPTION
This PR moves all references to URLs under https://github.com/apple/ to https://github.com/swiftlang/.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
