### PR TITLE
[6.0] Don't use `Synchronization.Atomic` for `deliverExpectationCheckedEvents`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -148,7 +148,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("AvailabilityMacro=_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0"),
       .enableExperimentalFeature("AvailabilityMacro=_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
       .enableExperimentalFeature("AvailabilityMacro=_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0"),
-      .enableExperimentalFeature("AvailabilityMacro=_synchronizationAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"),
 
       .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0"),
     ]

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -177,6 +177,15 @@ extension Locked where T: Numeric {
   @discardableResult func increment() -> T {
     add(1)
   }
+
+  /// Decrement the current wrapped value of this instance.
+  ///
+  /// - Returns: The sum of ``rawValue`` and `-1`.
+  ///
+  /// This function is exactly equivalent to `add(-1)`.
+  @discardableResult func decrement() -> T {
+    add(-1)
+  }
 }
 
 extension Locked {

--- a/cmake/modules/shared/AvailabilityDefinitions.cmake
+++ b/cmake/modules/shared/AvailabilityDefinitions.cmake
@@ -13,5 +13,4 @@ add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_regexAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_swiftVersionAPI:macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0\">"
-  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_synchronizationAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0\">")


### PR DESCRIPTION
**Explanation:** Drops use of `Atomic<Int>` which is giving us some grief in some build environments where the Synchronization module isn't available.
**Scope:** 6.0 branch
**Issue:** N/A
**Original PR:** https://github.com/swiftlang/swift-testing/pull/666
**Risk:** Low
**Testing:** Existing coverage.
**Reviewer:** @briancroom @suzannaratcliff @stmontgomery
