### PR TITLE
Disallow `@Test` on member functions of `XCTestCase` subclasses.

### DIFF
--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -63,7 +63,11 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
     diagnostics += diagnoseIssuesWithLexicalContext(context.lexicalContext, containing: declaration, attribute: suiteAttribute)
     diagnostics += diagnoseIssuesWithLexicalContext(declaration, containing: declaration, attribute: suiteAttribute)
 
-    // Suites inheriting from XCTestCase are not supported.
+    // Suites inheriting from XCTestCase are not supported. This check is
+    // duplicated in TestDeclarationMacro but is not part of
+    // diagnoseIssuesWithLexicalContext() because it doesn't need to recurse
+    // across the entire lexical context list, just the innermost type
+    // declaration.
     if let declaration = declaration.asProtocol((any DeclGroupSyntax).self),
        declaration.inherits(fromTypeNamed: "XCTestCase", inModuleNamed: "XCTest") {
       diagnostics.append(.xcTestCaseNotSupported(declaration, whenUsing: suiteAttribute))

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -82,6 +82,10 @@ struct TestDeclarationMacroTests {
         "Attribute 'Suite' cannot be applied to a subclass of 'XCTestCase'",
       "@Suite final class C: XCTest.XCTestCase {}":
         "Attribute 'Suite' cannot be applied to a subclass of 'XCTestCase'",
+      "final class C: XCTestCase { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within class 'C'",
+      "final class C: XCTest.XCTestCase { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within class 'C'",
 
       // Unsupported inheritance
       "@Suite protocol P {}":


### PR DESCRIPTION
This PR adds a diagnostic if we detect that `@Test` has been used on a member function of an `XCTestCase` subclass. This was meant to be disallowed, but we neglected to add a check after adopting `lexicalContext`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
