### PR TITLE
[6.0.1] Fix WASI build with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,4 +38,5 @@ if(NOT SWIFT_SYSTEM_NAME)
   endif()
 endif()
 
+include(SwiftModuleInstallation)
 add_subdirectory(Sources)

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -94,11 +94,16 @@ add_library(Testing
   Traits/Trait.swift)
 target_link_libraries(Testing PRIVATE
   _TestingInternals)
+if(NOT BUILD_SHARED_LIBS)
+  # When building a static library, tell clients to autolink the internal
+  # library.
+  target_compile_options(Testing PRIVATE
+    "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestingInternals")
+endif()
 add_dependencies(Testing
   TestingMacros)
 target_compile_options(Testing PRIVATE
   -enable-library-evolution
   -emit-module-interface -emit-module-interface-path $<TARGET_PROPERTY:Testing,Swift_MODULE_DIRECTORY>/Testing.swiftinterface)
 
-include(SwiftModuleInstallation)
 _swift_testing_install_target(Testing)

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT BUILD_SHARED_LIBS)
   # When building a static library, install the internal library archive
   # alongside the main library. In shared library builds, the internal library
   # is linked into the main library and does not need to be installed separately.
-  get_swift_install_lib_dir(STATIC_LIBRARY lib_destination_dir)
+  get_swift_testing_install_lib_dir(STATIC_LIBRARY lib_destination_dir)
   install(TARGETS _TestingInternals
     ARCHIVE DESTINATION ${lib_destination_dir})
 endif()

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -17,3 +17,12 @@ target_include_directories(_TestingInternals PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_options(_TestingInternals PRIVATE
   -fno-exceptions)
+
+if(NOT BUILD_SHARED_LIBS)
+  # When building a static library, install the internal library archive
+  # alongside the main library. In shared library builds, the internal library
+  # is linked into the main library and does not need to be installed separately.
+  get_swift_install_lib_dir(STATIC_LIBRARY lib_destination_dir)
+  install(TARGETS _TestingInternals
+    ARCHIVE DESTINATION ${lib_destination_dir})
+endif()


### PR DESCRIPTION
Explanation: When building the Testing library as a static library (BUILD_SHARED_LIBS=FALSE), `_TestingInternals` is not included in the `libTesting.a` archive by default. (when building as a shared library, `libTesting.so` includes `_TestingInternals` objects). This causes the linker to complain about missing symbols, so we need to ship `lib_TestingInternals.a` and autolink it too.
 
Original PR: https://github.com/swiftlang/swift-testing/pull/651 https://github.com/swiftlang/swift-testing/pull/672
Risk: Low; NFC for non WASI platforms
Testing: Tested in ci.swift.org
Reviewer: @grynspan 