### PR TITLE
Don't define `swt_getWASIVersion()` on non-WASI.

### DIFF
--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -121,7 +121,7 @@ static int swt_siginfo_t_si_status(const siginfo_t *siginfo) {
 }
 #endif
 
-//#if defined(__wasi__)
+#if defined(__wasi__)
 /// Get the version of the C standard library and runtime used by WASI, if
 /// available.
 ///
@@ -137,7 +137,7 @@ static const char *_Nullable swt_getWASIVersion(void) {
   return 0;
 #endif
 }
-//#endif
+#endif
 
 SWT_ASSUME_NONNULL_END
 


### PR DESCRIPTION
Don't define `swt_getWASIVersion()` on non-WASI. Oops. :)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
