### PR TITLE
Do not include sysctl.h on Linux.

### DIFF
--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -57,7 +57,7 @@
 #include <sys/stat.h>
 #endif
 
-#if __has_include(<sys/sysctl.h>)
+#if __has_include(<sys/sysctl.h>) && !defined(__linux__)
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
This PR ensures `<sys/sysctl.h>` is not included on Linux, where it generates compile-time diagnostics on distros/versions where it's still present. The diagnostic looks something like:

```
[5/5][100%][7.920s] Linking Swift shared library lib/libTesting.so
<module-includes>:3:10: note: in file included from <module-includes>:3:
1 | #include "./Defines.h"
2 | #include "./Discovery.h"
3 | #include "./Includes.h"
  |          `- note: in file included from <module-includes>:3:
4 | #include "./Stubs.h"
5 | #include "./TestSupport.h"

/home/build-user/swift-testing/Sources/_TestingInternals/include/./Includes.h:61:10: note: in file included from /home/build-user/swift-testing/Sources/_TestingInternals/include/./Includes.h:61:
 59 |
 60 | #if __has_include(<sys/sysctl.h>)
 61 | #include <sys/sysctl.h>
    |          `- note: in file included from /home/build-user/swift-testing/Sources/_TestingInternals/include/./Includes.h:61:
 62 | #endif
 63 |
```

Since we don't use `sysctl()` on Linux (and it's been outright removed from the OS!), let's fix the diagnostic.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
