### PR TITLE
Optimize `failureBreakpoint()`.

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -239,7 +239,7 @@ extension Issue {
 // MARK: - Debugging failures
 
 /// A unique value used by ``failureBreakpoint()``.
-@usableFromInline nonisolated(unsafe) var failureBreakpointValue = 0
+@usableFromInline @exclusivity(unchecked) nonisolated(unsafe) var failureBreakpointValue = 0
 
 /// A function called by the testing library when a failure occurs.
 ///
@@ -261,7 +261,7 @@ extension Issue {
 /// This function performs no action of its own. It is not part of the public
 /// interface of the testing library, but it is exported and its symbol name
 /// must remain stable.
-@inline(never) @_optimize(none)
+@inline(never)
 @usableFromInline
 func failureBreakpoint() {
   // This function's body cannot be completely empty or else linker symbol


### PR DESCRIPTION
`failureBreakpoint()` currently has optimizations disabled which produces some significant assembly for what's supposed to be a no-op. Enabling optimizations and marking its magic value as `@exclusivity(unchecked)` reduces it to a single indirect store.

This is probably not the hottest hot path in the library (since it will only be called when a test is failing) but the whole point of the function is to be a no-op, and without this change it's _quite_ noisy and includes a whole function call into the Swift runtime (see the `bl` instructions below.)

### arm64

#### Before
```asm
_$s7Testing17failureBreakpointyyF:
0000000000000660	sub	sp, sp, #0x30
0000000000000664	stp	x29, x30, [sp, #0x20]
0000000000000668	add	x29, sp, #0x20
000000000000066c	adrp	x8, 0 ; 0x0
0000000000000670	add	x0, x8, #0x0
0000000000000674	add	x1, sp, #0x8
0000000000000678	mov	x2, #0x21
000000000000067c	mov	x3, #0x0
0000000000000680	bl	0x680
0000000000000684	mov	x8, #0x1
0000000000000688	adrp	x9, 0 ; 0x0
000000000000068c	add	x9, x9, #0x0
0000000000000690	str	x8, [x9]
0000000000000694	add	x0, sp, #0x8
0000000000000698	bl	0x698
000000000000069c	ldp	x29, x30, [sp, #0x20]
00000000000006a0	add	sp, sp, #0x30
00000000000006a4	ret
```

#### After
```asm
_$s7Testing17failureBreakpointyyF:
0000000000000660	adrp	x8, 0 ; 0x0
0000000000000664	str	xzr, [x8]
0000000000000668	ret
```

Note this disassembly comes from the intermediate .o file generated for the relevant source file, so addresses aren't available yet. Neither function actually attempts to write to 0x0.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
