### PR TITLE
Silence a concurrency warning on Linux/Windows building an actor-isolated test.

### DIFF
--- a/Tests/TestingTests/KnownIssueTests.swift
+++ b/Tests/TestingTests/KnownIssueTests.swift
@@ -376,12 +376,13 @@ final class KnownIssueTests: XCTestCase {
 
     await fulfillment(of: [issueRecorded, knownIssueNotRecorded], timeout: 0.0)
   }
+}
 
-  @MainActor
-  func testMainActorIsolated() async {
-    await Test {
-      await withKnownIssue(isIntermittent: true) { () async in }
-    }.run(configuration: .init())
-  }
+@MainActor
+@Test("withKnownIssue {} with main actor isolation")
+func mainActorIsolatedKnownIssue() async {
+  await Test {
+    await withKnownIssue(isIntermittent: true) { () async in }
+  }.run(configuration: .init())
 }
 #endif


### PR DESCRIPTION
We have one `@MainActor`, `async` test on a non-sendable `XCTestCase` subclass. Not surprisingly, this doesn't work fantastically well. Move the test out of the class to fix the resulting compiler diagnostic.

Related to https://github.com/swiftlang/swift-package-manager/pull/7960.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
