### PR TITLE
Work around compiler regression causing CI failure.

### DIFF
--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -17,19 +17,18 @@ import SwiftSyntaxMacros
 /// If the developer specified Self.something as an argument to the `@Test` or
 /// `@Suite` attribute, we will currently incorrectly infer Self as equalling
 /// the `__TestContainer` type we emit rather than the type containing the
-/// test. This class strips off `Self.` wherever that occurs and, if possible,
-/// replaces it with the actual containing type name.
+/// test. This class strips off `Self.` wherever that occurs.
 ///
 /// Note that this operation is technically incorrect if a subexpression of the
 /// attribute declares a type and refers to it with `Self`. We accept this
 /// constraint as it is unlikely to pose real-world issues and is generally
 /// solvable by using an explicit type name instead of `Self`.
+///
+/// This class should instead replace `Self` with the name of the containing
+/// type when rdar://105470382 is resolved.
 private final class _SelfRemover<C>: SyntaxRewriter where C: MacroExpansionContext {
   /// The macro context in which the expression is being parsed.
   let context: C
-
-  /// The type with which to replace `Self`.
-  let typeExpr: TypeExprSyntax?
 
   /// Initialize an instance of this class.
   ///
@@ -38,22 +37,18 @@ private final class _SelfRemover<C>: SyntaxRewriter where C: MacroExpansionConte
   ///   - viewMode: The view mode to use when walking the syntax tree.
   init(in context: C) {
     self.context = context
-    self.typeExpr = context.typeOfLexicalContext.map { TypeExprSyntax(type: $0) }
   }
 
   override func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
     if let base = node.base?.as(DeclReferenceExprSyntax.self) {
       if base.baseName.tokenKind == .keyword(.Self) {
-        if let typeExpr {
-          // Replace Self with the actual type name.
-          return ExprSyntax(node.with(\.base, ExprSyntax(typeExpr)))
-        }
-        // We don't know the enclosing type name, so just strip Self and hope
-        // the compiler is happy with the leading dot syntax.
+        // We cannot currently correctly convert Self.self into the expected
+        // type name, but once rdar://105470382 is resolved we can replace the
+        // base expression with the typename here (at which point Self.self
+        // ceases to be an interesting case anyway.)
         return ExprSyntax(node.declName)
       }
     } else if let base = node.base?.as(MemberAccessExprSyntax.self) {
-      // Recursively walk into the base expression.
       return ExprSyntax(node.with(\.base, visit(base)))
     }
     return ExprSyntax(node)

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -169,7 +169,6 @@ struct TestsWithStaticMemberAccessBySelfKeyword {
 #if FIXED_135346598
   @Test(.hidden, arguments: Self.f(max: 100))
   func g(i: Int) {}
-#endif
 
   @Test(.hidden, arguments: [Self.f(max:)])
   func h(i: @Sendable (Int) -> Range<Int>) {}
@@ -180,6 +179,7 @@ struct TestsWithStaticMemberAccessBySelfKeyword {
 
   @Test(.hidden, arguments: [Box(rawValue: Self.f(max:))])
   func j(i: Box<@Sendable (Int) -> Range<Int>>) {}
+#endif
 
   struct Nested {
     static let x = 0 ..< 100

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -166,8 +166,10 @@ struct TestsWithStaticMemberAccessBySelfKeyword {
   @Test(.hidden, arguments: Self.x)
   func f(i: Int) {}
 
+#if FIXED_135346598
   @Test(.hidden, arguments: Self.f(max: 100))
   func g(i: Int) {}
+#endif
 
   @Test(.hidden, arguments: [Self.f(max:)])
   func h(i: @Sendable (Int) -> Range<Int>) {}


### PR DESCRIPTION
This PR attempts to work around the compiler regression reported in rdar://135346598 that is currently causing our macOS CI jobs to fail.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
