### PR TITLE
Hoist JSON Lines logic from EntryPoint.swift.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -120,7 +120,7 @@ private func entryPoint(
     args?.eventStreamVersion = eventStreamVersionIfNil
   }
 
-  let eventHandler = try eventHandlerForStreamingEvents(version: args?.eventStreamVersion, forwardingTo: recordHandler)
+  let eventHandler = try eventHandlerForStreamingEvents(version: args?.eventStreamVersion, encodeAsJSONLines: false, forwardingTo: recordHandler)
   let exitCode = await entryPoint(passing: args, eventHandler: eventHandler)
 
   // To maintain compatibility with Xcode 16 Beta 1, suppress custom exit codes.

--- a/Sources/Testing/Support/Additions/NumericAdditions.swift
+++ b/Sources/Testing/Support/Additions/NumericAdditions.swift
@@ -25,3 +25,12 @@ extension Numeric {
     return "\(self) \(noun)s"
   }
 }
+
+// MARK: -
+
+extension UInt8 {
+  /// Whether or not this instance is an ASCII newline character (`\n` or `\r`).
+  var isASCIINewline: Bool {
+    self == UInt8(ascii: "\r") || self == UInt8(ascii: "\n")
+  }
+}

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -228,7 +228,7 @@ struct SwiftPMTests {
 
   func decodeABIv0RecordStream(fromFileAtPath path: String) throws -> [ABIv0.Record] {
     try FileHandle(forReadingAtPath: path).readToEnd()
-      .split(separator: 10) // "\n"
+      .split(whereSeparator: \.isASCIINewline)
       .map { line in
         try line.withUnsafeBytes { line in
           try JSON.decode(ABIv0.Record.self, from: line)


### PR DESCRIPTION
This PR moves the logic that implements JSON Lines support (i.e. the code that strips newlines from JSON generated by Foundation) out of EntryPoint.swift so that it can be used by other callers.

This change was originally part of #697. I'm splitting it out into its own PR to make that one (both really) easier to read and understand.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
