### PR TITLE
Add an EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig documentation: https://editorconfig.org
+
+root = true
+
+# Default settings applied to every file type.
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,4 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 insert_final_newline = true
-max_line_length = 80
 trim_trailing_whitespace = true


### PR DESCRIPTION
Add an EditorConfig (`.editorconfig`) file to this repo.

### Motivation:

[EditorConfig](https://editorconfig.org) helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. It will be helpful to add one of these files to swift-testing so that all contributors use the whitespace conventions described in our [style guide](https://github.com/swiftlang/swift-testing/blob/main/Documentation/StyleGuide.md) automatically when using a supported IDE/editor.

Note that Xcode 16 Beta has added support for EditorConfig files — see 20796230 in the [release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
