### PR TITLE
[6.0] Plumb through the testing library version into a function instead of a C++ macro.

### DIFF
--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -125,7 +125,7 @@ let simulatorVersion: String = {
 ///
 /// This value is not part of the public interface of the testing library.
 var testingLibraryVersion: String {
-  SWT_TESTING_LIBRARY_VERSION
+  swt_getTestingLibraryVersion().flatMap(String.init(validatingCString:)) ?? "unknown"
 }
 
 /// A human-readable string describing the Swift Standard Library's version.

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_SCAN_FOR_MODULES 0)
 include(LibraryVersion)
 add_library(_TestingInternals STATIC
   Discovery.cpp
+  Versions.cpp
   WillThrow.cpp)
 target_include_directories(_TestingInternals PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/Sources/_TestingInternals/Versions.cpp
+++ b/Sources/_TestingInternals/Versions.cpp
@@ -1,0 +1,20 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#include "Versions.h"
+
+const char *swt_getTestingLibraryVersion(void) {
+#if defined(_SWT_TESTING_LIBRARY_VERSION)
+  return _SWT_TESTING_LIBRARY_VERSION;
+#else
+#warning _SWT_TESTING_LIBRARY_VERSION not defined: testing library version is unavailable
+  return nullptr;
+#endif
+}

--- a/Sources/_TestingInternals/include/Defines.h
+++ b/Sources/_TestingInternals/include/Defines.h
@@ -32,15 +32,4 @@
 /// An attribute that renames a C symbol in Swift.
 #define SWT_SWIFT_NAME(name) __attribute__((swift_name(#name)))
 
-/// The testing library version from the package manifest.
-///
-/// - Bug: The value provided to the compiler (`_SWT_TESTING_LIBRARY_VERSION`)
-///   is not visible in Swift, so this second macro is needed.
-///   ((#43521)[https://github.com/swiftlang/swift/issues/43521])
-#if defined(_SWT_TESTING_LIBRARY_VERSION)
-#define SWT_TESTING_LIBRARY_VERSION _SWT_TESTING_LIBRARY_VERSION
-#else
-#define SWT_TESTING_LIBRARY_VERSION "unknown"
-#endif
-
 #endif // SWT_DEFINES_H

--- a/Sources/_TestingInternals/include/Versions.h
+++ b/Sources/_TestingInternals/include/Versions.h
@@ -1,0 +1,28 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if !defined(SWT_VERSIONS_H)
+#define SWT_VERSIONS_H
+
+#include "Defines.h"
+
+SWT_ASSUME_NONNULL_BEGIN
+
+/// Get the human-readable version of the testing library.
+///
+/// - Returns: A human-readable string describing the version of the testing
+///   library, or `nullptr` if no version information is available. This
+///   string's value and format may vary between platforms, releases, or any
+///   other conditions. Do not attempt to parse it.
+SWT_EXTERN const char *_Nullable swt_getTestingLibraryVersion(void);
+
+SWT_ASSUME_NONNULL_END
+
+#endif


### PR DESCRIPTION
**Explanation:** Correctly sets the testing library version (it was failing to set on the Swift side.)
**Scope:** Building with CMake
**Issue:** N/A
**Original PR:** https://github.com/swiftlang/swift-testing/pull/648
**Risk:** Low
**Testing:** Built a toolchain and verified the string was ingested all the way through.
**Reviewer:** @grynspan @briancroom