### PR TITLE
[android] fix 32 bit android build

### DIFF
--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -420,7 +420,7 @@ extension FileHandle {
         return false
       }
       var statStruct = stat()
-      return (0 == fstat(fd, &statStruct) && swt_S_ISFIFO(statStruct.st_mode))
+      return (0 == fstat(fd, &statStruct) && swt_S_ISFIFO(mode_t(statStruct.st_mode)))
     }
 #elseif os(Windows)
     return withUnsafeWindowsHANDLE { handle in

--- a/Sources/Testing/Support/GetSymbol.swift
+++ b/Sources/Testing/Support/GetSymbol.swift
@@ -31,7 +31,7 @@ typealias ImageAddress = Never
 #if SWT_TARGET_OS_APPLE
 private nonisolated(unsafe) let RTLD_DEFAULT = ImageAddress(bitPattern: -2)
 #elseif os(Android) && _pointerBitWidth(_32)
-private nonisolated(unsafe) let RTLD_DEFAULT = ImageAddress(bitPattern: 0xFFFFFFFF)
+private nonisolated(unsafe) let RTLD_DEFAULT = ImageAddress(bitPattern: UInt(0xFFFFFFFF))
 #elseif os(Linux) || os(Android)
 private nonisolated(unsafe) let RTLD_DEFAULT = ImageAddress(bitPattern: 0)
 #endif


### PR DESCRIPTION
This fixes the following errors:
```
S:/SourceCache/swift-testing/Sources/Testing/Support/FileHandle.swift:423:70: error: cannot convert value of type 'UInt32' to expected argument type 'mode_t' (aka 'UInt16')
421 |       }
422 |       var statStruct = stat()
423 |       return (0 == fstat(fd, &statStruct) && swt_S_ISFIFO(statStruct.st_mode))
    |                                                                      `- error: cannot convert value of type 'UInt32' to expected argument type 'mode_t' (aka 'UInt16')
424 |     }
425 | #elseif os(Windows)
S:/SourceCache/swift-testing/Sources/Testing/Support/GetSymbol.swift:34:73: error: integer literal '4294967295' overflows when stored into 'Int'
32 | private nonisolated(unsafe) let RTLD_DEFAULT = ImageAddress(bitPattern: -2)
33 | #elseif os(Android) && _pointerBitWidth(_32)
34 | private nonisolated(unsafe) let RTLD_DEFAULT = ImageAddress(bitPattern: 0xFFFFFFFF)
   |                                                                         `- error: integer literal '4294967295' overflows when stored into 'Int'
```

### Motivation:

Fix 32 bit android build.

### Modifications:

Add explicit types to to cast correctly and to pick correct overload.

### Result:

Android swift-testing will build for armv7k and i686.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
