### PR TITLE
Add platform-specific branches for FreeBSD.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -673,7 +673,7 @@ extension Event.ConsoleOutputRecorder.Options {
   /// Whether or not the system terminal claims to support 16-color ANSI escape
   /// codes.
   private static var _terminalSupports16ColorANSIEscapeCodes: Bool {
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android)
     if let termVariable = Environment.variable(named: "TERM") {
       return termVariable != "dumb"
     }
@@ -695,7 +695,7 @@ extension Event.ConsoleOutputRecorder.Options {
   /// Whether or not the system terminal claims to support 256-color ANSI escape
   /// codes.
   private static var _terminalSupports256ColorANSIEscapeCodes: Bool {
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android)
     if let termVariable = Environment.variable(named: "TERM") {
       return strstr(termVariable, "256") != nil
     }
@@ -717,7 +717,7 @@ extension Event.ConsoleOutputRecorder.Options {
   /// Whether or not the system terminal claims to support true-color ANSI
   /// escape codes.
   private static var _terminalSupportsTrueColorANSIEscapeCodes: Bool {
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android)
     if let colortermVariable = Environment.variable(named: "COLORTERM") {
       return strstr(colortermVariable, "truecolor") != nil
     }

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -24,7 +24,7 @@ private import _TestingInternals
 ///
 /// This constant is not part of the public interface of the testing library.
 var EXIT_NO_TESTS_FOUND: CInt {
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || os(WASI)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
   EX_UNAVAILABLE
 #elseif os(Windows)
   CInt(ERROR_NOT_FOUND)

--- a/Sources/Testing/Events/Recorder/Event.Symbol.swift
+++ b/Sources/Testing/Events/Recorder/Event.Symbol.swift
@@ -100,7 +100,7 @@ extension Event.Symbol {
   /// be used to represent it in text-based output. The value of this property
   /// is platform-dependent.
   public var unicodeCharacter: Character {
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || os(WASI)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
     switch self {
     case .default:
       // Unicode: WHITE DIAMOND

--- a/Sources/Testing/ExitTests/ExitCondition.swift
+++ b/Sources/Testing/ExitTests/ExitCondition.swift
@@ -42,11 +42,13 @@ public enum ExitCondition: Sendable {
   /// |-|-|
   /// | macOS | [`<stdlib.h>`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/_Exit.3.html), [`<sysexits.h>`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sysexits.3.html) |
   /// | Linux | [`<stdlib.h>`](https://sourceware.org/glibc/manual/latest/html_node/Exit-Status.html), `<sysexits.h>` |
+  /// | FreeBSD | `<stdlib.h>`, `<sysexits.h>` |
   /// | Windows | [`<stdlib.h>`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/exit-success-exit-failure) |
   ///
-  /// On macOS and Windows, the full exit code reported by the process is
-  /// yielded to the parent process. Linux and other POSIX-like systems may only
-  /// reliably report the low unsigned 8 bits (0&ndash;255) of the exit code.
+  /// On macOS, FreeBSD, and Windows, the full exit code reported by the process
+  /// is yielded to the parent process. Linux and other POSIX-like systems may
+  /// only reliably report the low unsigned 8 bits (0&ndash;255) of the exit
+  /// code.
   case exitCode(_ exitCode: CInt)
 
   /// The process terminated with the given signal.
@@ -61,6 +63,7 @@ public enum ExitCondition: Sendable {
   /// |-|-|
   /// | macOS | [`<signal.h>`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/signal.3.html) |
   /// | Linux | [`<signal.h>`](https://sourceware.org/glibc/manual/latest/html_node/Standard-Signals.html) |
+  /// | FreeBSD | `<signal.h>` |
   /// | Windows | [`<signal.h>`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/signal-constants) |
   ///
   /// On Windows, by default, the C runtime will terminate a process with exit

--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -12,7 +12,7 @@
 
 internal import _TestingInternals
 
-#if SWT_TARGET_OS_APPLE || os(Linux)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD)
 /// Block the calling thread, wait for the target process to exit, and return
 /// a value describing the conditions under which it exited.
 ///
@@ -104,11 +104,16 @@ private let _createWaitThreadImpl: Void = {
     { _ in
       // Set the thread name to help with diagnostics. Note that different
       // platforms support different thread name lengths. See MAXTHREADNAMESIZE
-      // on Darwin and TASK_COMM_LEN on Linux.
+      // on Darwin, TASK_COMM_LEN on Linux, and MAXCOMLEN on FreeBSD. We try to
+      // maximize legibility in the available space.
 #if SWT_TARGET_OS_APPLE
       _ = pthread_setname_np("Swift Testing exit test monitor")
-#else
+#elseif os(Linux)
       _ = pthread_setname_np(pthread_self(), "SWT ExT monitor")
+#elseif os(FreeBSD)
+      _ = pthread_set_name_np(pthread_self(), "SWT ex test monitor")
+#else
+#warning("Platform-specific implementation missing: thread naming unavailable")
 #endif
 
       // Run an infinite loop that waits for child processes to terminate and

--- a/Sources/Testing/SourceAttribution/Backtrace+Symbolication.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace+Symbolication.swift
@@ -70,14 +70,12 @@ extension Backtrace {
         result[i] = SymbolicatedAddress(address: address, offset: offset, symbolName: symbolName)
       }
     }
-#elseif os(Linux)
-    // Although Linux has dladdr(), it does not have symbol names from ELF
-    // binaries by default. The standard library's backtracing functionality has
-    // implemented sufficient ELF/DWARF parsing to be able to symbolicate Linux
-    // backtraces. TODO: adopt the standard library's Backtrace on Linux
-    // Note that this means on Linux we don't have demangling capability (since
-    // we don't have the mangled symbol names in the first place) so this code
-    // does not check the mode argument.
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+    // Although these platforms have dladdr(), they do not have symbol names
+    // from DWARF binaries by default, only from shared libraries. The standard
+    // library's backtracing functionality has implemented sufficient ELF/DWARF
+    // parsing to be able to symbolicate Linux backtraces.
+    // TODO: adopt the standard library's Backtrace on these platforms
 #elseif os(Windows)
     _withDbgHelpLibrary { hProcess in
       guard let hProcess else {

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -69,7 +69,7 @@ public struct Backtrace: Sendable {
       initializedCount = addresses.withMemoryRebound(to: UnsafeMutableRawPointer.self) { addresses in
         .init(clamping: backtrace(addresses.baseAddress!, .init(clamping: addresses.count)))
       }
-#elseif os(Linux)
+#elseif os(Linux) || os(FreeBSD)
       initializedCount = .init(clamping: backtrace(addresses.baseAddress!, .init(clamping: addresses.count)))
 #elseif os(Windows)
       initializedCount = Int(clamping: RtlCaptureStackBackTrace(0, ULONG(clamping: addresses.count), addresses.baseAddress!, nil))

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -42,7 +42,7 @@ enum Environment {
     }
   }
 
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || os(WASI)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
   /// Get all environment variables from a POSIX environment block.
   ///
   /// - Parameters:
@@ -103,7 +103,7 @@ enum Environment {
     }
 #endif
     return _get(fromEnviron: _NSGetEnviron()!.pointee!)
-#elseif os(Linux) || os(Android)
+#elseif os(Linux) || os(FreeBSD) || os(Android)
     _get(fromEnviron: swt_environ())
 #elseif os(WASI)
     _get(fromEnviron: __wasilibc_get_environ())
@@ -170,7 +170,7 @@ enum Environment {
       }
       return nil
     }
-#elseif SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || os(WASI)
+#elseif SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
     getenv(name).flatMap { String(validatingCString: $0) }
 #elseif os(Windows)
     name.withCString(encodedAs: UTF16.self) { name in

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -156,7 +156,7 @@ struct FileHandle: ~Copyable, Sendable {
   /// descriptor, `nil` is passed to `body`.
   borrowing func withUnsafePOSIXFileDescriptor<R>(_ body: (CInt?) throws -> R) rethrows -> R {
     try withUnsafeCFILEHandle { handle in
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || os(WASI)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
       let fd = fileno(handle)
 #elseif os(Windows)
       let fd = _fileno(handle)
@@ -215,7 +215,7 @@ struct FileHandle: ~Copyable, Sendable {
   /// other threads.
   borrowing func withLock<R>(_ body: () throws -> R) rethrows -> R {
     try withUnsafeCFILEHandle { handle in
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android)
       flockfile(handle)
       defer {
         funlockfile(handle)
@@ -250,7 +250,7 @@ extension FileHandle {
     // If possible, reserve enough space in the resulting buffer to contain
     // the contents of the file being read.
     var size: Int?
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || os(WASI)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
     withUnsafePOSIXFileDescriptor { fd in
       var s = stat()
       if let fd, 0 == fstat(fd, &s) {
@@ -388,7 +388,7 @@ extension FileHandle {
 extension FileHandle {
   /// Is this file handle a TTY or PTY?
   var isTTY: Bool {
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || os(WASI)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
     // If stderr is a TTY and TERM is set, that's good enough for us.
     withUnsafePOSIXFileDescriptor { fd in
       if let fd, 0 != isatty(fd), let term = Environment.variable(named: "TERM"), !term.isEmpty {
@@ -414,7 +414,7 @@ extension FileHandle {
 
   /// Is this file handle a pipe or FIFO?
   var isPipe: Bool {
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || os(WASI)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
     withUnsafePOSIXFileDescriptor { fd in
       guard let fd else {
         return false

--- a/Sources/Testing/Support/GetSymbol.swift
+++ b/Sources/Testing/Support/GetSymbol.swift
@@ -13,7 +13,7 @@ internal import _TestingInternals
 #if !SWT_NO_DYNAMIC_LINKING
 
 /// The platform-specific type of a loaded image handle.
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android)
 typealias ImageAddress = UnsafeMutableRawPointer
 #elseif os(Windows)
 typealias ImageAddress = HMODULE
@@ -28,7 +28,7 @@ typealias ImageAddress = Never
 /// and cannot be imported directly into Swift. As well, `RTLD_DEFAULT` is only
 /// defined on Linux when `_GNU_SOURCE` is defined, so it is not sufficient to
 /// declare a wrapper function in the internal module's Stubs.h file.
-#if SWT_TARGET_OS_APPLE
+#if SWT_TARGET_OS_APPLE || os(FreeBSD)
 private nonisolated(unsafe) let RTLD_DEFAULT = ImageAddress(bitPattern: -2)
 #elseif os(Android) && _pointerBitWidth(_32)
 private nonisolated(unsafe) let RTLD_DEFAULT = ImageAddress(bitPattern: UInt(0xFFFFFFFF))
@@ -59,7 +59,7 @@ private nonisolated(unsafe) let RTLD_DEFAULT = ImageAddress(bitPattern: 0)
 /// calling `EnumProcessModules()` and iterating over the returned handles
 /// looking for one containing the given function.
 func symbol(in handle: ImageAddress? = nil, named symbolName: String) -> UnsafeRawPointer? {
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android)
   dlsym(handle ?? RTLD_DEFAULT, symbolName).map(UnsafeRawPointer.init)
 #elseif os(Windows)
   symbolName.withCString { symbolName in

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -36,7 +36,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   /// To keep the implementation of this type as simple as possible,
   /// `pthread_mutex_t` is used on Apple platforms instead of `os_unfair_lock`
   /// or `OSAllocatedUnfairLock`.
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
   private typealias _Lock = pthread_mutex_t
 #elseif os(Windows)
   private typealias _Lock = SRWLOCK
@@ -52,7 +52,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   private final class _Storage: ManagedBuffer<T, _Lock> {
     deinit {
       withUnsafeMutablePointerToElements { lock in
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
         _ = pthread_mutex_destroy(lock)
 #elseif os(Windows)
         // No deinitialization needed.
@@ -71,7 +71,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   init(rawValue: T) {
     _storage = _Storage.create(minimumCapacity: 1, makingHeaderWith: { _ in rawValue })
     _storage.withUnsafeMutablePointerToElements { lock in
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
       _ = pthread_mutex_init(lock, nil)
 #elseif os(Windows)
       InitializeSRWLock(lock)
@@ -101,7 +101,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   /// concurrency tools.
   nonmutating func withLock<R>(_ body: (inout T) throws -> R) rethrows -> R {
     try _storage.withUnsafeMutablePointers { rawValue, lock in
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
       _ = pthread_mutex_lock(lock)
       defer {
         _ = pthread_mutex_unlock(lock)
@@ -121,7 +121,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
     }
   }
 
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
   /// Acquire the lock and invoke a function while it is held, yielding both the
   /// protected value and a reference to the lock itself.
   ///

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -31,7 +31,7 @@ let operatingSystemVersion: String = {
   default:
     return "\(productVersion) (\(buildNumber))"
   }
-#elseif !SWT_NO_UNAME && (SWT_TARGET_OS_APPLE || os(Linux) || os(WASI))
+#elseif !SWT_NO_UNAME && (SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD))
   var name = utsname()
   if 0 == uname(&name) {
     let release = withUnsafeBytes(of: name.release) { release in

--- a/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
@@ -11,7 +11,7 @@
 private import _TestingInternals
 
 #if !SWT_NO_FILE_IO
-#if os(macOS) || (os(iOS) && targetEnvironment(macCatalyst)) || os(Linux)
+#if os(macOS) || (os(iOS) && targetEnvironment(macCatalyst)) || os(Linux) || os(FreeBSD)
 /// The path to the current user's home directory, if known.
 private var _homeDirectoryPath: String? {
 #if SWT_TARGET_OS_APPLE
@@ -57,7 +57,7 @@ var swiftTestingDirectoryPath: String? {
   // The (default) name of the .swift-testing directory.
   let swiftTestingDirectoryName = ".swift-testing"
 
-#if os(macOS) || (os(iOS) && targetEnvironment(macCatalyst)) || os(Linux)
+#if os(macOS) || (os(iOS) && targetEnvironment(macCatalyst)) || os(Linux) || os(FreeBSD)
   if let homeDirectoryPath = _homeDirectoryPath {
     return appendPathComponent(swiftTestingDirectoryName, to: homeDirectoryPath)
   }

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -306,7 +306,7 @@ static void enumerateTypeMetadataSections(const SectionEnumerator& body) {
   }
 }
 
-#elif defined(__linux__) || defined(_WIN32) || defined(__wasi__) || defined(__ANDROID__)
+#elif defined(__linux__) || defined(__FreeBSD__) || defined(_WIN32) || defined(__wasi__) || defined(__ANDROID__)
 #pragma mark - Linux/Windows implementation
 
 /// Specifies the address range corresponding to a section.

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -85,7 +85,7 @@ static LANGID swt_MAKELANGID(int p, int s) {
 }
 #endif
 
-#if defined(__linux__) || defined(__ANDROID__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__ANDROID__)
 /// The environment block.
 ///
 /// By POSIX convention, the environment block variable is declared in client

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -127,7 +127,7 @@ struct ABIEntryPointTests {
     passing arguments: __CommandLineArguments_v0,
     recordHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void = { _ in }
   ) async throws -> Bool {
-#if !os(Linux) && !os(Android) && !SWT_NO_DYNAMIC_LINKING
+#if !os(Linux) && !os(FreeBSD) && !os(Android) && !SWT_NO_DYNAMIC_LINKING
     // Get the ABI entry point by dynamically looking it up at runtime.
     //
     // NOTE: The standard Linux linker does not allow exporting symbols from

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -204,12 +204,21 @@ private import _TestingInternals
 #if !os(Linux)
   @Test("Exit test reports > 8 bits of the exit code")
   func fullWidthExitCode() async {
-    // On macOS and Linux, we use waitid() which per POSIX should report the
-    // full exit code, not just the low 8 bits. This behaviour is not
-    // well-documented and while Darwin correctly reports the full value, Linux
-    // does not (at least as of this writing) and other POSIX-like systems may
-    // also have issues. This test serves as a canary when adding new platforms
-    // that we need to document the difference.
+    // On POSIX-like platforms, we use waitid() which per POSIX should report
+    // the full exit code, not just the low 8 bits. This behaviour is not
+    // well-documented and not all platforms (as of this writing) report the
+    // full value:
+    //
+    // | Platform             |  Bits Reported |
+    // |----------------------|----------------|
+    // | Darwin               |             32 |
+    // | Linux                |              8 |
+    // | Windows              | 32 (see below) |
+    // | FreeBSD              |             32 |
+    //
+    // Other platforms may also have issues reporting the full value. This test
+    // serves as a canary when adding new platforms that we need to document the
+    // difference.
     //
     // Windows does not have the 8-bit exit code restriction and always reports
     // the full CInt value back to the testing library.

--- a/Tests/TestingTests/Support/EnvironmentTests.swift
+++ b/Tests/TestingTests/Support/EnvironmentTests.swift
@@ -90,7 +90,7 @@ extension Environment {
       environment[name] = value
     }
     return true
-#elseif SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || os(WASI)
+#elseif SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || os(WASI)
     if let value {
       return 0 == setenv(name, value, 1)
     }

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -14,7 +14,7 @@ private import _TestingInternals
 #if !SWT_NO_FILE_IO
 // NOTE: we don't run these tests on iOS (etc.) because processes on those
 // platforms are sandboxed and do not have arbitrary filesystem access.
-#if os(macOS) || os(Linux) || os(Android) || os(Windows)
+#if os(macOS) || os(Linux) || os(FreeBSD) || os(Android) || os(Windows)
 @Suite("FileHandle Tests")
 struct FileHandleTests {
   // FileHandle is non-copyable, so it cannot yet be used as a test parameter.
@@ -224,7 +224,7 @@ func temporaryDirectory() throws -> String {
     }
     return try #require(Environment.variable(named: "TMPDIR"))
   }
-#elseif os(Linux)
+#elseif os(Linux) || os(FreeBSD)
   "/tmp"
 #elseif os(Android)
   Environment.variable(named: "TMPDIR") ?? "/data/local/tmp"


### PR DESCRIPTION
This PR adds support for FreeBSD where we have platform-specific code. Most changes simply involve changing `os(Linux)` to `os(Linux) || os(FreeBSD)`, although there is some actual platform-specific code and at least one spot where Darwin and FreeBSD share an implementation but Linux does not.

> [!NOTE]
> This new code is minimally tested. Support for FreeBSD is provided by the Swift community.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
