### PR TITLE
[6.0] Set the library version reported via CMake to 6.0.

### DIFF
--- a/cmake/modules/LibraryVersion.cmake
+++ b/cmake/modules/LibraryVersion.cmake
@@ -8,13 +8,14 @@
 
 # The current version of the Swift Testing release. For release branches,
 # remember to remove -dev.
-set(SWT_TESTING_LIBRARY_VERSION "6.1.0-dev")
+set(SWT_TESTING_LIBRARY_VERSION "6.1-dev")
 
 find_package(Git QUIET)
 if(Git_FOUND)
-  # Look for a tag (including non-annotated, i.e. commit-specific, ones.)
+  # Get the commit hash corresponding to the current build. Limit length to 15
+  # to match `swift --version` output format.
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags
+    COMMAND ${GIT_EXECUTABLE} rev-parse --short=15 --verify HEAD
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/modules/LibraryVersion.cmake
+++ b/cmake/modules/LibraryVersion.cmake
@@ -8,7 +8,7 @@
 
 # The current version of the Swift Testing release. For release branches,
 # remember to remove -dev.
-set(SWT_TESTING_LIBRARY_VERSION "6.1-dev")
+set(SWT_TESTING_LIBRARY_VERSION "6.0")
 
 find_package(Git QUIET)
 if(Git_FOUND)

--- a/cmake/modules/LibraryVersion.cmake
+++ b/cmake/modules/LibraryVersion.cmake
@@ -6,34 +6,37 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+# The current version of the Swift Testing release. For release branches,
+# remember to remove -dev.
+set(SWT_TESTING_LIBRARY_VERSION "6.1.0-dev")
+
 find_package(Git QUIET)
 if(Git_FOUND)
+  # Look for a tag (including non-annotated, i.e. commit-specific, ones.)
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags --exact-match
+    COMMAND ${GIT_EXECUTABLE} describe --tags
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_TAG
+    OUTPUT_VARIABLE GIT_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_QUIET)
-  if(GIT_TAG)
-    add_compile_definitions(
-      "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=${GIT_TAG}>")
-  else()
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --verify HEAD
-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-      OUTPUT_VARIABLE GIT_REVISION
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} status -s
-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-      OUTPUT_VARIABLE GIT_STATUS
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(GIT_STATUS)
-      add_compile_definitions(
-        "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=${GIT_REVISION} (modified)>")
-    else()
-      add_compile_definitions(
-        "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=${GIT_REVISION}>")
-    endif()
+
+  # Check if there are local changes.
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} status -s
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_STATUS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(GIT_STATUS)
+    set(GIT_VERSION "${GIT_VERSION} - modified")
   endif()
 endif()
+
+# Combine the hard-coded Swift version with available Git information.
+if(GIT_VERSION)
+set(SWT_TESTING_LIBRARY_VERSION "${SWT_TESTING_LIBRARY_VERSION} (${GIT_VERSION})")
+endif()
+
+# All done!
+message(STATUS "Swift Testing version: ${SWT_TESTING_LIBRARY_VERSION}")
+add_compile_definitions(
+  "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=\"${SWT_TESTING_LIBRARY_VERSION}\">")


### PR DESCRIPTION
**Explanation:** Sets the version of the library as built in CMake to "6.0".
**Scope:** 6.0 releases built with CMake instead of SwiftPM
**Issue:** N/A
**Original PR:** https://github.com/swiftlang/swift-testing/pull/637
**Risk:** Low
**Testing:** Manually tested at desk and in a toolchain build as we don't have CI jobs using CMake yet. See https://github.com/swiftlang/swift/pull/76034
**Reviewer:** @compnerd @briancroom