### PR TITLE
Exit tests shouldn't emit crash logs.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -37,6 +37,9 @@ public struct ExitTest: Sendable {
     // test. In the future, we might want to investigate actually setting up a
     // listener port in the parent process and tracking interesting exceptions
     // as separate exit conditions.
+    //
+    // BUG: The system may still opt to write crash logs to /Library/Logs
+    // instead of the user's home folder. rdar://47982238
     _ = task_set_exception_ports(
       swt_mach_task_self(),
       exception_mask_t(EXC_MASK_CORPSE_NOTIFY),

--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -39,7 +39,12 @@
 #include <string.h>
 #include <time.h>
 
-#if defined(__APPLE__) && __has_include(<dispatch/dispatch.h>)
+#if defined(__APPLE__) && !SWT_NO_MACH_PORTS
+#include <mach/mach_init.h>
+#include <mach/task.h>
+#endif
+
+#if defined(__APPLE__) && !SWT_NO_LIBDISPATCH
 #include <dispatch/dispatch.h>
 #endif
 
@@ -51,6 +56,10 @@
 #include <fcntl.h>
 #elif __has_include(<sys/fcntl.h>)
 #include <sys/fcntl.h>
+#endif
+
+#if __has_include(<sys/resource.h>)
+#include <sys/resource.h>
 #endif
 
 #if __has_include(<sys/stat.h>)

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -64,6 +64,17 @@ static bool swt_S_ISFIFO(mode_t mode) {
 #endif
 #endif
 
+#if defined(__APPLE__) && !SWT_NO_MACH_PORTS
+/// Get a Mach port representing the current task (process.)
+///
+/// This function is provided because `mach_task_self()` is a complex macro, but
+/// directly accessing `mach_task_self_` from Swift triggers concurrency
+/// warnings about accessing shared mutable state.
+static mach_port_t swt_mach_task_self(void) {
+  return mach_task_self();
+}
+#endif
+
 #if defined(_WIN32)
 /// Make a Win32 language ID.
 ///


### PR DESCRIPTION
When a process crashes, the platforms we support all write a crash log (or core, or error report) to disk. This is not necessary for exit test child processes (since we intentionally crash them.)

This PR suppresses generation of those logs from within an exit test:

- On Darwin, we disable the exception port for crash report files;
- On Linux, we set the maximum core dump size to zero bytes; and
- On Windows, we disable Windows Error Reporting.

The above effects are only applied to the exit test's child process, not to the parent test process nor the system as a whole.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
