### PR TITLE
[6.0.0][CMake] Explicitly link Testing to Foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ project(SwiftTesting
   LANGUAGES CXX Swift)
 
 if(NOT APPLE)
-  find_package(dispatch CONFIG)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
+    find_package(dispatch CONFIG)
+  endif()
   find_package(Foundation CONFIG)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ endif()
 project(SwiftTesting
   LANGUAGES CXX Swift)
 
+if(NOT APPLE)
+  find_package(dispatch CONFIG)
+  find_package(Foundation CONFIG)
+endif()
+
 include(GNUInstallDirs)
 
 list(APPEND CMAKE_MODULE_PATH

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -94,6 +94,11 @@ add_library(Testing
   Traits/Trait.swift)
 target_link_libraries(Testing PRIVATE
   _TestingInternals)
+if(NOT APPLE)
+  target_link_libraries(Testing PUBLIC
+    dispatch
+    Foundation)
+endif()
 add_dependencies(Testing
   TestingMacros)
 target_compile_options(Testing PRIVATE

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -95,8 +95,11 @@ add_library(Testing
 target_link_libraries(Testing PRIVATE
   _TestingInternals)
 if(NOT APPLE)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
+    target_link_libraries(Testing PUBLIC
+      dispatch)
+  endif()
   target_link_libraries(Testing PUBLIC
-    dispatch
     Foundation)
 endif()
 add_dependencies(Testing

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -125,7 +125,7 @@ let simulatorVersion: String = {
 ///
 /// This value is not part of the public interface of the testing library.
 var testingLibraryVersion: String {
-  SWT_TESTING_LIBRARY_VERSION
+  swt_getTestingLibraryVersion().flatMap(String.init(validatingCString:)) ?? "unknown"
 }
 
 /// A human-readable string describing the Swift Standard Library's version.

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_SCAN_FOR_MODULES 0)
 include(LibraryVersion)
 add_library(_TestingInternals STATIC
   Discovery.cpp
+  Versions.cpp
   WillThrow.cpp)
 target_include_directories(_TestingInternals PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/Sources/_TestingInternals/Versions.cpp
+++ b/Sources/_TestingInternals/Versions.cpp
@@ -1,0 +1,20 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#include "Versions.h"
+
+const char *swt_getTestingLibraryVersion(void) {
+#if defined(_SWT_TESTING_LIBRARY_VERSION)
+  return _SWT_TESTING_LIBRARY_VERSION;
+#else
+#warning _SWT_TESTING_LIBRARY_VERSION not defined: testing library version is unavailable
+  return nullptr;
+#endif
+}

--- a/Sources/_TestingInternals/include/Defines.h
+++ b/Sources/_TestingInternals/include/Defines.h
@@ -32,15 +32,4 @@
 /// An attribute that renames a C symbol in Swift.
 #define SWT_SWIFT_NAME(name) __attribute__((swift_name(#name)))
 
-/// The testing library version from the package manifest.
-///
-/// - Bug: The value provided to the compiler (`_SWT_TESTING_LIBRARY_VERSION`)
-///   is not visible in Swift, so this second macro is needed.
-///   ((#43521)[https://github.com/swiftlang/swift/issues/43521])
-#if defined(_SWT_TESTING_LIBRARY_VERSION)
-#define SWT_TESTING_LIBRARY_VERSION _SWT_TESTING_LIBRARY_VERSION
-#else
-#define SWT_TESTING_LIBRARY_VERSION "unknown"
-#endif
-
 #endif // SWT_DEFINES_H

--- a/Sources/_TestingInternals/include/Versions.h
+++ b/Sources/_TestingInternals/include/Versions.h
@@ -1,0 +1,28 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if !defined(SWT_VERSIONS_H)
+#define SWT_VERSIONS_H
+
+#include "Defines.h"
+
+SWT_ASSUME_NONNULL_BEGIN
+
+/// Get the human-readable version of the testing library.
+///
+/// - Returns: A human-readable string describing the version of the testing
+///   library, or `nullptr` if no version information is available. This
+///   string's value and format may vary between platforms, releases, or any
+///   other conditions. Do not attempt to parse it.
+SWT_EXTERN const char *_Nullable swt_getTestingLibraryVersion(void);
+
+SWT_ASSUME_NONNULL_END
+
+#endif

--- a/cmake/modules/LibraryVersion.cmake
+++ b/cmake/modules/LibraryVersion.cmake
@@ -6,34 +6,38 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+# The current version of the Swift Testing release. For release branches,
+# remember to remove -dev.
+set(SWT_TESTING_LIBRARY_VERSION "6.0")
+
 find_package(Git QUIET)
 if(Git_FOUND)
+  # Get the commit hash corresponding to the current build. Limit length to 15
+  # to match `swift --version` output format.
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags --exact-match
+    COMMAND ${GIT_EXECUTABLE} rev-parse --short=15 --verify HEAD
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_TAG
+    OUTPUT_VARIABLE GIT_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_QUIET)
-  if(GIT_TAG)
-    add_compile_definitions(
-      "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=${GIT_TAG}>")
-  else()
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} rev-parse --verify HEAD
-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-      OUTPUT_VARIABLE GIT_REVISION
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    execute_process(
-      COMMAND ${GIT_EXECUTABLE} status -s
-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-      OUTPUT_VARIABLE GIT_STATUS
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(GIT_STATUS)
-      add_compile_definitions(
-        "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=${GIT_REVISION} (modified)>")
-    else()
-      add_compile_definitions(
-        "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=${GIT_REVISION}>")
-    endif()
+
+  # Check if there are local changes.
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} status -s
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_STATUS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(GIT_STATUS)
+    set(GIT_VERSION "${GIT_VERSION} - modified")
   endif()
 endif()
+
+# Combine the hard-coded Swift version with available Git information.
+if(GIT_VERSION)
+set(SWT_TESTING_LIBRARY_VERSION "${SWT_TESTING_LIBRARY_VERSION} (${GIT_VERSION})")
+endif()
+
+# All done!
+message(STATUS "Swift Testing version: ${SWT_TESTING_LIBRARY_VERSION}")
+add_compile_definitions(
+  "$<$<COMPILE_LANGUAGE:CXX>:_SWT_TESTING_LIBRARY_VERSION=\"${SWT_TESTING_LIBRARY_VERSION}\">")


### PR DESCRIPTION
Cherry-pick #693 into `release/6.0.0`

* **Explanation**: Previously in CMake builds, when `Foundation` was not in the regular search directory (e.g. resource directory or SDK search paths) `#if canImport(Foundation)` used to fail, and the functionalities are not included. This patch provides a way to provide `Foundation_DIR`  for `find_packgage(Foundation CONFIG)`, so that clients can correctly link Testing to Foundation
* **Scope**: CMake builds
* **Risk**: Low. No actual code changes.
* **Testing**: Passes current test suite Also manually tested the build toolchain
* **Issues**: N/A
* **Reviewer**: TBA