### PR TITLE
Fix build errors in `ExitCondition` operators on platforms without exit tests.

### DIFF
--- a/Sources/Testing/ExitTests/ExitCondition.swift
+++ b/Sources/Testing/ExitTests/ExitCondition.swift
@@ -105,6 +105,9 @@ extension ExitCondition {
   ///
   /// For any values `a` and `b`, `a == b` implies that `a != b` is `false`.
   public static func ==(lhs: Self, rhs: Self) -> Bool {
+#if SWT_NO_EXIT_TESTS
+    fatalError("Unsupported")
+#else
     return switch (lhs, rhs) {
     case let (.failure, .exitCode(exitCode)), let (.exitCode(exitCode), .failure):
       exitCode != EXIT_SUCCESS
@@ -116,6 +119,7 @@ extension ExitCondition {
     default:
       lhs === rhs
     }
+#endif
   }
 
   /// Check whether or not two values of this type are _not_ equal.
@@ -145,7 +149,11 @@ extension ExitCondition {
   ///
   /// For any values `a` and `b`, `a == b` implies that `a != b` is `false`.
   public static func !=(lhs: Self, rhs: Self) -> Bool {
+#if SWT_NO_EXIT_TESTS
+    fatalError("Unsupported")
+#else
     !(lhs == rhs)
+#endif
   }
 
   /// Check whether or not two values of this type are identical.
@@ -215,6 +223,10 @@ extension ExitCondition {
   ///
   /// For any values `a` and `b`, `a === b` implies that `a !== b` is `false`.
   public static func !==(lhs: Self, rhs: Self) -> Bool {
+#if SWT_NO_EXIT_TESTS
+    fatalError("Unsupported")
+#else
     !(lhs === rhs)
+#endif
   }
 }


### PR DESCRIPTION
On platforms without exit tests, `ExitCondition` is marked unavailable. On those platforms, the new operators on `ExitCondition` call each other and the compiler complains because they're calling unavailable symbols. Silence the compiler.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
