### PR TITLE
Set the library version reported via CMake to 6.1-dev.

### DIFF
--- a/cmake/modules/LibraryVersion.cmake
+++ b/cmake/modules/LibraryVersion.cmake
@@ -8,13 +8,14 @@
 
 # The current version of the Swift Testing release. For release branches,
 # remember to remove -dev.
-set(SWT_TESTING_LIBRARY_VERSION "6.1.0-dev")
+set(SWT_TESTING_LIBRARY_VERSION "6.1-dev")
 
 find_package(Git QUIET)
 if(Git_FOUND)
-  # Look for a tag (including non-annotated, i.e. commit-specific, ones.)
+  # Get the commit hash corresponding to the current build. Limit length to 15
+  # to match `swift --version` output format.
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags
+    COMMAND ${GIT_EXECUTABLE} rev-parse --short=15 --verify HEAD
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/modules/LibraryVersion.cmake
+++ b/cmake/modules/LibraryVersion.cmake
@@ -6,34 +6,37 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+# The current version of the Swift Testing release. For release branches,
+# remember to remove -dev.
+set(SWT_TESTING_LIBRARY_VERSION "6.1.0-dev")
+
 find_package(Git QUIET)
 if(Git_FOUND)
+  # Look for a tag (including non-annotated, i.e. commit-specific, ones.)
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags --exact-match
+    COMMAND ${GIT_EXECUTABLE} describe --tags
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_TAG
+    OUTPUT_VARIABLE GIT_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_QUIET)
-  if(GIT_TAG)
-    add_compile_definitions(
-      "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=${GIT_TAG}>")
-  else()
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --verify HEAD
-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-      OUTPUT_VARIABLE GIT_REVISION
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} status -s
-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-      OUTPUT_VARIABLE GIT_STATUS
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(GIT_STATUS)
-      add_compile_definitions(
-        "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=${GIT_REVISION} (modified)>")
-    else()
-      add_compile_definitions(
-        "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=${GIT_REVISION}>")
-    endif()
+
+  # Check if there are local changes.
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} status -s
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_STATUS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(GIT_STATUS)
+    set(GIT_VERSION "${GIT_VERSION} - modified")
   endif()
 endif()
+
+# Combine the hard-coded Swift version with available Git information.
+if(GIT_VERSION)
+set(SWT_TESTING_LIBRARY_VERSION "${SWT_TESTING_LIBRARY_VERSION} (${GIT_VERSION})")
+endif()
+
+# All done!
+message(STATUS "Swift Testing version: ${SWT_TESTING_LIBRARY_VERSION}")
+add_compile_definitions(
+  "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=\"${SWT_TESTING_LIBRARY_VERSION}\">")


### PR DESCRIPTION
This PR updates the version reported when using CMake (i.e. when building in the toolchain) to `"6.1-dev"` with optional trailing git commit hash, if available. The resulting string looks like:

> `6.1.0-dev (c6450e02cc76cd7 - modified)`

"c6450e02cc76cd7" in this example refers to the most recent commit on the branch I was testing on via `git rev-parse --verify HEAD`, and "modified" is present because I had uncommitted changes.

(We'll want to double-check that CMake used in CI can see the git repository and has access to the git tool.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
