### PR TITLE
[6.0.2][CMake] Explicitly link Testing to Foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ project(SwiftTesting
   LANGUAGES CXX Swift)
 
 if(NOT APPLE)
-  find_package(dispatch CONFIG)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
+    find_package(dispatch CONFIG)
+  endif()
   find_package(Foundation CONFIG)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ endif()
 project(SwiftTesting
   LANGUAGES CXX Swift)
 
+if(NOT APPLE)
+  find_package(dispatch CONFIG)
+  find_package(Foundation CONFIG)
+endif()
+
 include(GNUInstallDirs)
 
 list(APPEND CMAKE_MODULE_PATH

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -94,6 +94,11 @@ add_library(Testing
   Traits/Trait.swift)
 target_link_libraries(Testing PRIVATE
   _TestingInternals)
+if(NOT APPLE)
+  target_link_libraries(Testing PUBLIC
+    dispatch
+    Foundation)
+endif()
 add_dependencies(Testing
   TestingMacros)
 target_compile_options(Testing PRIVATE

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -95,8 +95,11 @@ add_library(Testing
 target_link_libraries(Testing PRIVATE
   _TestingInternals)
 if(NOT APPLE)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
+    target_link_libraries(Testing PUBLIC
+      dispatch)
+  endif()
   target_link_libraries(Testing PUBLIC
-    dispatch
     Foundation)
 endif()
 add_dependencies(Testing


### PR DESCRIPTION
Cherry-pick #693 into `release/6.0.2`

* **Explanation**: Previously in CMake builds, when `Foundation` was not in the regular search directory (e.g. resource directory or SDK search paths) `#if canImport(Foundation)` used to fail, and the functionalities are not included. This patch provides a way to provide `Foundation_DIR`  for `find_packgage(Foundation CONFIG)`, so that clients can correctly link Testing to Foundation
* **Scope**: CMake builds
* **Risk**: Low. No actual code changes.
* **Testing**: Passes current test suite Also manually tested the build toolchain
* **Issues**: N/A
* **Reviewer**: @stmontgomery 