### PR TITLE
CMake: Install `_TestingInternals` in static library builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,4 +38,5 @@ if(NOT SWIFT_SYSTEM_NAME)
   endif()
 endif()
 
+include(SwiftModuleInstallation)
 add_subdirectory(Sources)

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -94,11 +94,16 @@ add_library(Testing
   Traits/Trait.swift)
 target_link_libraries(Testing PRIVATE
   _TestingInternals)
+if(NOT BUILD_SHARED_LIBS)
+  # When building a static library, tell clients to autolink the internal
+  # library.
+  target_compile_options(Testing PRIVATE
+    "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestingInternals")
+endif()
 add_dependencies(Testing
   TestingMacros)
 target_compile_options(Testing PRIVATE
   -enable-library-evolution
   -emit-module-interface -emit-module-interface-path $<TARGET_PROPERTY:Testing,Swift_MODULE_DIRECTORY>/Testing.swiftinterface)
 
-include(SwiftModuleInstallation)
 _swift_testing_install_target(Testing)

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -17,3 +17,12 @@ target_include_directories(_TestingInternals PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_options(_TestingInternals PRIVATE
   -fno-exceptions)
+
+if(NOT BUILD_SHARED_LIBS)
+  # When building a static library, install the internal library archive
+  # alongside the main library. In shared library builds, the internal library
+  # is linked into the main library and does not need to be installed separately.
+  get_swift_install_lib_dir(STATIC_LIBRARY lib_destination_dir)
+  install(TARGETS _TestingInternals
+    ARCHIVE DESTINATION ${lib_destination_dir})
+endif()


### PR DESCRIPTION
When building the Testing library as a static library (BUILD_SHARED_LIBS=FALSE), `_TestingInternals` is not included in the `libTesting.a` archive by default. (when building as a shared library, `libTesting.so` includes `_TestingInternals`). This causes the linker to complain about missing symbols, so we need to manually merge the objects from `_TestingInternals` into `libTesting.a`.

This change is required to ship swift-testing as a part of Swift SDK for WebAssembly

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
