### PR TITLE
Implement an overload of `confirmation()` that takes an unbounded range.

### DIFF
--- a/Sources/Testing/Issues/Confirmation.swift
+++ b/Sources/Testing/Issues/Confirmation.swift
@@ -9,12 +9,12 @@
 //
 
 /// A type that can be used to confirm that an event occurs zero or more times.
-public final class Confirmation: Sendable {
+public struct Confirmation: Sendable {
   /// The number of times ``confirm(count:)`` has been called.
   ///
   /// This property is fileprivate because it may be mutated asynchronously and
   /// callers may be tempted to use it in ways that result in data races.
-  fileprivate let count = Locked(rawValue: 0)
+  fileprivate var count = Locked(rawValue: 0)
 
   /// Confirm this confirmation.
   ///

--- a/Sources/Testing/Issues/Confirmation.swift
+++ b/Sources/Testing/Issues/Confirmation.swift
@@ -9,12 +9,12 @@
 //
 
 /// A type that can be used to confirm that an event occurs zero or more times.
-public struct Confirmation: Sendable {
+public final class Confirmation: Sendable {
   /// The number of times ``confirm(count:)`` has been called.
   ///
   /// This property is fileprivate because it may be mutated asynchronously and
   /// callers may be tempted to use it in ways that result in data races.
-  fileprivate var count = Locked(rawValue: 0)
+  fileprivate let count = Locked(rawValue: 0)
 
   /// Confirm this confirmation.
   ///
@@ -177,6 +177,22 @@ public func confirmation<R>(
     }
   }
   return try await body(confirmation)
+}
+
+/// An overload of ``confirmation(_:expectedCount:sourceLocation:_:)-9bfdc``
+/// that handles the unbounded range operator (`...`).
+///
+/// This overload is necessary because `UnboundedRange` does not conform to
+/// `RangeExpression`. It effectively always succeeds because any number of
+/// confirmations matches, so it is marked unavailable and is not implemented.
+@available(*, unavailable, message: "Unbounded range '...' has no effect when used with a confirmation.")
+public func confirmation<R>(
+  _ comment: Comment? = nil,
+  expectedCount: UnboundedRange,
+  sourceLocation: SourceLocation = #_sourceLocation,
+  _ body: (Confirmation) async throws -> R
+) async rethrows -> R {
+  fatalError("Unsupported")
 }
 
 @_spi(Experimental)

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -188,7 +188,7 @@ enum Environment {
               return nil
             case let errorCode:
               let error = Win32Error(rawValue: errorCode)
-              fatalError("unexpected error when getting environment variable '\(name)': \(error) (\(errorCode))")
+              fatalError("Unexpected error when getting environment variable '\(name)': \(error) (\(errorCode))")
             }
           } else if count > buffer.count {
             // Try again with the larger count.

--- a/Sources/TestingMacros/Support/AvailabilityGuards.swift
+++ b/Sources/TestingMacros/Support/AvailabilityGuards.swift
@@ -118,7 +118,7 @@ private func _createAvailabilityTraitExpr(
     return ".__unavailable(message: \(message), sourceLocation: \(sourceLocationExpr))"
 
   default:
-    fatalError("Unsupported keyword \(whenKeyword) passed to \(#function)")
+    fatalError("Unsupported keyword \(whenKeyword) passed to \(#function). Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
   }
 }
 


### PR DESCRIPTION
Unbounded ranges are not meaningful when used with `confirmation()` because _any_ confirmation count matches. As well, the `...` operator produces an instance of `UnboundedRange` which is a non-nominal type and cannot conform to `RangeExpression`. It may be non-obvious to a developer why `...` doesn't work as the `expectedCount` argument to that function when other range operators work as expected.

This PR implements a stub overload of `confirmation()` that takes an unbounded range. The stub overload is marked unavailable and cannot be called.

Example usage:

```swift
await confirmation("Stuff happens", expectedCount: ...) { stuff in
  // ...
}
```

Generated diagnostic:

> 🛑 'confirmation(\_:expectedCount:sourceLocation:\_:)' is unavailable: Unbounded range '...' has no effect when used with a confirmation.

As a reminder, using a range expression with `confirmation()` is an experimental feature and has not been API-reviewed.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
