### PR TITLE
[android] fix the build

### DIFF
--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -140,7 +140,10 @@
 #endif
 
 #if defined(__ANDROID__)
+#if defined(__swift__)
+// The linux/stat header is private in the Android modulemap.
 #pragma clang module import posix_filesystem.linux_stat
+#endif
 #include <sys/system_properties.h>
 #endif
 


### PR DESCRIPTION
the posix_filesystem module is available only from Swift, as it comes from the Swift android overlay.

### Motivation:

Fixing the android build.

### Modifications:

Modify include.

### Result:

It builds.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
