### PR TITLE
[6.0] Switch to official 600.0.0 tag for swift-syntax (#708)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-latest"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0"),
   ],
 
   targets: [

--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -29,10 +29,9 @@ if(SwiftTesting_BuildMacrosAsExecutables)
   # swift-syntax.
   include(FetchContent)
   set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/_d)
-  # TODO: Update GIT_TAG to the 6.0 release tag once it is available.
   FetchContent_Declare(SwiftSyntax
     GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
-    GIT_TAG 27b74edd5de625d0e399869a5af08f1501af8837)
+    GIT_TAG cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25) # 600.0.0
   FetchContent_MakeAvailable(SwiftSyntax)
 endif()
 


### PR DESCRIPTION
- **Explanation**: Switch to the official [600.0.0 tag](https://github.com/swiftlang/swift-syntax/releases/tag/600.0.0) for swift-syntax, which was recently created.
- **Original PR**: [https://github.com/swiftlang/swift-testing/pull/651 https://github.com/swiftlang/swift-testing/pull/672](https://github.com/swiftlang/swift-testing/pull/690)
- **Risk**: Low
- **Testing**: Tested in ci.swift.org
- **Reviewer**: @grynspan @briancroom