### PR TITLE
Work around swiftinterface generation bug on Windows.

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -239,13 +239,12 @@ extension Issue {
 // MARK: - Debugging failures
 
 /// A unique value used by ``failureBreakpoint()``.
-@usableFromInline
 #if !os(Windows)
 // Work around compiler bug by not specifying unchecked exclusivity on Windows.
 // SEE: https://github.com/swiftlang/swift/issues/76279
 @exclusivity(unchecked)
 #endif
-nonisolated(unsafe) var failureBreakpointValue = 0
+@usableFromInline nonisolated(unsafe) var failureBreakpointValue = 0
 
 /// A function called by the testing library when a failure occurs.
 ///

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -239,7 +239,13 @@ extension Issue {
 // MARK: - Debugging failures
 
 /// A unique value used by ``failureBreakpoint()``.
-@usableFromInline @exclusivity(unchecked) nonisolated(unsafe) var failureBreakpointValue = 0
+@usableFromInline
+#if !os(Windows)
+// Work around compiler bug by not specifying unchecked exclusivity on Windows.
+// SEE: https://github.com/swiftlang/swift/issues/76279
+@exclusivity(unchecked)
+#endif
+nonisolated(unsafe) var failureBreakpointValue = 0
 
 /// A function called by the testing library when a failure occurs.
 ///
@@ -272,5 +278,5 @@ func failureBreakpoint() {
   // opportunities elsewhere. Instead, this function performs a trivial
   // operation on a usable-from-inline value, which the compiler must assume
   // cannot be optimized away.
-  failureBreakpointValue = 1
+  failureBreakpointValue = 0
 }

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -531,9 +531,9 @@ struct MiscellaneousTests {
 
   @Test("failureBreakpoint() call")
   func failureBreakpointCall() {
-    failureBreakpointValue = 0
+    failureBreakpointValue = 1
     failureBreakpoint()
-    #expect(failureBreakpointValue == 1)
+    #expect(failureBreakpointValue == 0)
   }
 
   @available(_clockAPI, *)


### PR DESCRIPTION
Works around the issue described in https://github.com/swiftlang/swift/issues/76279.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
