### PR TITLE
[CMake] Temporarily remove Foundation dependency

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_ABI_ENTRY_POINT
+#if !SWT_NO_FOUNDATION && canImport(Foundation) && !SWT_NO_ABI_ENTRY_POINT
 #if SWT_BUILDING_WITH_CMAKE
 @_implementationOnly import _TestingInternals
 #else

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -313,7 +313,7 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   }
 
 #if !SWT_NO_FILE_IO
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   // Configuration for the test run passed in as a JSON file (experimental)
   //
   // This argument should always be the first one we parse.
@@ -442,7 +442,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     }
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   // Event stream output (experimental)
   if let eventStreamOutputPath = args.eventStreamOutputPath {
     let file = try FileHandle(forWritingAtPath: eventStreamOutputPath)
@@ -508,7 +508,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
   return configuration
 }
 
-#if canImport(Foundation) && !SWT_NO_FILE_IO
+#if !SWT_NO_FOUNDATION && canImport(Foundation) && !SWT_NO_FILE_IO
 /// Create an event handler that streams events to the given file using the
 /// specified ABI version.
 ///

--- a/Sources/Testing/ABI/v0/ABIv0.Record+Streaming.swift
+++ b/Sources/Testing/ABI/v0/ABIv0.Record+Streaming.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
+#if !SWT_NO_FOUNDATION && canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
 extension ABIv0.Record {
   /// Create an event handler that encodes events as JSON and forwards them to
   /// an ABI-friendly event handler.

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -100,5 +100,9 @@ target_compile_options(Testing PRIVATE
   -enable-library-evolution
   -emit-module-interface -emit-module-interface-path $<TARGET_PROPERTY:Testing,Swift_MODULE_DIRECTORY>/Testing.swiftinterface)
 
+# FIXME: Temporarily drop Foundation dependency in CMake build.
+target_compile_definitions(Testing PRIVATE
+  SWT_NO_FOUNDATION)
+
 include(SwiftModuleInstallation)
 _swift_testing_install_target(Testing)

--- a/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
+++ b/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
@@ -62,7 +62,7 @@ extension Test.Case.Argument.ID {
   ///
   /// - ``CustomTestArgumentEncodable``
   init?(identifying value: some Sendable, parameter: Test.Parameter) throws {
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
     func customArgumentWrapper(for value: some CustomTestArgumentEncodable) -> some Encodable {
       _CustomArgumentWrapper(rawValue: value)
     }
@@ -89,7 +89,7 @@ extension Test.Case.Argument.ID {
 #endif
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   /// Encode the specified test argument value and store its encoded
   /// representation as an array of bytes suitable for storing in an instance of
   /// ``Test/Case/Argument/ID-swift.struct``.

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 private import Foundation
 #endif
 
@@ -30,7 +30,7 @@ enum JSON {
   ///
   /// - Throws: Whatever is thrown by `body` or by the encoding process.
   static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: Any] = [:], _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
     let encoder = JSONEncoder()
 
     // Keys must be sorted to ensure deterministic matching of encoded data.
@@ -60,7 +60,7 @@ enum JSON {
   ///
   /// - Throws: Whatever is thrown by the decoding process.
   static func decode<T>(_ type: T.Type, from jsonRepresentation: UnsafeRawBufferPointer) throws -> T where T: Decodable {
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
     try withExtendedLifetime(jsonRepresentation) {
       let byteCount = jsonRepresentation.count
       let data = if byteCount > 0 {


### PR DESCRIPTION
As a workaround for testing swift-corelibs-foundation. SwiftPM is currently always link test targets with 'Testing', that causes 2 Foundation in the process when testing Foundation itself.
