### PR TITLE
Optimizations to `Backtrace.current()`.

### DIFF
--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -37,11 +37,7 @@ public struct Backtrace: Sendable {
   /// The pointers in `addresses` are converted to instances of ``Address``. Any
   /// `nil` addresses are represented as `0`.
   public init(addresses: some Sequence<UnsafeRawPointer?>) {
-    self.init(
-      addresses: addresses.lazy
-        .map(UInt.init(bitPattern:))
-        .map(Address.init)
-    )
+    self.addresses = addresses.map { Address(UInt(bitPattern: $0)) }
   }
 
   /// Get the current backtrace.
@@ -93,7 +89,7 @@ public struct Backtrace: Sendable {
       }
 #else
       return addresses[..<endIndex].withMemoryRebound(to: UnsafeRawPointer?.self) { addresses in
-        return Self(addresses: addresses)
+        Self(addresses: addresses)
       }
 #endif
     }

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -67,16 +67,16 @@ public struct Backtrace: Sendable {
       if #available(_backtraceAsyncAPI, *) {
         initializedCount = backtrace_async(addresses.baseAddress!, addresses.count, nil)
       } else {
-        initializedCount = .init(backtrace(addresses.baseAddress!, .init(addresses.count)))
+        initializedCount = .init(clamping: backtrace(addresses.baseAddress!, .init(clamping: addresses.count)))
       }
 #elseif os(Android)
       initializedCount = addresses.withMemoryRebound(to: UnsafeMutableRawPointer.self) { addresses in
-        .init(backtrace(addresses.baseAddress!, .init(addresses.count)))
+        .init(clamping: backtrace(addresses.baseAddress!, .init(clamping: addresses.count)))
       }
 #elseif os(Linux)
-      initializedCount = .init(backtrace(addresses.baseAddress!, .init(addresses.count)))
+      initializedCount = .init(clamping: backtrace(addresses.baseAddress!, .init(clamping: addresses.count)))
 #elseif os(Windows)
-      initializedCount = Int(RtlCaptureStackBackTrace(0, ULONG(addresses.count), addresses.baseAddress!, nil))
+      initializedCount = Int(clamping: RtlCaptureStackBackTrace(0, ULONG(clamping: addresses.count), addresses.baseAddress!, nil))
 #elseif os(WASI)
       // SEE: https://github.com/WebAssembly/WASI/issues/159
       // SEE: https://github.com/swiftlang/swift/pull/31693

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -192,7 +192,10 @@ extension Backtrace {
 
   /// The implementation of ``Backtrace/startCachingForThrownErrors()``, run
   /// only once.
-  private static let _startCachingForThrownErrors: Void = {
+  ///
+  /// This value is named oddly so that it shows up clearly in symbolicated
+  /// backtraces.
+  private static let __SWIFT_TESTING_IS_CAPTURING_A_BACKTRACE_FOR_A_THROWN_ERROR__: Void = {
     _oldWillThrowHandler.withLock { oldWillThrowHandler in
       oldWillThrowHandler = swt_setWillThrowHandler { errorAddress in
         let backtrace = Backtrace.current()
@@ -208,7 +211,7 @@ extension Backtrace {
   /// developer-supplied code to ensure that thrown errors' backtraces are
   /// always captured.
   static func startCachingForThrownErrors() {
-    _startCachingForThrownErrors
+    __SWIFT_TESTING_IS_CAPTURING_A_BACKTRACE_FOR_A_THROWN_ERROR__
   }
 
   /// Flush stale entries from the error-mapping cache.

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -85,9 +85,17 @@ public struct Backtrace: Sendable {
 #endif
 
       let endIndex = addresses.index(addresses.startIndex, offsetBy: initializedCount)
-      return addresses[..<endIndex].withMemoryRebound(to: UnsafeRawPointer?.self) { addresses in
+#if _pointerBitWidth(_64)
+      // The width of a pointer equals the width of an `Address`, so we can just
+      // bitcast the memory rather than mapping through UInt first.
+      return addresses[..<endIndex].withMemoryRebound(to: Address.self) { addresses in
         Self(addresses: addresses)
       }
+#else
+      return addresses[..<endIndex].withMemoryRebound(to: UnsafeRawPointer?.self) { addresses in
+        return Self(addresses: addresses)
+      }
+#endif
     }
   }
 }


### PR DESCRIPTION
This PR optimizes `Backtrace.current()`:

- There are now fewer library symbols are captured in a backtrace. This particularly affects debug builds where nested scoped accesses aren't optimized away.
- I've eliminated almost all copies of the backtrace's underlying data. On 64-bit targets, the only copy required is to final `Array` storage and is handled by the standard library.
- I've eliminated runtime bounds checks on backtrace counts that need to be cast from one integer type to another.
- I've renamed the internal symbol `_startCachingForThrownErrors` to `__SWIFT_TESTING_IS_CAPTURING_A_BACKTRACE_FOR_A_THROWN_ERROR__`. This symbol unavoidably shows up in backtraces captured when `swift_willThrow` is called, so I gave it a name that (hopefully) clearly explains why it's there.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
