### PR TITLE
Remove extraneous @escaping and @Sendable attributes from CustomExecutionTrait.execute(...) SPI

### DIFF
--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -110,5 +110,5 @@ public protocol CustomExecutionTrait: Trait {
   ///
   /// - Note: If a test function or test suite is skipped, this function does
   ///   not get invoked by the runner.
-  @Sendable func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws
+  func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws
 }

--- a/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomExecutionTraitTests.swift
@@ -68,7 +68,7 @@ struct CustomExecutionTraitTests {
 private struct CustomTrait: CustomExecutionTrait, TestTrait {
   var before: Confirmation
   var after: Confirmation
-  func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
+  func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
     before()
     defer {
       after()
@@ -80,7 +80,7 @@ private struct CustomTrait: CustomExecutionTrait, TestTrait {
 private struct CustomThrowingErrorTrait: CustomExecutionTrait, TestTrait {
   fileprivate struct CustomTraitError: Error {}
 
-  func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
+  func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
     throw CustomTraitError()
   }
 }
@@ -88,7 +88,7 @@ private struct CustomThrowingErrorTrait: CustomExecutionTrait, TestTrait {
 struct DoSomethingBeforeAndAfterTrait: CustomExecutionTrait, SuiteTrait, TestTrait {
   static let state = Locked(rawValue: 0)
 
-  func execute(_ function: @escaping @Sendable () async throws -> Void, for test: Testing.Test, testCase: Testing.Test.Case?) async throws {
+  func execute(_ function: @Sendable () async throws -> Void, for test: Testing.Test, testCase: Testing.Test.Case?) async throws {
     #expect(Self.state.increment() == 1)
 
     try await function()


### PR DESCRIPTION
This refines the `CustomExecutionTrait` SPI protocol by removing two unnecessary attributes from the signature of its `execute(_:for:testCase:)` method requirement:

1. The `@escaping` attribute on the `function` parameter was needed originally to avoid a warning, but `function` should _not_ actually be considered escaping and part of the contract of this interface is that the implementor must call it before returning. The compiler no longer complains about this, so we can enforce this requirement by removing the unnecessary `@escaping` attribute now.
2. The outer `@Sendable` was necessary when this SPI was first written to avoid a Swift concurrency warning, since a reference to the function is taken elsewhere in the codebase, but this is no longer needed in recent Swift compilers.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
