### PR TITLE
Reduce overhead of `.expectationChecked` event handling in `#expect()`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -148,6 +148,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("AvailabilityMacro=_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0"),
       .enableExperimentalFeature("AvailabilityMacro=_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
       .enableExperimentalFeature("AvailabilityMacro=_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_synchronizationAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"),
 
       .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0"),
     ]

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -95,8 +95,10 @@ public func __checkValue(
   // Post an event for the expectation regardless of whether or not it passed.
   // If the current event handler is not configured to handle events of this
   // kind, this event is discarded.
-  var expectation = Expectation(evaluatedExpression: expression, isPassing: condition, isRequired: isRequired, sourceLocation: sourceLocation)
-  Event.post(.expectationChecked(expectation))
+  lazy var expectation = Expectation(evaluatedExpression: expression, isPassing: condition, isRequired: isRequired, sourceLocation: sourceLocation)
+  if Configuration.deliverExpectationCheckedEventsAnywhere {
+    Event.post(.expectationChecked(expectation))
+  }
 
   // Early exit if the expectation passed.
   if condition {

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -96,7 +96,7 @@ public func __checkValue(
   // If the current event handler is not configured to handle events of this
   // kind, this event is discarded.
   lazy var expectation = Expectation(evaluatedExpression: expression, isPassing: condition, isRequired: isRequired, sourceLocation: sourceLocation)
-  if Configuration.deliverExpectationCheckedEventsAnywhere {
+  if Configuration.deliverExpectationCheckedEvents {
     Event.post(.expectationChecked(expectation))
   }
 

--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -74,6 +74,9 @@ public struct TypeInfo: Sendable {
 // MARK: - Name
 
 extension TypeInfo {
+  /// An in-memory cache of fully-qualified type name components.
+  private static let _fullyQualifiedNameComponentsCache = Locked<[ObjectIdentifier: [String]]>()
+
   /// The complete name of this type, with the names of all referenced types
   /// fully-qualified by their module names when possible.
   ///
@@ -92,6 +95,10 @@ extension TypeInfo {
   public var fullyQualifiedNameComponents: [String] {
     switch _kind {
     case let .type(type):
+      if let cachedResult = Self._fullyQualifiedNameComponentsCache.rawValue[ObjectIdentifier(type)] {
+        return cachedResult
+      }
+
       var result = String(reflecting: type)
         .split(separator: ".")
         .map(String.init)
@@ -108,6 +115,10 @@ extension TypeInfo {
       // name may include "(unknown context at $xxxxxxxx)" as a component. Strip
       // those out as they're uninteresting to us.
       result = result.filter { !$0.starts(with: "(unknown context at") }
+
+      Self._fullyQualifiedNameComponentsCache.withLock { fullyQualifiedNameComponentsCache in
+        fullyQualifiedNameComponentsCache[ObjectIdentifier(type)] = result
+      }
 
       return result
     case let .nameOnly(fullyQualifiedNameComponents, _, _):

--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -144,7 +144,7 @@ extension Configuration {
   /// On older Apple platforms, this property is not available and ``all`` is
   /// directly consulted instead (which is less efficient.)
   @available(_synchronizationAPI, *)
-  private static let _deliverExpectationCheckedEventsCount = Atomic<Int>(0)
+  private static let _deliverExpectationCheckedEventsCount = Atomic(0)
 
   /// Whether or not events of the kind
   /// ``Event/Kind-swift.enum/expectationChecked(_:)`` should be delivered to

--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -129,14 +129,12 @@ extension Configuration {
   /// - Parameters:
   ///   - id: The unique identifier of this instance, as previously returned by
   ///     `_addToAll()`. If `nil`, this function has no effect.
-  private func _removeFromAll(identifiedBy id: UInt64?) {
-    if let id {
-      let configuration = Self._all.withLock { all in
-        all.instances.removeValue(forKey: id)
-      }
-      if let configuration, configuration.deliverExpectationCheckedEvents, #available(_synchronizationAPI, *) {
-        Self._deliverExpectationCheckedEventsCount.subtract(1, ordering: .sequentiallyConsistent)
-      }
+  private func _removeFromAll(identifiedBy id: UInt64) {
+    let configuration = Self._all.withLock { all in
+      all.instances.removeValue(forKey: id)
+    }
+    if let configuration, configuration.deliverExpectationCheckedEvents, #available(_synchronizationAPI, *) {
+      Self._deliverExpectationCheckedEventsCount.subtract(1, ordering: .sequentiallyConsistent)
     }
   }
 

--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -128,7 +128,7 @@ extension Configuration {
   ///
   /// - Parameters:
   ///   - id: The unique identifier of this instance, as previously returned by
-  ///     `_addToAll()`. If `nil`, this function has no effect.
+  ///     `_addToAll()`.
   private func _removeFromAll(identifiedBy id: UInt64) {
     let configuration = Self._all.withLock { all in
       all.instances.removeValue(forKey: id)

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -532,4 +532,15 @@ struct MiscellaneousTests {
     failureBreakpoint()
     #expect(failureBreakpointValue == 1)
   }
+
+  @available(_clockAPI, *)
+  @Test("Repeated calls to #expect() run in reasonable time", .disabled("time-sensitive"))
+  func repeatedlyExpect() {
+    let duration = Test.Clock().measure {
+      for _ in 0 ..< 1_000_000 {
+        #expect(true as Bool)
+      }
+    }
+    #expect(duration < .seconds(1))
+  }
 }


### PR DESCRIPTION
This PR refactors the implementation of `#expect()` and `#require()` a bit such that they don't incur more than minimal overhead posting `.expectationChecked` events if nobody is listening for them (which, currently, nobody is.)

We considered removing `.expectationChecked` outright, but XCTest has historically had a number of requests for a way to observe calls to `XCTAssert()` etc. even when they pass, so we opted not to remove the event kind at this time.

This PR also introduces a cache for fully-qualified type names so that we don't need to call into the runtime to get them as often.

Overall speedup is approximately **90% or 11x**. Test time for a tight loop of 1,000,000 `#expect()` calls goes from 5.898893 seconds down to 0.515558291 seconds (as measured on my work computer.)

Resolves rdar://133517028.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
