### PR TITLE
[CMake] Fix build with SwiftTesting_BuildMacrosAsExecutables option set

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -97,7 +97,7 @@ elseif(SwiftTesting_MACRO_PATH)
     add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-load-plugin-library ${SwiftTesting_MACRO_PATH}>")
   else()
     message(STATUS "TestingMacros: ${SwiftTesting_MACRO_PATH} (executable)")
-    add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-load-plugin-exectuable ${SwiftTesting_MACRO_PATH}#TestingMacros>")
+    add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-load-plugin-executable ${SwiftTesting_MACRO_PATH}#TestingMacros>")
   endif()
 endif()
 

--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -56,6 +56,9 @@ if(SwiftTesting_BuildMacrosAsExecutables)
 
   # Include the .swift file which contains its `@main` entry point type.
   target_compile_definitions(TestingMacros PRIVATE SWT_NO_LIBRARY_MACRO_PLUGINS)
+
+  install(TARGETS TestingMacros
+    RUNTIME DESTINATION bin)
 else()
   add_library(TestingMacros SHARED)
 


### PR DESCRIPTION
Resolve the issues with an out-of-toolchain build from the command line with ninja

### Motivation:

Fixes https://github.com/swiftlang/swift-testing/issues/644 

### Modifications:

There were two issues:
    - typo -load-plugin-exectuable -> -load-plugin-executable
    - The executable target for TestingMacros was not installed

### Result:

A build from the command line with cmake -GNinja -Bbuild will successfully complete if SwiftSyntax is not find_package-able

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
