### PR TITLE
[CMake] Explicitly link Testing to Foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ project(SwiftTesting
   LANGUAGES CXX Swift)
 
 if(NOT APPLE)
-  find_package(dispatch CONFIG)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
+    find_package(dispatch CONFIG)
+  endif()
   find_package(Foundation CONFIG)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ endif()
 project(SwiftTesting
   LANGUAGES CXX Swift)
 
+if(NOT APPLE)
+  find_package(dispatch CONFIG)
+  find_package(Foundation CONFIG)
+endif()
+
 include(GNUInstallDirs)
 
 list(APPEND CMAKE_MODULE_PATH

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -97,8 +97,11 @@ add_library(Testing
 target_link_libraries(Testing PRIVATE
   _TestingInternals)
 if(NOT APPLE)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
+    target_link_libraries(Testing PUBLIC
+      dispatch)
+  endif()
   target_link_libraries(Testing PUBLIC
-    dispatch
     Foundation)
 endif()
 if(NOT BUILD_SHARED_LIBS)

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -96,6 +96,11 @@ add_library(Testing
   Traits/Trait.swift)
 target_link_libraries(Testing PRIVATE
   _TestingInternals)
+if(NOT APPLE)
+  target_link_libraries(Testing PUBLIC
+    dispatch
+    Foundation)
+endif()
 if(NOT BUILD_SHARED_LIBS)
   # When building a static library, tell clients to autolink the internal
   # library.


### PR DESCRIPTION
Explicitly link to `Foundation` in CMake builds

If `Foundation_DIR` is passed, `find_package` finds the `Foundation` target and `target_link_libraries` adds required `-I` and `-l`/`-L`. If not, `find_package` fails and `target_link_libraries` just assumes it's a system library name and just adds `-lFoundation`.