### PR TITLE
Add support for capturing backtraces from typed throws.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -149,6 +149,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("AvailabilityMacro=_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
       .enableExperimentalFeature("AvailabilityMacro=_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
       .enableExperimentalFeature("AvailabilityMacro=_synchronizationAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_typedThrowsAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"),
 
       .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0"),
     ]

--- a/Sources/_TestingInternals/WillThrow.cpp
+++ b/Sources/_TestingInternals/WillThrow.cpp
@@ -18,3 +18,15 @@ SWT_IMPORT_FROM_STDLIB std::atomic<SWTWillThrowHandler> _swift_willThrow;
 SWTWillThrowHandler swt_setWillThrowHandler(SWTWillThrowHandler handler) {
   return _swift_willThrow.exchange(handler, std::memory_order_acq_rel);
 }
+
+/// The Swift runtime typed-error-handling hook.
+SWT_IMPORT_FROM_STDLIB __attribute__((weak_import)) std::atomic<SWTWillThrowTypedHandler> _swift_willThrowTypedImpl;
+
+SWTWillThrowTypedHandler swt_setWillThrowTypedHandler(SWTWillThrowTypedHandler handler) {
+#if defined(__APPLE__)
+  if (&_swift_willThrowTypedImpl == nullptr) {
+    return nullptr;
+  }
+#endif
+  return _swift_willThrowTypedImpl.exchange(handler, std::memory_order_acq_rel);
+}

--- a/Sources/_TestingInternals/include/WillThrow.h
+++ b/Sources/_TestingInternals/include/WillThrow.h
@@ -41,6 +41,54 @@ typedef void (* SWT_SENDABLE SWTWillThrowHandler)(void *error);
 /// ``SWTWillThrowHandler``
 SWT_EXTERN SWTWillThrowHandler SWT_SENDABLE _Nullable swt_setWillThrowHandler(SWTWillThrowHandler SWT_SENDABLE _Nullable handler);
 
+/// The type of handler that is called by `swift_willThrowTyped()`.
+///
+/// - Parameters:
+///   - error: The error that is about to be thrown. This pointer points
+///     directly to the unboxed error in memory. For errors of reference type,
+///     the pointer points to the object and is not the object's address itself.
+///   - errorType: The metatype of `error`.
+///   - errorConformance: The witness table for `error`'s conformance to the
+///     `Error` protocol.
+typedef void (* SWT_SENDABLE SWTWillThrowTypedHandler)(void *error, const void *errorType, const void *errorConformance);
+
+/// Set the callback function that fires when an instance of `Swift.Error` is
+/// thrown using the typed throws mechanism.
+///
+/// - Parameters:
+///   - handler: The handler function to set, or `nil` to clear the handler
+///     function.
+///
+/// - Returns: The previously-set handler function, if any.
+///
+/// This function sets the global `_swift_willThrowTypedImpl()` variable in the
+/// Swift runtime, which is reserved for use by the testing framework. If
+/// another testing framework such as XCTest has already set a handler, it is
+/// returned.
+///
+/// ## See Also
+///
+/// ``SWTWillThrowTypedHandler``
+SWT_EXTERN SWTWillThrowTypedHandler SWT_SENDABLE _Nullable swt_setWillThrowTypedHandler(SWTWillThrowTypedHandler SWT_SENDABLE _Nullable handler);
+
+#if !defined(__APPLE__)
+/// The result of `swift__getErrorValue()`.
+///
+/// For more information, see this type's declaration
+/// [in the Swift repository](https://github.com/swiftlang/swift/blob/main/include/swift/Runtime/Error.h).
+typedef struct SWTErrorValueResult {
+  void *value;
+  const void *type;
+  const void *errorConformance;
+} SWTErrorValueResult;
+
+/// Unbox an error existential and get its type and protocol conformance.
+///
+/// This function is provided by the Swift runtime. For more information, see
+/// this function's declaration [in the Swift repository](https://github.com/swiftlang/swift/blob/main/include/swift/Runtime/Error.h).
+SWT_IMPORT_FROM_STDLIB void swift_getErrorValue(void *error, void *_Nullable *_Nonnull scratch, SWTErrorValueResult *out);
+#endif
+
 SWT_ASSUME_NONNULL_END
 
 #endif

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -9,16 +9,23 @@
 //
 
 @testable @_spi(ForToolsIntegrationOnly) import Testing
+#if SWT_TARGET_OS_APPLE && canImport(Foundation)
+import Foundation
+#endif
 
 struct BacktracedError: Error {}
+final class BacktracedRefCountedError: Error {}
 
 @Suite("Backtrace Tests")
 struct BacktraceTests {
   @Test("Thrown error captures backtrace")
   func thrownErrorCapturesBacktrace() async throws {
-    await confirmation("Backtrace found") { hadBacktrace in
-      let test = Test {
+    await confirmation("Backtrace found", expectedCount: 2) { hadBacktrace in
+      let testValueType = Test {
         throw BacktracedError()
+      }
+      let testReferenceType = Test {
+        throw BacktracedRefCountedError()
       }
       var configuration = Configuration()
       configuration.eventHandler = { event, _ in
@@ -28,10 +35,67 @@ struct BacktraceTests {
           hadBacktrace()
         }
       }
-      let runner = await Runner(testing: [test], configuration: configuration)
+      let runner = await Runner(testing: [testValueType, testReferenceType], configuration: configuration)
       await runner.run()
     }
   }
+
+  @available(_typedThrowsAPI, *)
+  @Test("Typed thrown error captures backtrace")
+  func typedThrownErrorCapturesBacktrace() async throws {
+    await confirmation("Error recorded", expectedCount: 4) { errorRecorded in
+      await confirmation("Backtrace found", expectedCount: 2) { hadBacktrace in
+        let testValueType = Test {
+          try Result<Never, _>.failure(BacktracedError()).get()
+        }
+        let testReferenceType = Test {
+          try Result<Never, _>.failure(BacktracedRefCountedError()).get()
+        }
+        let testAnyType = Test {
+          try Result<Never, any Error>.failure(BacktracedError()).get()
+        }
+        let testAnyObjectType = Test {
+          try Result<Never, any Error>.failure(BacktracedRefCountedError()).get()
+        }
+        var configuration = Configuration()
+        configuration.eventHandler = { event, _ in
+          if case let .issueRecorded(issue) = event.kind {
+            errorRecorded()
+            if let backtrace = issue.sourceContext.backtrace, !backtrace.addresses.isEmpty {
+              hadBacktrace()
+            }
+          }
+        }
+        let runner = await Runner(testing: [testValueType, testReferenceType, testAnyType, testAnyObjectType], configuration: configuration)
+        await runner.run()
+      }
+    }
+  }
+
+#if SWT_TARGET_OS_APPLE && canImport(Foundation)
+  @available(_typedThrowsAPI, *)
+  @Test("Thrown NSError captures backtrace")
+  func thrownNSErrorCapturesBacktrace() async throws {
+    await confirmation("Backtrace found", expectedCount: 2) { hadBacktrace in
+      let testValueType = Test {
+        throw NSError(domain: "", code: 0, userInfo: [:])
+      }
+      let testReferenceType = Test {
+        try Result<Never, any Error>.failure(NSError(domain: "", code: 0, userInfo: [:])).get()
+      }
+      var configuration = Configuration()
+      configuration.eventHandler = { event, _ in
+        if case let .issueRecorded(issue) = event.kind,
+           let backtrace = issue.sourceContext.backtrace,
+           !backtrace.addresses.isEmpty {
+          hadBacktrace()
+        }
+      }
+      let runner = await Runner(testing: [testValueType, testReferenceType], configuration: configuration)
+      await runner.run()
+    }
+  }
+#endif
 
   @Test("Backtrace.current() is populated")
   func currentBacktrace() {

--- a/cmake/modules/shared/AvailabilityDefinitions.cmake
+++ b/cmake/modules/shared/AvailabilityDefinitions.cmake
@@ -14,4 +14,5 @@ add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_synchronizationAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0\">"
+  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_typedThrowsAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0\">")


### PR DESCRIPTION
Swift 6 introduces the typed throws feature to replace `rethrows` and to support error handling in Embedded Swift. This feature uses an ABI that differs from the one used by untyped (traditional) `throws` and as such, our hook into the runtime (`_swift_willThrow`) is insufficient to provide backtrace information for errors thrown this way.

This PR adds support for capturing said backtraces _if and only if_ the thrown error is of reference type. Such errors have stable addresses that we can track over time, whereas errors of value type will be copied when used with typed throws.

~~I'm also taking the opportunity to implement some performance enhancements to `Backtrace`. It shouldn't get called _very_ frequently, but it also should be fast!~~ This PR is dependent on #647.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
