### PR TITLE
Fix a crash if an empty JSON configuration file is specified.

### DIFF
--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -62,11 +62,16 @@ enum JSON {
   static func decode<T>(_ type: T.Type, from jsonRepresentation: UnsafeRawBufferPointer) throws -> T where T: Decodable {
 #if canImport(Foundation)
     try withExtendedLifetime(jsonRepresentation) {
-      let data = Data(
-        bytesNoCopy: .init(mutating: jsonRepresentation.baseAddress!),
-        count: jsonRepresentation.count,
-        deallocator: .none
-      )
+      let byteCount = jsonRepresentation.count
+      let data = if byteCount > 0 {
+        Data(
+          bytesNoCopy: .init(mutating: jsonRepresentation.baseAddress!),
+          count: byteCount,
+          deallocator: .none
+        )
+      } else {
+        Data()
+      }
       return try JSONDecoder().decode(type, from: data)
     }
 #else

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -11,6 +11,9 @@
 #if canImport(Foundation) && !SWT_NO_ABI_ENTRY_POINT
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
+#if canImport(Foundation)
+private import Foundation
+#endif
 private import _TestingInternals
 
 @Suite("ABI entry point tests")
@@ -150,5 +153,14 @@ struct ABIEntryPointTests {
     // Call the entry point function.
     return try await abiEntryPoint(.init(argumentsJSON), recordHandler)
   }
+
+#if canImport(Foundation)
+  @Test func decodeEmptyConfiguration() throws {
+    let emptyBuffer = UnsafeRawBufferPointer(start: nil, count: 0)
+    #expect(throws: DecodingError.self) {
+      _ = try JSON.decode(__CommandLineArguments_v0.self, from: emptyBuffer)
+    }
+  }
+#endif
 }
 #endif


### PR DESCRIPTION
If you pass an empty file to `swift test --configuration-path`, we crash on an unexpected `nil` value. Fix it fix it fix it!

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
