### PR TITLE
Avoid accidental use of `#_sourceLocation` in the library target.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -470,7 +470,7 @@ extension ExitTest {
     } catch {
       // NOTE: an error caught here indicates an I/O problem.
       // TODO: should we record these issues as systemic instead?
-      Issue.record(error)
+      Issue(for: error).record()
       return
     }
 
@@ -482,7 +482,7 @@ extension ExitTest {
       } catch {
         // NOTE: an error caught here indicates a decoding problem.
         // TODO: should we record these issues as systemic instead?
-        Issue.record(error)
+        Issue(for: error).record()
       }
     }
   }


### PR DESCRIPTION
We can't use our own macros in the library target directly.

Resolves rdar://136385550.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
