### PR TITLE
Add a `Pipe` type.

### DIFF
--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -165,8 +165,7 @@ struct FileHandle: ~Copyable, Sendable {
   ///   `closeWhenDone` was `false` when this instance was initialized. Callers
   ///   must take care not to close file handles they do not own.
   consuming func close() {
-    fclose(_fileHandle)
-    _closeWhenDone = false
+    _closeWhenDone = true
   }
 
   /// Call a function and pass the underlying C file handle to it.

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -132,24 +132,9 @@ struct FileHandleTests {
 
   @Test("Can recognize opened pipe")
   func isPipe() throws {
-#if os(Windows)
-    var rHandle: HANDLE?
-    var wHandle: HANDLE?
-    try #require(CreatePipe(&rHandle, &wHandle, nil, 0))
-    if let rHandle {
-      CloseHandle(rHandle)
-    }
-    let fdWrite = _open_osfhandle(intptr_t(bitPattern: wHandle), 0)
-    let file = try #require(_fdopen(fdWrite, "wb"))
-#else
-    var fds: [CInt] = [-1, -1]
-    try #require(0 == pipe(&fds))
-    try #require(fds[1] >= 0)
-    close(fds[0])
-    let file = try #require(fdopen(fds[1], "wb"))
-#endif
-    let fileHandle = FileHandle(unsafeCFILEHandle: file, closeWhenDone: true)
-    #expect(Bool(fileHandle.isPipe))
+    let pipe = try FileHandle.Pipe()
+    #expect(pipe.readEnd.isPipe as Bool)
+    #expect(pipe.writeEnd.isPipe as Bool)
   }
 
   @Test("/dev/null is not a TTY or pipe")

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -154,6 +154,7 @@ struct FileHandleTests {
     #expect(pipe.writeEnd.isPipe as Bool)
   }
 
+#if SWT_TARGET_OS_APPLE
   @Test("Can close ends of a pipe")
   func closeEndsOfPipe() async throws {
     try await confirmation("File handle closed", expectedCount: 2) { closed in
@@ -166,6 +167,7 @@ struct FileHandleTests {
       _ = pipe2.closeWriteEnd()
     }
   }
+#endif
 
   @Test("/dev/null is not a TTY or pipe")
   func devNull() throws {

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -44,12 +44,29 @@ struct FileHandleTests {
     }
   }
 
+  @Test("Init from invalid file descriptor")
+  func invalidFileDescriptor() throws {
+    #expect(throws: CError.self) {
+      _ = try FileHandle(unsafePOSIXFileDescriptor: -1, mode: "")
+    }
+  }
+
 #if os(Windows)
   @Test("Can get Windows file HANDLE")
   func fileHANDLE() throws {
     let fileHandle = try FileHandle.temporary()
     try fileHandle.withUnsafeWindowsHANDLE { handle in
       try #require(handle != nil)
+    }
+  }
+#endif
+
+#if SWT_TARGET_OS_APPLE
+  @Test("close() function")
+  func closeFunction() async throws {
+    try await confirmation("File handle closed") { closed in
+      let fileHandle = try fileHandleForCloseMonitoring(with: closed)
+      fileHandle.close()
     }
   }
 #endif
@@ -135,6 +152,19 @@ struct FileHandleTests {
     let pipe = try FileHandle.Pipe()
     #expect(pipe.readEnd.isPipe as Bool)
     #expect(pipe.writeEnd.isPipe as Bool)
+  }
+
+  @Test("Can close ends of a pipe")
+  func closeEndsOfPipe() async throws {
+    try await confirmation("File handle closed", expectedCount: 2) { closed in
+      var pipe1 = try FileHandle.Pipe()
+      pipe1.readEnd = try fileHandleForCloseMonitoring(with: closed)
+      _ = pipe1.closeReadEnd()
+
+      var pipe2 = try FileHandle.Pipe()
+      pipe2.writeEnd = try fileHandleForCloseMonitoring(with: closed)
+      _ = pipe2.closeWriteEnd()
+    }
   }
 
   @Test("/dev/null is not a TTY or pipe")
@@ -224,4 +254,23 @@ func temporaryDirectory() throws -> String {
 #endif
 }
 
+#if SWT_TARGET_OS_APPLE
+func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> FileHandle {
+  let context = Unmanaged.passRetained(confirmation as AnyObject).toOpaque()
+  let file = try #require(
+    funopen(
+      context,
+      { _, _, _ in 0 },
+      nil,
+      nil,
+      { context in
+        let confirmation = Unmanaged<AnyObject>.fromOpaque(context!).takeRetainedValue() as! Confirmation
+        confirmation()
+        return 0
+      }
+    ) as SWT_FILEHandle?
+  )
+  return FileHandle(unsafeCFILEHandle: file, closeWhenDone: false)
+}
+#endif
 #endif

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -44,12 +44,14 @@ struct FileHandleTests {
     }
   }
 
+#if !os(Windows) // Windows does not like invalid file descriptors.
   @Test("Init from invalid file descriptor")
   func invalidFileDescriptor() throws {
     #expect(throws: CError.self) {
       _ = try FileHandle(unsafePOSIXFileDescriptor: -1, mode: "")
     }
   }
+#endif
 
 #if os(Windows)
   @Test("Can get Windows file HANDLE")


### PR DESCRIPTION
This PR adds a move-only wrapper for POSIX and Windows anonymous pipes (i.e. those created with `pipe(2)`.) We will need pipes in order to implement platform-independent interprocess communication such as that required by exit tests or future adoption of distributed actors.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
