### PR TITLE
Preserve `verbosity` argument in `HumanReadableOutputRecorder.record()`.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -52,9 +52,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
 #if !SWT_NO_FILE_IO
     // Configure the event recorder to write events to stderr.
     if configuration.verbosity > .min {
-      var options = Event.ConsoleOutputRecorder.Options()
-      options = .for(.stderr)
-      let eventRecorder = Event.ConsoleOutputRecorder(options: options) { string in
+      let eventRecorder = Event.ConsoleOutputRecorder(options: .for(.stderr)) { string in
         try? FileHandle.stderr.write(string)
       }
       configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -51,14 +51,16 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
 
 #if !SWT_NO_FILE_IO
     // Configure the event recorder to write events to stderr.
-    var options = Event.ConsoleOutputRecorder.Options()
-    options = .for(.stderr)
-    let eventRecorder = Event.ConsoleOutputRecorder(options: options) { string in
-      try? FileHandle.stderr.write(string)
-    }
-    configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
-      eventRecorder.record(event, in: context)
-      oldEventHandler(event, context)
+    if configuration.verbosity > .min {
+      var options = Event.ConsoleOutputRecorder.Options()
+      options = .for(.stderr)
+      let eventRecorder = Event.ConsoleOutputRecorder(options: options) { string in
+        try? FileHandle.stderr.write(string)
+      }
+      configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
+        eventRecorder.record(event, in: context)
+        oldEventHandler(event, context)
+      }
     }
 #endif
 

--- a/Sources/Testing/ABI/v0/ABIv0.Record+Streaming.swift
+++ b/Sources/Testing/ABI/v0/ABIv0.Record+Streaming.swift
@@ -79,7 +79,7 @@ extension ABIv0.Record {
           eventHandler(testJSON)
         }
       } else {
-        let messages = humanReadableOutputRecorder.record(event, in: context)
+        let messages = humanReadableOutputRecorder.record(event, in: context, verbosity: 0)
         if let eventRecord = Self(encoding: event, in: context, messages: messages) {
           try? JSON.withEncoding(of: eventRecord, eventHandler)
         }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -202,11 +202,27 @@ extension Event.HumanReadableOutputRecorder {
   /// - Parameters:
   ///   - event: The event to record.
   ///   - eventContext: The context associated with the event.
+  ///   - verbosity: How verbose output should be. When the value of this
+  ///     argument is greater than `0`, additional output is provided. When the
+  ///     value of this argument is less than `0`, some output is suppressed.
+  ///     If the value of this argument is `nil`, the value set for the current
+  ///     configuration is used instead. The exact effects of this argument are
+  ///     implementation-defined and subject to change.
   ///
   /// - Returns: An array of zero or more messages that can be displayed to the
   ///   user.
-  @discardableResult public func record(_ event: borrowing Event, in eventContext: borrowing Event.Context) -> [Message] {
-    let verbosity = eventContext.configuration?.verbosity ?? 0
+  @discardableResult public func record(
+    _ event: borrowing Event,
+    in eventContext: borrowing Event.Context,
+    verbosity: Int? = nil
+  ) -> [Message] {
+    let verbosity: Int = if let verbosity {
+      verbosity
+    } else if let verbosity = eventContext.configuration?.verbosity {
+      verbosity
+    } else {
+      0
+    }
     let test = eventContext.test
     let testName = if let test {
       if let displayName = test.displayName {
@@ -501,12 +517,3 @@ extension Event.HumanReadableOutputRecorder {
 // MARK: - Codable
 
 extension Event.HumanReadableOutputRecorder.Message: Codable {}
-
-// MARK: - Deprecated
-
-extension Event.HumanReadableOutputRecorder {
-  @available(*, deprecated, message: "Use record(_:in:) instead. Verbosity is now controlled by eventContext.configuration.verbosity.")
-  @discardableResult public func record(_ event: borrowing Event, in eventContext: borrowing Event.Context, verbosity: Int) -> [Message] {
-    record(event, in: eventContext)
-  }
-}


### PR DESCRIPTION
This PR restores/undeprecates the `verbosity` argument to `HumanReadableOutputRecorder.record()` that was deprecated in #677. We still need to be able to override the command-line-specified value in the event stream.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
