### PR TITLE
Work around the swiftinterface generation issue for Android too

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -239,8 +239,8 @@ extension Issue {
 // MARK: - Debugging failures
 
 /// A unique value used by ``failureBreakpoint()``.
-#if !os(Windows)
-// Work around compiler bug by not specifying unchecked exclusivity on Windows.
+#if !os(Windows) && !os(Android)
+// Work around compiler bug by not specifying unchecked exclusivity on Windows/Android.
 // SEE: https://github.com/swiftlang/swift/issues/76279
 @exclusivity(unchecked)
 #endif


### PR DESCRIPTION
This is a follow-up to 5f62e0112a0279c6d9ac9e61de1639860dd6e9f8, as the same issue also hits the Android build

Works around the issue described in
https://github.com/swiftlang/swift/issues/76279, but for Android in addition to Windows.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
