### PR TITLE
Fix the 32-bit Windows build

### DIFF
--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -385,7 +385,7 @@ static void enumerateTypeMetadataSections(const SectionEnumerator& body) {
   if (!EnumProcessModules(GetCurrentProcess(), &hModules[0], hModules.size() * sizeof(HMODULE), &byteCountNeeded)) {
     return;
   }
-  DWORD hModuleCount = std::min(hModules.size(), byteCountNeeded / sizeof(HMODULE));
+  size_t hModuleCount = std::min(hModules.size(), static_cast<size_t>(byteCountNeeded) / sizeof(HMODULE));
 
   // Look in all the loaded modules for Swift type metadata sections and store
   // them in a side table.


### PR DESCRIPTION
Fix the windows build

### Motivation:

https://ci-external.swift.org/job/swift-main-windows-toolchain/630/console

```
C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain\swift-testing\Sources\_TestingInternals\Discovery.cpp(388,24): error: no matching function for call to 'min'
  388 |   DWORD hModuleCount = std::min(hModules.size(), byteCountNeeded / sizeof(HMODULE));
      |                        ^~~~~~~~
C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain\swift-testing\Sources\_TestingInternals\Discovery.cpp(485,3): note: in instantiation of function template specialization 'enumerateTypeMetadataSections<(lambda at C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain\swift-testing\Sources\_TestingInternals\Discovery.cpp:485:33)>' requested here
  485 |   enumerateTypeMetadataSections([=] (const void *imageAddress, const void *section, size_t size, bool *stop) {
      |   ^
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\utility(98,6): note: candidate template ignored: deduced conflicting types for parameter '_Ty' ('size_type' (aka 'unsigned int') vs. 'DWORD' (aka 'unsigned long'))
   98 |     (min) (const _Ty& _Left, const _Ty& _Right) noexcept(noexcept(_Right < _Left)) /* strengthened */ {
      |      ^
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\xutility(6915,26): note: candidate template ignored: could not match 'initializer_list<_Ty>' against 'size_type' (aka 'unsigned int')
 6915 | _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist, _Pr _Pred) {
      |                          ^
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\xutility(6922,26): note: candidate function template not viable: requires single argument '_Ilist', but 2 arguments were provided
 6922 | _NODISCARD constexpr _Ty(min)(initializer_list<_Ty> _Ilist) {
      |                          ^    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\include\utility(88,33): note: candidate function template not viable: requires 3 arguments, but 2 were provided
   88 | _NODISCARD constexpr const _Ty&(min) (const _Ty& _Left, const _Ty& _Right, _Pr _Pred) noexcept(
      |                                 ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

### Modifications:

Add casts.

### Result:

The windows build builds.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
