### PR TITLE
Record issues generated within exit tests.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -446,7 +446,7 @@ extension ExitTest {
         // and process it as a (minimal) event stream.
         let readEnd = backChannel.closeWriteEnd()
         taskGroup.addTask {
-          Self._processRecordsFromBackChannel(readEnd)
+          Self._processRecords(fromBackChannel: readEnd)
           return nil
         }
 
@@ -463,7 +463,7 @@ extension ExitTest {
   /// - Parameters:
   ///   - backChannel: The file handle to read from. Reading continues until an
   ///     error is encountered or the end of the file is reached.
-  private static func _processRecordsFromBackChannel(_ backChannel: borrowing FileHandle) {
+  private static func _processRecords(fromBackChannel backChannel: borrowing FileHandle) {
     let bytes: [UInt8]
     do {
       bytes = try backChannel.readToEnd()

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -296,8 +296,8 @@ extension ExitTest {
     var configuration = Configuration()
 
     // Encode events as JSON and write them to the back channel file handle.
-    // Only forward issue-recorded events. (If we start handling other kinds
-    // of event in the future, we can forward them too.)
+    // Only forward issue-recorded events. (If we start handling other kinds of
+    // events in the future, we can forward them too.)
     let eventHandler = ABIv0.Record.eventHandler(encodeAsJSONLines: true) { json in
       try? _backChannelForEntryPoint?.write(json)
     }

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -71,7 +71,7 @@ public struct ExitTest: Sendable, ~Copyable {
   /// - Returns: A file handle open for writing to which events should be
   ///   written, or `nil` if the file handle could not be resolved.
   private static func _findBackChannel() -> FileHandle? {
-    guard let backChannelEnvironmentVariable = Environment.variable(named: "SWT_EXPERIMENTAL_BACKCHANNEL_FD") else {
+    guard let backChannelEnvironmentVariable = Environment.variable(named: "SWT_EXPERIMENTAL_BACKCHANNEL") else {
       return nil
     }
 
@@ -408,7 +408,7 @@ extension ExitTest {
 #warning("Platform-specific implementation missing: back-channel pipe unavailable")
 #endif
         if let backChannelEnvironmentVariable {
-          childEnvironment["SWT_EXPERIMENTAL_BACKCHANNEL_FD"] = backChannelEnvironmentVariable
+          childEnvironment["SWT_EXPERIMENTAL_BACKCHANNEL"] = backChannelEnvironmentVariable
         }
 
         // Spawn the child process.

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -505,8 +505,14 @@ extension ExitTest {
       let comments: [Comment] = event.messages.compactMap { message in
         message.symbol == .details ? Comment(rawValue: message.text) : nil
       }
-      let issue = Issue(kind: .unconditional, comments: comments, sourceContext: .init(backtrace: nil, sourceLocation: issue.sourceLocation))
-      issue.record()
+      let sourceContext = SourceContext(
+        backtrace: nil, // `issue._backtrace` will have the wrong address space.
+        sourceLocation: issue.sourceLocation
+      )
+      // TODO: improve fidelity of issue kind reporting (especially those without associated values)
+      var issueCopy = Issue(kind: .unconditional, comments: comments, sourceContext: sourceContext)
+      issueCopy.isKnown = issue.isKnown
+      issueCopy.record()
     }
   }
 }

--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -157,7 +157,7 @@ func spawnExecutable(
     )
 
     let commandLine = _escapeCommandLine(CollectionOfOne(executablePath) + arguments)
-    let environ = environment.map { "\($0.key)=\($0.value)"}.joined(separator: "\0") + "\0\0"
+    let environ = environment.map { "\($0.key)=\($0.value)" }.joined(separator: "\0") + "\0\0"
 
     return try commandLine.withCString(encodedAs: UTF16.self) { commandLine in
       try environ.withCString(encodedAs: UTF16.self) { environ in
@@ -248,7 +248,8 @@ private func _withStartupInfoEx<R>(attributeCount: Int = 0, _ body: (UnsafeMutab
 /// Windows processes are responsible for handling their own command-line
 /// escaping. This function is adapted from the code in
 /// swift-corelibs-foundation (see `quoteWindowsCommandLine()`) which was
-/// itself adapted from code [published by Microsoft](https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way).
+/// itself adapted from code [published by Microsoft](https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way)
+/// (ADO 8992662).
 private func _escapeCommandLine(_ arguments: [String]) -> String {
   return arguments.lazy
     .map { arg in

--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -8,9 +8,20 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import _TestingInternals
+internal import _TestingInternals
 
 #if !SWT_NO_EXIT_TESTS
+/// A platform-specific value identifying a process running on the current
+/// system.
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD)
+typealias ProcessID = pid_t
+#elseif os(Windows)
+typealias ProcessID = HANDLE
+#else
+#warning("Platform-specific implementation missing: process IDs unavailable")
+typealias ProcessID = Never
+#endif
+
 /// Spawn a process and wait for it to terminate.
 ///
 /// - Parameters:
@@ -18,16 +29,21 @@ private import _TestingInternals
 ///   - arguments: The arguments to pass to the executable, not including the
 ///     executable path.
 ///   - environment: The environment block to pass to the executable.
+///   - additionalFileHandles: A collection of file handles to inherit in the
+///     child process.
 ///
-/// - Returns: The exit condition of the spawned process.
+/// - Returns: A value identifying the process that was spawned. The caller must
+///   eventually pass this value to ``wait(for:)`` to avoid leaking system
+///   resources.
 ///
 /// - Throws: Any error that prevented the process from spawning or its exit
 ///   condition from being read.
-func spawnAndWait(
-  forExecutableAtPath executablePath: String,
+func spawnExecutable(
+  atPath executablePath: String,
   arguments: [String],
-  environment: [String: String]
-) async throws -> ExitCondition {
+  environment: [String: String],
+  additionalFileHandles: UnsafeBufferPointer<FileHandle> = .init(start: nil, count: 0)
+) throws -> ProcessID {
   // Darwin and Linux differ in their optionality for the posix_spawn types we
   // use, so use this typealias to paper over the differences.
 #if SWT_TARGET_OS_APPLE
@@ -37,18 +53,13 @@ func spawnAndWait(
 #endif
 
 #if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD)
-  let pid = try withUnsafeTemporaryAllocation(of: P<posix_spawn_file_actions_t>.self, capacity: 1) { fileActions in
+  return try withUnsafeTemporaryAllocation(of: P<posix_spawn_file_actions_t>.self, capacity: 1) { fileActions in
     guard 0 == posix_spawn_file_actions_init(fileActions.baseAddress!) else {
       throw CError(rawValue: swt_errno())
     }
     defer {
       _ = posix_spawn_file_actions_destroy(fileActions.baseAddress!)
     }
-
-    // Do not forward standard I/O.
-    _ = posix_spawn_file_actions_addopen(fileActions.baseAddress!, STDIN_FILENO, "/dev/null", O_RDONLY, 0)
-    _ = posix_spawn_file_actions_addopen(fileActions.baseAddress!, STDOUT_FILENO, "/dev/null", O_WRONLY, 0)
-    _ = posix_spawn_file_actions_addopen(fileActions.baseAddress!, STDERR_FILENO, "/dev/null", O_WRONLY, 0)
 
     return try withUnsafeTemporaryAllocation(of: P<posix_spawnattr_t>.self, capacity: 1) { attrs in
       guard 0 == posix_spawnattr_init(attrs.baseAddress!) else {
@@ -57,11 +68,39 @@ func spawnAndWait(
       defer {
         _ = posix_spawnattr_destroy(attrs.baseAddress!)
       }
+
+      // Do not forward standard I/O.
+      _ = posix_spawn_file_actions_addopen(fileActions.baseAddress!, STDIN_FILENO, "/dev/null", O_RDONLY, 0)
+      _ = posix_spawn_file_actions_addopen(fileActions.baseAddress!, STDOUT_FILENO, "/dev/null", O_WRONLY, 0)
+      _ = posix_spawn_file_actions_addopen(fileActions.baseAddress!, STDERR_FILENO, "/dev/null", O_WRONLY, 0)
+
+#if os(Linux) || os(FreeBSD)
+      var highestFD = CInt(0)
+#endif
+      for i in 0 ..< additionalFileHandles.count {
+        try additionalFileHandles[i].withUnsafePOSIXFileDescriptor { fd in
+          guard let fd else {
+            throw SystemError(description: "A child process inherit a file handle without an associated file descriptor. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
+          }
 #if SWT_TARGET_OS_APPLE
-      // Close all other file descriptors open in the parent. Note that Linux
-      // does not support this flag and, unlike Foundation.Process, we do not
-      // attempt to emulate it.
+          _ = posix_spawn_file_actions_addinherit_np(fileActions.baseAddress!, fd)
+#elseif os(Linux) || os(FreeBSD)
+          highestFD = max(highestFD, fd)
+#endif
+        }
+      }
+
+#if SWT_TARGET_OS_APPLE
+      // Close all other file descriptors open in the parent.
       _ = posix_spawnattr_setflags(attrs.baseAddress!, CShort(POSIX_SPAWN_CLOEXEC_DEFAULT))
+#elseif os(Linux) || os(FreeBSD)
+      // This platform doesn't have POSIX_SPAWN_CLOEXEC_DEFAULT, but we can at
+      // least close all file descriptors higher than the highest inherited one.
+      // We are assuming here that the caller didn't set FD_CLOEXEC on any of
+      // these file descriptors.
+      _ = swt_posix_spawn_file_actions_addclosefrom_np(fileActions.baseAddress!, highestFD + 1)
+#else
+#warning("Platform-specific implementation missing: cannot close unused file descriptors")
 #endif
 
       var argv: [UnsafeMutablePointer<CChar>?] = [strdup(executablePath)]
@@ -88,15 +127,130 @@ func spawnAndWait(
       return pid
     }
   }
-
-  return try await wait(for: pid)
 #elseif os(Windows)
-  // NOTE: Windows processes are responsible for handling their own
-  // command-line escaping. This code is adapted from the code in
-  // swift-corelibs-foundation (SEE: quoteWindowsCommandLine()) which was
-  // itself adapted from the code published by Microsoft at
-  // https://learn.microsoft.com/en-gb/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
-  let commandLine = (CollectionOfOne(executablePath) + arguments).lazy
+  return try _withStartupInfoEx(attributeCount: 1) { startupInfo in
+    // Forward the back channel's write end to the child process so that it can
+    // send information back to us. Note that we don't keep the pipe open as
+    // bidirectional, though we could if we find we need to in the future.
+    let inheritedHandlesBuffer = UnsafeMutableBufferPointer<HANDLE?>.allocate(capacity: additionalFileHandles.count)
+    defer {
+      inheritedHandlesBuffer.deallocate()
+    }
+    for i in 0 ..< additionalFileHandles.count {
+      try additionalFileHandles[i].withUnsafeWindowsHANDLE { handle in
+        guard let handle else {
+          throw SystemError(description: "A child process inherit a file handle without an associated Windows handle. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
+        }
+        inheritedHandlesBuffer[i] = handle
+      }
+    }
+
+    // Update the attribute list to hold the handle buffer.
+    _ = UpdateProcThreadAttribute(
+      startupInfo.pointee.lpAttributeList,
+      0,
+      swt_PROC_THREAD_ATTRIBUTE_HANDLE_LIST(),
+      inheritedHandlesBuffer.baseAddress!,
+      SIZE_T(MemoryLayout<HANDLE>.stride * inheritedHandlesBuffer.count),
+      nil,
+      nil
+    )
+
+    let commandLine = _escapeCommandLine(CollectionOfOne(executablePath) + arguments)
+    let environ = environment.map { "\($0.key)=\($0.value)"}.joined(separator: "\0") + "\0\0"
+
+    return try commandLine.withCString(encodedAs: UTF16.self) { commandLine in
+      try environ.withCString(encodedAs: UTF16.self) { environ in
+        var processInfo = PROCESS_INFORMATION()
+
+        guard CreateProcessW(
+          nil,
+          .init(mutating: commandLine),
+          nil,
+          nil,
+          true, // bInheritHandles
+          DWORD(CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT),
+          .init(mutating: environ),
+          nil,
+          startupInfo.pointer(to: \.StartupInfo)!,
+          &processInfo
+        ) else {
+          throw Win32Error(rawValue: GetLastError())
+        }
+        _ = CloseHandle(processInfo.hThread)
+
+        return processInfo.hProcess!
+      }
+    }
+  }
+#else
+#warning("Platform-specific implementation missing: process spawning unavailable")
+  throw SystemError(description: "Exit tests are unimplemented on this platform.")
+#endif
+}
+
+// MARK: -
+
+#if os(Windows)
+/// Create a temporary instance of `STARTUPINFOEXW` to pass to
+/// `CreateProcessW()`.
+///
+/// - Parameters:
+///   - attributeCount: The number of attributes to make space for in the
+///     resulting structure's attribute list.
+///   - body: A function to invoke. A temporary, mutable pointer to an instance
+///     of `STARTUPINFOEXW` is passed to this function.
+///
+/// - Returns: Whatever is returned by `body`.
+///
+/// - Throws: Whatever is thrown while creating the startup info structure or
+///   its attribute list, or whatever is thrown by `body`.
+private func _withStartupInfoEx<R>(attributeCount: Int = 0, _ body: (UnsafeMutablePointer<STARTUPINFOEXW>) throws -> R) throws -> R {
+  // Initialize the startup info structure.
+  var startupInfo = STARTUPINFOEXW()
+  startupInfo.StartupInfo.cb = DWORD(MemoryLayout.size(ofValue: startupInfo))
+
+  guard attributeCount > 0 else {
+    return try body(&startupInfo)
+  }
+
+  // Initialize an attribute list of sufficient size for the specified number of
+  // attributes. Alignment is a problem because LPPROC_THREAD_ATTRIBUTE_LIST is
+  // an opaque pointer and we don't know the alignment of the underlying data.
+  // We *should* use the alignment of C's max_align_t, but it is defined using a
+  // C++ using statement on Windows and isn't imported into Swift. So, 16 it is.
+  var attributeListByteCount = SIZE_T(0)
+  _ = InitializeProcThreadAttributeList(nil, DWORD(attributeCount), 0, &attributeListByteCount)
+  return try withUnsafeTemporaryAllocation(byteCount: Int(attributeListByteCount), alignment: 16) { attributeList in
+    let attributeList = LPPROC_THREAD_ATTRIBUTE_LIST(attributeList.baseAddress!)
+    guard InitializeProcThreadAttributeList(attributeList, DWORD(attributeCount), 0, &attributeListByteCount) else {
+      throw Win32Error(rawValue: GetLastError())
+    }
+    defer {
+      DeleteProcThreadAttributeList(attributeList)
+    }
+    startupInfo.lpAttributeList = attributeList
+
+    return try body(&startupInfo)
+  }
+}
+
+/// Construct an escaped command line string suitable for passing to
+/// `CreateProcessW()`.
+///
+/// - Parameters:
+///   - arguments: The arguments, including the executable path, to include in
+///     the command line string.
+///
+/// - Returns: A command line string. This string can later be parsed with
+///   `CommandLineToArgvW()`.
+///
+/// Windows processes are responsible for handling their own command-line
+/// escaping. This function is adapted from the code in
+/// swift-corelibs-foundation (see `quoteWindowsCommandLine()`) which was
+/// itself adapted from code [published by Microsoft](https://learn.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way).
+private func _escapeCommandLine(_ arguments: [String]) -> String {
+  return arguments.lazy
     .map { arg in
       if !arg.contains(where: {" \t\n\"".contains($0)}) {
         return arg
@@ -123,41 +277,6 @@ func spawnAndWait(
       quoted.append("\"")
       return quoted
     }.joined(separator: " ")
-  let environ = environment.map { "\($0.key)=\($0.value)"}.joined(separator: "\0") + "\0\0"
-
-  let processHandle: HANDLE! = try commandLine.withCString(encodedAs: UTF16.self) { commandLine in
-    try environ.withCString(encodedAs: UTF16.self) { environ in
-      var processInfo = PROCESS_INFORMATION()
-
-      var startupInfo = STARTUPINFOW()
-      startupInfo.cb = DWORD(MemoryLayout.size(ofValue: startupInfo))
-      guard CreateProcessW(
-        nil,
-        .init(mutating: commandLine),
-        nil,
-        nil,
-        false,
-        DWORD(CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT),
-        .init(mutating: environ),
-        nil,
-        &startupInfo,
-        &processInfo
-      ) else {
-        throw Win32Error(rawValue: GetLastError())
-      }
-      _ = CloseHandle(processInfo.hThread)
-
-      return processInfo.hProcess
-    }
-  }
-  defer {
-    CloseHandle(processHandle)
-  }
-
-  return try await wait(for: processHandle)
-#else
-#warning("Platform-specific implementation missing: process spawning unavailable")
-  throw SystemError(description: "Exit tests are unimplemented on this platform.")
-#endif
 }
+#endif
 #endif

--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -22,10 +22,12 @@ internal import _TestingInternals
 /// - Throws: If the exit status of the process with ID `pid` cannot be
 ///   determined (i.e. it does not represent an exit condition.)
 private func _blockAndWait(for pid: consuming pid_t) throws -> ExitCondition {
+  let pid = consume pid
+
   // Get the exit status of the process or throw an error (other than EINTR.)
   while true {
     var siginfo = siginfo_t()
-    if 0 == waitid(P_PID, id_t(copy pid), &siginfo, WEXITED) {
+    if 0 == waitid(P_PID, id_t(pid), &siginfo, WEXITED) {
       switch siginfo.si_code {
       case .init(CLD_EXITED):
         return .exitCode(siginfo.si_status)
@@ -143,8 +145,10 @@ private func _createWaitThread() {
 /// - Throws: Any error encountered calling `waitpid()` except for `EINTR`,
 ///   which is ignored.
 func wait(for pid: consuming pid_t) async throws -> ExitCondition {
+  let pid = consume pid
+
 #if SWT_TARGET_OS_APPLE && !SWT_NO_LIBDISPATCH
-  let source = DispatchSource.makeProcessSource(identifier: copy pid, eventMask: .exit)
+  let source = DispatchSource.makeProcessSource(identifier: pid, eventMask: .exit)
   defer {
     source.cancel()
   }
@@ -189,7 +193,7 @@ func wait(for pid: consuming pid_t) async throws -> ExitCondition {
 /// - Throws: Any error encountered calling `WaitForSingleObject()` or
 ///   `GetExitCodeProcess()`.
 func wait(for processHandle: consuming HANDLE) async throws -> ExitCondition {
-  let processHandle = copy processHandle
+  let processHandle = consume processHandle
   defer {
     _ = CloseHandle(processHandle)
   }

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -12,6 +12,7 @@ include(LibraryVersion)
 include(TargetTriple)
 add_library(_TestingInternals STATIC
   Discovery.cpp
+  Stubs.cpp
   Versions.cpp
   WillThrow.cpp)
 target_include_directories(_TestingInternals PUBLIC

--- a/Sources/_TestingInternals/Stubs.cpp
+++ b/Sources/_TestingInternals/Stubs.cpp
@@ -1,0 +1,45 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// This source file includes implementations of functions that _should_ simply
+/// be `static` stubs in Stubs.h, but which for technical reasons cannot be
+/// imported into Swift when defined in a header.
+///
+/// Do not, as a rule, add function implementations in this file. Prefer to add
+/// them to Stubs.h so that they can be inlined at compile- or link-time. Only
+/// include functions here if Swift cannot successfully import and call them
+/// otherwise.
+
+#undef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE 1
+#undef _GNU_SOURCE
+#define _GNU_SOURCE 1
+
+#include "Stubs.h"
+
+#if defined(__linux__)
+int swt_pthread_setname_np(pthread_t thread, const char *name) {
+  return pthread_setname_np(thread, name);
+}
+#endif
+
+#if defined(__GLIBC__)
+int swt_posix_spawn_file_actions_addclosefrom_np(posix_spawn_file_actions_t *fileActions, int from) {
+  int result = 0;
+
+#if defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 34)
+  result = posix_spawn_file_actions_addclosefrom_np(fileActions, from);
+#endif
+#endif
+
+  return result;
+}
+#endif

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -83,6 +83,14 @@ static mach_port_t swt_mach_task_self(void) {
 static LANGID swt_MAKELANGID(int p, int s) {
   return MAKELANGID(p, s);
 }
+
+/// Get the value of `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`.
+///
+/// This function is provided because `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` is a
+/// complex macro and cannot be imported directly into Swift.
+static DWORD_PTR swt_PROC_THREAD_ATTRIBUTE_HANDLE_LIST(void) {
+  return PROC_THREAD_ATTRIBUTE_HANDLE_LIST;
+}
 #endif
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__ANDROID__)
@@ -99,13 +107,25 @@ SWT_EXTERN char *_Nullable *_Null_unspecified environ;
 static char *_Nullable *_Null_unspecified swt_environ(void) {
   return environ;
 }
+#endif
 
+#if defined(__linux__)
 /// Set the name of the current thread.
 ///
 /// This function declaration is provided because `pthread_setname_np()` is
 /// only declared if `_GNU_SOURCE` is set, but setting it causes build errors
 /// due to conflicts with Swift's Glibc module.
-SWT_IMPORT_FROM_STDLIB int pthread_setname_np(pthread_t, const char *);
+SWT_EXTERN int swt_pthread_setname_np(pthread_t thread, const char *name);
+#endif
+
+#if defined(__GLIBC__)
+/// Close file descriptors above a given value when spawing a new process.
+///
+/// This symbol is provided because the underlying function was added to glibc
+/// relatively recently and may not be available on all targets. Checking
+/// `__GLIBC_PREREQ()` is insufficient because `_DEFAULT_SOURCE` may not be
+/// defined at the point spawn.h is first included.
+SWT_EXTERN int swt_posix_spawn_file_actions_addclosefrom_np(posix_spawn_file_actions_t *fileActions, int from);
 #endif
 
 #if !defined(__ANDROID__)

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -365,22 +365,6 @@ struct ConditionMacroTests {
     #expect(diagnostic.message.contains("is redundant"))
   }
 
-#if !SWT_NO_EXIT_TESTS
-  @Test("Expectation inside an exit test diagnoses",
-    arguments: [
-      "#expectExitTest(exitsWith: .failure) { #expect(1 > 2) }",
-      "#requireExitTest(exitsWith: .success) { #expect(1 > 2) }",
-    ]
-  )
-  func expectationInExitTest(input: String) throws {
-    let (_, diagnostics) = try parse(input)
-    let diagnostic = try #require(diagnostics.first)
-    #expect(diagnostic.diagMessage.severity == .error)
-    #expect(diagnostic.message.contains("record an issue"))
-    #expect(diagnostic.message.contains("(exitsWith:"))
-  }
-#endif
-
   @Test("Macro expansion is performed within a test function")
   func macroExpansionInTestFunction() throws {
     let input = ##"""


### PR DESCRIPTION
This PR introduces a "back channel" file handle to exit tests, allowing us to record issues that occur within exit test bodies. For example:

```swift
await #expect(exitsWith: .failure) {
  let context = try #require(possiblyMissingContext)
  ...
}
```

In this example, if the call to `try #require()` finds `nil`, it will record an issue, but that issue today will be lost because there's no mechanism to forward the issue back to the parent process hosting the exit test. This PR fixes that!

Issues are converted to JSON using the same schema we use for event handling, then written over a pipe back to the parent process where they are decoded. This decoding is lossy, so there will be further refinement needed here to try to preserve more information about the recorded issues. That said, "it's got good bones" right?

On Darwin, Linux, and FreeBSD, the pipe's write end is allowed to survive into the child process (i.e. no `FD_CLOEXEC`). On Windows, the equivalent is to tell `CreateProcessW()` to explicitly inherit a `HANDLE`. The identity of this file descriptor or handle is passed to the child process via environment variable. The child process then parses the file descriptor or handle out of the environment and converts it back to a `FileHandle` that is then connected to an instance of `Configuration` with an event handler set, and off we go.

Because we can now report these issues back to the parent process, I've removed the compile-time diagnostic in the `#expect(exitsWith:)` macro implementation that we emit when we see a nested `#expect()` or `#require()` call.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
