### PR TITLE
Ask Foundation to capture `NSError`/`CFError` backtraces for us.

### DIFF
--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -338,9 +338,9 @@ extension Backtrace {
   static let isFoundationCaptureEnabled = {
 #if SWT_TARGET_OS_APPLE && !SWT_NO_DYNAMIC_LINKING
     let _CFErrorSetCallStackCaptureEnabled = symbol(named: "_CFErrorSetCallStackCaptureEnabled").map {
-      unsafeBitCast($0, to: (@convention(c) (UInt8) -> UInt8).self)
+      unsafeBitCast($0, to: (@convention(c) (DarwinBoolean) -> DarwinBoolean).self)
     }
-    _ = _CFErrorSetCallStackCaptureEnabled?(1)
+    _ = _CFErrorSetCallStackCaptureEnabled?(true)
     return _CFErrorSetCallStackCaptureEnabled != nil
 #else
     false

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -108,7 +108,7 @@ struct BacktraceTests {
   }
 
   @Test("Thrown NSError has a different backtrace than we generated", .enabled(if: Backtrace.isFoundationCaptureEnabled))
-  func foundationGeneratedNSError() throws {
+  func foundationGeneratedNSError() {
     do {
       try throwNSError()
     } catch {
@@ -129,7 +129,6 @@ struct BacktraceTests {
     }
   }
 #endif
-
 
   @Test("Backtrace.current() is populated")
   func currentBacktrace() {

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -95,7 +95,41 @@ struct BacktraceTests {
       await runner.run()
     }
   }
+
+  @inline(never)
+  func throwNSError() throws {
+    let error = NSError(domain: "Oh no!", code: 123, userInfo: [:])
+    throw error
+  }
+
+  @inline(never)
+  func throwBacktracedRefCountedError() throws {
+    throw BacktracedRefCountedError()
+  }
+
+  @Test("Thrown NSError has a different backtrace than we generated", .enabled(if: Backtrace.isFoundationCaptureEnabled))
+  func foundationGeneratedNSError() throws {
+    do {
+      try throwNSError()
+    } catch {
+      let backtrace1 = Backtrace(forFirstThrowOf: error, checkFoundation: true)
+      let backtrace2 = Backtrace(forFirstThrowOf: error, checkFoundation: false)
+      #expect(backtrace1 != backtrace2)
+    }
+
+    // Foundation won't capture backtraces for reference-counted errors that
+    // don't inherit from NSError (even though the existential error box itself
+    // is of an NSError subclass.)
+    do {
+      try throwBacktracedRefCountedError()
+    } catch {
+      let backtrace1 = Backtrace(forFirstThrowOf: error, checkFoundation: true)
+      let backtrace2 = Backtrace(forFirstThrowOf: error, checkFoundation: false)
+      #expect(backtrace1 == backtrace2)
+    }
+  }
 #endif
+
 
   @Test("Backtrace.current() is populated")
   func currentBacktrace() {


### PR DESCRIPTION
On Apple platforms, when an error occurs in an Objective-C method or C function, convention is to return the error as an instance of `NSError`/`CFError` via an out-parameter. When that Objective-C method or C function is called by a Swift function, the Swift function detects the error, then effectively rethrows it, at which point our `swift_willThrow` hook is triggered. This can obscure the real origin of the error which may be many stack frames down from the point Swift takes over.

This PR asks Foundation, via a relatively new internal function, to capture backtraces for instances of `NSError` and `CFError` at the point they are created. Then, when Swift Testing attempts to look up the backtrace for an error it has caught, if Foundation has generated one, then Swift Testing can substitute it in place of the one it generated in the `swift_willThrow` hook.

Resolves rdar://114386243.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
