### PR TITLE
Remove stray use of old `SWT_BUILDING_WITH_CMAKE` condition.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -9,11 +9,7 @@
 //
 
 #if canImport(Foundation) && !SWT_NO_ABI_ENTRY_POINT
-#if SWT_BUILDING_WITH_CMAKE
-@_implementationOnly import _TestingInternals
-#else
 private import _TestingInternals
-#endif
 
 extension ABIv0 {
   /// The type of the entry point to the testing library used by tools that want


### PR DESCRIPTION
We no longer define `SWT_BUILDING_WITH_CMAKE`, but one file's still checking for it. Fix.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
