### PR TITLE
Support: unwrap storage for parameter to `pipe`

### DIFF
--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -447,7 +447,7 @@ extension FileHandle {
           throw CError(rawValue: swt_errno())
         }
 #else
-        guard 0 == pipe(fds.baseAddress) else {
+        guard 0 == pipe(fds.baseAddress!) else {
           throw CError(rawValue: swt_errno())
         }
 #endif


### PR DESCRIPTION
Android declares pipe as:

```
int pipe(int __fds[_Nonnull 2]);
```

Ensure that we unwrap the storage before we pass along the parameter to the syscall. This repairs the build for Android.