### PR TITLE
Avoid truncating the path to the test executable on Windows.

### DIFF
--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -46,9 +46,9 @@ func spawnExecutable(
 ) throws -> ProcessID {
   // Darwin and Linux differ in their optionality for the posix_spawn types we
   // use, so use this typealias to paper over the differences.
-#if SWT_TARGET_OS_APPLE
+#if SWT_TARGET_OS_APPLE || os(FreeBSD)
   typealias P<T> = T?
-#elseif os(Linux) || os(FreeBSD)
+#elseif os(Linux)
   typealias P<T> = T
 #endif
 

--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -16,7 +16,11 @@ extension CommandLine {
     get throws {
 #if os(macOS)
       var result: String?
+#if DEBUG
+      var bufferCount = UInt32(1) // force looping
+#else
       var bufferCount = UInt32(PATH_MAX)
+#endif
       while result == nil {
         withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(bufferCount)) { buffer in
           // _NSGetExecutablePath returns 0 on success and -1 if bufferCount is
@@ -53,7 +57,11 @@ extension CommandLine {
       }
 #elseif os(Windows)
       var result: String?
+#if DEBUG
+      var bufferCount = Int(1) // force looping
+#else
       var bufferCount = Int(MAX_PATH)
+#endif
       while result == nil {
         try withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: bufferCount) { buffer in
           SetLastError(DWORD(ERROR_SUCCESS))

--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -18,14 +18,13 @@ extension CommandLine {
       var result: String?
       var bufferCount = UInt32(PATH_MAX)
       while result == nil {
-        result = withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(bufferCount)) { buffer in
+        withUnsafeTemporaryAllocation(of: CChar.self, capacity: Int(bufferCount)) { buffer in
           // _NSGetExecutablePath returns 0 on success and -1 if bufferCount is
           // too small. If that occurs, we'll return nil here and loop with the
           // new value of bufferCount.
           if 0 == _NSGetExecutablePath(buffer.baseAddress, &bufferCount) {
-            return String(cString: buffer.baseAddress!)
+            result = String(cString: buffer.baseAddress!)
           }
-          return nil
         }
       }
       return result!
@@ -56,7 +55,7 @@ extension CommandLine {
       var result: String?
       var bufferCount = Int(MAX_PATH)
       while result == nil {
-        result = try withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: bufferCount) { buffer in
+        try withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: bufferCount) { buffer in
           SetLastError(DWORD(ERROR_SUCCESS))
           _ = GetModuleFileNameW(nil, buffer.baseAddress!, DWORD(buffer.count))
           switch GetLastError() {
@@ -67,7 +66,6 @@ extension CommandLine {
             }
           case DWORD(ERROR_INSUFFICIENT_BUFFER):
             bufferCount += Int(MAX_PATH)
-            return nil
           case let errorCode:
             throw Win32Error(rawValue: errorCode)
           }


### PR DESCRIPTION
On Windows, we get the path to the (current) test executable by calling `GetModuleFileNameW()`. This function has odd behaviour when the input buffer is too short. Rather than returning `false` or `-1` or some such, as you might expect, it returns successfully but truncates the path (and null-terminates while doing so.)

The function _does_ set the last error in this case to `ERROR_INSUFFICIENT_BUFFER`, indicating we need a larger buffer. (The error behaviour on Windows XP is different, but we don't support Windows XP. If you decide to add support for Windows XP to Swift Testing, keep this in mind.)

So this PR checks for `ERROR_INSUFFICIENT_BUFFER` and loops with a larger buffer, similar to what we do on Darwin.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
