### PR TITLE
[6.0] Work around compiler regression causing CI failure.

### DIFF
--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -166,6 +166,7 @@ struct TestsWithStaticMemberAccessBySelfKeyword {
   @Test(.hidden, arguments: Self.x)
   func f(i: Int) {}
 
+#if FIXED_135346598
   @Test(.hidden, arguments: Self.f(max: 100))
   func g(i: Int) {}
 
@@ -178,6 +179,7 @@ struct TestsWithStaticMemberAccessBySelfKeyword {
 
   @Test(.hidden, arguments: [Box(rawValue: Self.f(max:))])
   func j(i: Box<@Sendable (Int) -> Range<Int>>) {}
+#endif
 
   struct Nested {
     static let x = 0 ..< 100


### PR DESCRIPTION
**Explanation:** Disables some tests that currently fail to build against the main toolchain.
**Scope:** 6.0 branch
**Issue:** N/A
**Original PR:** https://github.com/swiftlang/swift-testing/pull/664
**Risk:** Low
**Testing:** CI job run—disables existing tests
**Reviewer:** @briancroom @suzannaratcliff @stmontgomery
