### PR TITLE
Add copyright statement blocks to several Markdown files.

### DIFF
--- a/Documentation/CMake.md
+++ b/Documentation/CMake.md
@@ -1,5 +1,15 @@
 # Building with CMake
 
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
 ## Add Swift Testing to your project
 
 Add Swift Testing to your project using the standard `FetchContent` or

--- a/Documentation/Releases.md
+++ b/Documentation/Releases.md
@@ -1,5 +1,15 @@
 # How to create a release of Swift Testing
 
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
 This document describes how to create a new release of Swift Testing using Git
 tags.
 

--- a/Documentation/SPI.md
+++ b/Documentation/SPI.md
@@ -1,5 +1,15 @@
 # SPI groups in Swift Testing
 
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
 <!-- Archived from
   <https://forums.swift.org/t/spi-groups-in-swift-testing/70236> -->
 

--- a/Documentation/Vision.md
+++ b/Documentation/Vision.md
@@ -1,5 +1,15 @@
 # A New Direction for Testing in Swift
 
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2023-2024 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
 ## Introduction
 
 A key requirement for the success of any developer platform is a way to use


### PR DESCRIPTION
As it says on the tin: add copyright statement blocks to several Markdown files.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
