### PR TITLE
Fix a typo in a call of install path getter function name

### DIFF
--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT BUILD_SHARED_LIBS)
   # When building a static library, install the internal library archive
   # alongside the main library. In shared library builds, the internal library
   # is linked into the main library and does not need to be installed separately.
-  get_swift_install_lib_dir(STATIC_LIBRARY lib_destination_dir)
+  get_swift_testing_install_lib_dir(STATIC_LIBRARY lib_destination_dir)
   install(TARGETS _TestingInternals
     ARCHIVE DESTINATION ${lib_destination_dir})
 endif()

--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -58,7 +58,7 @@
 #include <sys/fcntl.h>
 #endif
 
-#if __has_include(<sys/resource.h>)
+#if __has_include(<sys/resource.h>) && !defined(__wasi__)
 #include <sys/resource.h>
 #endif
 


### PR DESCRIPTION
This is a follow-up fix to f078f7af1e5 that I made at the last minute before merging...
