### PR TITLE
[SWT-NNNN] Introduce API allowing traits to customize test execution

### DIFF
--- a/Documentation/Proposals/NNNN-custom-test-execution-traits.md
+++ b/Documentation/Proposals/NNNN-custom-test-execution-traits.md
@@ -4,7 +4,7 @@
 * Authors: [Stuart Montgomery](https://github.com/stmontgomery)
 * Status: **Awaiting review**
 * Implementation: [swiftlang/swift-testing#733](https://github.com/swiftlang/swift-testing/pull/733), [swiftlang/swift-testing#86](https://github.com/swiftlang/swift-testing/pull/86)
-* Review: ([pitch](https://forums.swift.org/...))
+* Review: ([pitch](https://forums.swift.org/t/pitch-custom-test-execution-traits/75055))
 
 ### Revision history
 
@@ -403,6 +403,10 @@ extension Trait where Self == MockAPICredentialsTrait {
 ## Source compatibility
 
 The proposed APIs are purely additive.
+
+This proposal will replace the existing `CustomExecutionTrait` SPI, and after
+further refactoring we anticipate it will obsolete the need for the
+`SPIAwareTrait` SPI as well.
 
 ## Integration with supporting tools
 

--- a/Documentation/Proposals/NNNN-custom-test-execution-traits.md
+++ b/Documentation/Proposals/NNNN-custom-test-execution-traits.md
@@ -422,6 +422,8 @@ supporting tools.
 
 ## Future directions
 
+### Access to suite type instances
+
 Some test authors have expressed interest in allowing custom traits to access
 the instance of a suite type for `@Test` instance methods, so the trait could
 inspect or mutate the instance. Currently, only instance-level members of a
@@ -429,6 +431,15 @@ suite type (including `init`, `deinit`, and the test function itself) can access
 `self`, so this would grant traits applied to an instance test method access to
 the instance as well. This is certainly interesting, but poses several technical
 challenges that puts it out of scope of this proposal.
+
+### Convenience trait for setting task locals
+
+Some reviewers of this proposal pointed out that the hypothetical usage example
+shown earlier involving setting a task local value while a test is executing
+will likely become a common use of these APIs. To streamline that pattern, it
+would be very natural to add a built-in trait type which facilitates this. I
+have prototyped this idea and plan to add it once this new trait functionality
+lands.
 
 ## Alternatives considered
 

--- a/Documentation/Proposals/NNNN-custom-test-execution-traits.md
+++ b/Documentation/Proposals/NNNN-custom-test-execution-traits.md
@@ -119,7 +119,7 @@ extension APICredentials {
 ```
 
 Binding task local values requires using the scoped access
-[`TaskLocal.withValue()`](https://developer.apple.com/documentation/swift/tasklocal/withvalue(_:operation:isolation:file:line:)
+[`TaskLocal.withValue()`](https://developer.apple.com/documentation/swift/tasklocal/withvalue(_:operation:isolation:file:line:))
 API though, and that would not be possible if `Trait` exposed separate methods
 like `setUp()` and `tearDown()`.
 
@@ -347,10 +347,10 @@ problem described above.
 
 ### Extend the `Trait` protocol
 
-The original SPI implementation of this feature included a protocol named
-`CustomExecutionTrait` which extended `Trait` and had roughly the same method
-requirement as the `CustomTestExecuting` protocol proposed above. This design
-worked, provided scoped access, and avoided the lengthy backtrace problem.
+The original, experimental implementation of this feature included a protocol
+named`CustomExecutionTrait` which extended `Trait` and had roughly the same
+method requirement as the `CustomTestExecuting` protocol proposed above. This
+design worked, provided scoped access, and avoided the lengthy backtrace problem.
 
 After evaluating the design and usage of this SPI though, it seemed unfortunate
 to structure it as a sub-protocol of `Trait` because it means that the full

--- a/Documentation/Proposals/NNNN-custom-test-execution-traits.md
+++ b/Documentation/Proposals/NNNN-custom-test-execution-traits.md
@@ -284,9 +284,9 @@ public protocol Trait: Sendable {
   var customTestExecutor: CustomTestExecutor? { get }
 }
 
-extension Trait where CustomTestExecutor == Self {
+extension Trait where Self: CustomTestExecuting {
   // Returns `self`.
-  public var customTestExecutor: CustomTestExecutor? { get }
+  public var customTestExecutor: Self? { get }
 }
 
 extension Trait where CustomTestExecutor == Never {

--- a/Documentation/Proposals/NNNN-custom-test-execution-traits.md
+++ b/Documentation/Proposals/NNNN-custom-test-execution-traits.md
@@ -1,0 +1,376 @@
+# Custom Test Execution Traits
+
+* Proposal: [SWT-NNNN](NNNN-filename.md)
+* Authors: [Stuart Montgomery](https://github.com/stmontgomery)
+* Status: **Awaiting review**
+* Implementation: [swiftlang/swift-testing#733](https://github.com/swiftlang/swift-testing/pull/733), [swiftlang/swift-testing#86](https://github.com/swiftlang/swift-testing/pull/86)
+* Review: ([pitch](https://forums.swift.org/...))
+
+## Introduction
+
+This introduces API which enables a custom `Trait`-conforming type to customize
+the execution of test functions and suites, including running code before or
+after them.
+
+## Motivation
+
+One of the primary motivations for the trait system in Swift Testing, as
+[described in the vision document](https://github.com/swiftlang/swift-evolution/blob/main/visions/swift-testing.md#trait-extensibility),
+is to provide a way to customize the behavior of tests which have things in
+common. If all the tests in a given suite type need the same custom behavior,
+`init` and/or `deinit` (if applicable) can be used today. But if only _some_ of
+the tests in a suite need custom behavior, or tests across different levels of
+the suite hierarchy need it, traits would be a good place to encapsulate common
+logic since they can be applied granularly per-test or per-suite. This aspect of
+the vision for traits hasn't been realized yet, though: the `Trait` protocol
+does not offer a way for a trait to customize the execution of the tests or
+suites it's applied to.
+
+Customizing a test's behavior typically means running code either before or
+after it runs, or both. Consolidating common set-up and tear-down logic allows
+each test function to be more succinct with less repetitive boilerplate so it
+can focus on what makes it unique.
+
+## Proposed solution
+
+At a high level, this proposal entails adding API to the `Trait` protocol
+allowing a conforming type to opt-in to customizing the execution of test
+behavior. We discuss how that capability should be exposed to trait types below.
+
+### Supporting scoped access
+
+There are different approaches one could take to expose hooks for a trait to
+customize test behavior. To illustrate one of them, consider the following
+example of a `@Test` function with a custom trait whose purpose is to set mock
+API credentials for the duration of each test it's applied to:
+
+```swift
+@Test(.mockAPICredentials)
+func example() {
+  // ...
+}
+
+struct MockAPICredentialsTrait: TestTrait { ... }
+
+extension Trait where Self == MockAPICredentialsTrait {
+  static var mockAPICredentials: Self { ... }
+}
+```
+
+In this hypothetical example, the current API credentials are stored via a
+static property on an `APICredentials` type which is part of the module being
+tested:
+
+```swift
+struct APICredentials {
+  var apiKey: String
+
+  static var shared: Self?
+}
+```
+
+One way that this custom trait could customize the API credentials during each
+test is if the `Trait` protocol were to expose a pair of method requirements
+which were then called before and after the test, respectively:
+
+```swift
+public protocol Trait: Sendable {
+  // ...
+  func setUp() async throws
+  func tearDown() async throws
+}
+
+extension Trait {
+  // ...
+  public func setUp() async throws { /* No-op */ }
+  public func tearDown() async throws { /* No-op */ }
+}
+```
+
+The custom trait type could adopt these using code such as the following:
+
+```swift
+extension MockAPICredentialsTrait {
+  func setUp() {
+    APICredentials.shared = .init(apiKey: "...")
+  }
+
+  func tearDown() {
+    APICredentials.shared = nil
+  }
+}
+```
+
+Many testing systems use this pattern, including XCTest. However, this approach
+encourages the use of global mutable state such as the `APICredentials.shared`
+variable, and this limits the testing library's ability to parallelize test
+execution, which is
+[another part of the Swift Testing vision](https://github.com/swiftlang/swift-evolution/blob/main/visions/swift-testing.md#parallelization-and-concurrency).
+
+The use of nonisolated static variables is generally discouraged now, and in
+Swift 6 the above `APICredentials.shared` property produces an error. One way
+to resolve that is to change it to a `@TaskLocal` variable, as this would be
+concurrency-safe and still allow tests accessing this state to run in parallel:
+
+```swift
+extension APICredentials {
+  @TaskLocal static var current: Self?
+}
+```
+
+Binding task local values requires using the scoped access
+[`TaskLocal.withValue()`](https://developer.apple.com/documentation/swift/tasklocal/withvalue(_:operation:isolation:file:line:)
+API though, and that would not be possible if `Trait` exposed separate methods
+like `setUp()` and `tearDown()`.
+
+For these reasons, I believe it's important to expose this trait capability
+using a single, scoped access-style API which accepts a closure. A simplified
+version of that idea might look like this:
+
+```swift
+public protocol Trait: Sendable {
+  // ...
+
+  // Simplified example, not the actual proposal
+  func executeTest(_ body: @Sendable () async throws -> Void) async throws
+}
+
+extension MockAPICredentialsTrait {
+  func executeTest(_ body: @Sendable () async throws -> Void) async throws {
+    let mockCredentials = APICredentials(apiKey: "...")
+    try await APICredentials.$current.withValue(mockCredentials) {
+      try await body()
+    }
+  }
+}
+```
+
+### Avoiding unnecessarily lengthy backtraces
+
+A scoped access-style API has some potential downsides. To apply this approach
+to a test function, the scoped call of a trait must wrap the invocation of that
+test function, and every _other_ trait applied to that same test which offers
+custom behavior _also_ must wrap the other traits' calls in a nesting fashion.
+To visualize this, imagine a test function with multiple traits:
+
+```swift
+@Test(.traitA, .traitB, .traitC)
+func exampleTest() {
+  // ...
+}
+```
+
+If all three of those traits customize test execution behavior, then each of
+them needs to wrap the call to the next one, and the last trait needs to wrap
+the invocation of the test, illustrated by the following:
+
+```
+TraitA.executeTest {
+  TraitB.executeTest {
+    TraitC.executeTest {
+      exampleTest()
+    }
+  }
+}
+```
+
+Tests may have an arbitrary number of traits applied to them, including those
+inherited from containing suite types. A naïve implementation in which _every_
+trait is given the opportunity to customize test behavior by calling its scoped
+access API might cause unnecessarily lengthy backtraces that make debugging the
+body of tests more difficult. Or worse: if the number of traits is great enough,
+it could cause a stack overflow.
+
+In practice, most traits probably will _not_ need to customize test behavior, so
+to mitigate these downsides it's important that there be some way to distinguish
+traits which customize test behavior. That way, the testing library can limit
+these scoped access calls to only the traits which require it.
+
+## Detailed design
+
+I propose the following new APIs:
+
+- A new protocol `CustomTestExecuting` with a single required `execute(...)`
+  method. This will be called to run a test, and allows the conforming type to
+  perform custom logic before or after.
+- A new property `customTestExecutor` on the `Trait` protocol whose type is an
+  `Optional` value of a type conforming to `CustomTestExecuting`. A `nil` value
+  from this property will skip calling the `execute(...)` method.
+- A default implementation of `Trait.customTestExecutor` whose value is `nil`.
+- A conditional implementation of `Trait.customTestExecutor` whose value is
+  `self` in the common case where the trait type conforms to
+  `CustomTestExecuting` itself.
+
+Since the `customTestExecutor` property is optional and `nil` by default, the
+testing library cannot invoke the `execute(...)` method unless a trait
+customizes test behavior. This avoids the "unnecessarily lengthy backtraces"
+problem above.
+
+Below are the proposed interfaces:
+
+```swift
+/// A protocol that allows customizing the execution of a test function (and
+/// each of its cases) or a test suite by performing custom code before or after
+/// it runs.
+public protocol CustomTestExecuting: Sendable {
+  /// Execute a function for the specified test and/or test case.
+  ///
+  /// - Parameters:
+  ///   - function: The function to perform. If `test` represents a test suite,
+  ///     this function encapsulates running all the tests in that suite. If
+  ///     `test` represents a test function, this function is the body of that
+  ///     test function (including all cases if it is parameterized.)
+  ///   - test: The test under which `function` is being performed.
+  ///   - testCase: The test case, if any, under which `function` is being
+  ///     performed. This is `nil` when invoked on a suite.
+  ///
+  /// - Throws: Whatever is thrown by `function`, or an error preventing
+  ///   execution from running correctly.
+  ///
+  /// This function is called for each ``Trait`` on a test suite or test
+  /// function which has a non-`nil` value for ``Trait/customTestExecutor-1dwpt``.
+  /// It allows additional work to be performed before or after the test runs.
+  ///
+  /// This function is invoked once for the test its associated trait is applied
+  /// to, and then once for each test case in that test, if applicable. If a
+  /// test is skipped, this function is not invoked for that test or its cases.
+  ///
+  /// Issues recorded by this function are associated with `test`.
+  func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws
+}
+
+public protocol Trait: Sendable {
+  // ...
+
+  /// The type of the custom test executor for this trait.
+  ///
+  /// The default type is `Never`.
+  associatedtype CustomTestExecutor: CustomTestExecuting = Never
+
+  /// The custom test executor for this trait, if any.
+  ///
+  /// If this trait's type conforms to ``CustomTestExecuting``, the default
+  /// value of this property is `self` and this trait will be used to customize
+  /// test execution. This is the most straightforward way to implement a trait
+  /// which customizes the execution of tests.
+  ///
+  /// However, if the value of this property is an instance of another type
+  /// conforming to ``CustomTestExecuting``, that instance will be used to
+  /// perform custom test execution instead.  Otherwise, the default value of
+  /// this property is `nil` (with the default type `Never?`), meaning that
+  /// custom test execution will not be performed for tests this trait is
+  /// applied to.
+  var customTestExecutor: CustomTestExecutor? { get }
+}
+
+extension Trait {
+  // ...
+
+  // The default implementation, which returns `nil`.
+  public var customTestExecutor: CustomTestExecutor? { get }
+}
+
+extension Trait where CustomTestExecutor == Self {
+  // Returns `self`.
+  public var customTestExecutor: CustomTestExecutor? { get }
+}
+
+extension Never: CustomTestExecuting {
+  public func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws
+}
+```
+
+Here is a complete example of the usage scenario described earlier, showcasing
+the proposed APIs:
+
+```swift
+@Test(.mockAPICredentials)
+func example() {
+  // ...validate API usage, referencing `APICredentials.current`...
+}
+
+struct MockAPICredentialsTrait: TestTrait, CustomTestExecuting {
+  func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
+    let mockCredentials = APICredentials(apiKey: "...")
+    try await APICredentials.$current.withValue(mockCredentials) {
+      try await function()
+    }
+  }
+}
+
+extension Trait where Self == MockAPICredentialsTrait {
+  static var mockAPICredentials: Self {
+    Self()
+  }
+}
+```
+
+## Source compatibility
+
+The proposed APIs are purely additive.
+
+## Integration with supporting tools
+
+Although some built-in traits are relevant to supporting tools (such as
+SourceKit-LSP statically discovering `.tags` traits), custom test behaviors are
+only relevant within the test executable process while tests are running. We
+don't anticipate any particular need for this feature to integrate with
+supporting tools.
+
+## Future directions
+
+Some test authors have expressed interest in allowing custom traits to access
+the instance of a suite type for `@Test` instance methods, so the trait could
+inspect or mutate the instance. Currently, only instance-level members of a
+suite type (including `init`, `deinit`, and the test function itself) can access
+`self`, so this would grant traits applied to an instance test method access to
+the instance as well. This is certainly interesting, but poses several technical
+challenges that puts it out of scope of this proposal.
+
+## Alternatives considered
+
+### Separate set up & tear down methods on `Trait`
+
+This idea was discussed in [Supporting scoped access](#supporting-scoped-access)
+above, and as mentioned there, the primary problem with this approach is that it
+cannot be used with scoped access-style APIs, including (importantly)
+`TaskLocal.withValue()`. For that reason, it prevents using that common Swift
+concurrency technique and reduces the potential for test parallelization.
+
+### Add `execute(...)` directly to the `Trait` protocol
+
+The proposed `execute(...)` method could be added as a requirement of the
+`Trait` protocol instead of being part of a separate `CustomTestExecuting`
+protocol, and it could have a default implementation which directly invokes the
+passed-in closure. But this approach would suffer from the lengthy backtrace
+problem described above.
+
+### Extend the `Trait` protocol
+
+The original SPI implementation of this feature included a protocol named
+`CustomExecutionTrait` which extended `Trait` and had roughly the same method
+requirement as the `CustomTestExecuting` protocol proposed above. This design
+worked, provided scoped access, and avoided the lengthy backtrace problem.
+
+After evaluating the design and usage of this SPI though, it seemed unfortunate
+to structure it as a sub-protocol of `Trait` because it means that the full
+capabilities of the trait system are spread across multiple protocols. In the
+proposed design, the ability to provide a custom test executor value is exposed
+via the main `Trait` protocol, and it relies on an associated type to
+conditionally opt-in to custom test behavior. In other words, the proposed
+design expresses custom test behavior as just a _capability_ that a trait may
+have, rather than a distinct sub-type of trait.
+
+Also, the implementation of this approach within the testing library was not
+ideal as it required a conditional `trait as? CustomExecutionTrait` downcast at
+runtime, in contrast to the simpler and more performant Optional property of the
+proposed API.
+
+## Acknowledgments
+
+Thanks to [Dennis Weissmann](https://github.com/dennisweissmann) for originally
+implementing this as SPI, and for helping promote its usefulness.
+
+Thanks to [Jonathan Grynspan](https://github.com/grynspan) for exploring ideas
+to refine the API, and considering alternatives to avoid unnecessarily long
+backtraces.

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -56,20 +56,19 @@ public struct Runner: Sendable {
 // MARK: - Running tests
 
 extension Runner {
-  /// Execute the ``CustomTestExecuting/execute(_:for:testCase:)`` functions of
-  /// any custom test executors for traits associated with the test in a plan
-  /// step.
+  /// Execute the ``TestExecuting/execute(_:for:testCase:)`` functions of any
+  /// test executors for traits associated with the test in a plan step.
   ///
   /// - Parameters:
   ///   - step: The step being performed.
   ///   - testCase: The test case, if applicable, for which to execute the
   ///     function.
   ///   - body: A function to execute from within the
-  ///     ``CustomTestExecuting/execute(_:for:testCase:)`` function of each
-  ///     non-`nil` custom test executor of the traits applied to `step.test`.
+  ///     ``TestExecuting/execute(_:for:testCase:)`` function of each non-`nil`
+  ///     test executor of the traits applied to `step.test`.
   ///
   /// - Throws: Whatever is thrown by `body` or by any of the
-  ///   ``CustomTestExecuting/execute(_:for:testCase:)`` functions.
+  ///   ``TestExecuting/execute(_:for:testCase:)`` functions.
   private func _executeTraits(
     for step: Plan.Step,
     testCase: Test.Case?,
@@ -91,7 +90,7 @@ extension Runner {
     // and ultimately the first trait is the first one to be invoked.
     let executeAllTraits = step.test.traits.lazy
       .reversed()
-      .compactMap { $0.customTestExecutor }
+      .compactMap { $0.testExecutor }
       .map { $0.execute(_:for:testCase:) }
       .reduce(body) { executeAllTraits, testExecutor in
         {

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -56,31 +56,28 @@ public struct Runner: Sendable {
 // MARK: - Running tests
 
 extension Runner {
-  /// Execute the ``TestExecuting/execute(_:for:testCase:)`` functions of any
-  /// test executors for traits associated with the test in a plan step.
+  /// Apply the custom scope for any test scope providers of the traits
+  /// associated with a specified test by calling their
+  /// ``TestScoping/provideScope(for:testCase:performing:)`` function.
   ///
   /// - Parameters:
-  ///   - step: The step being performed.
-  ///   - testCase: The test case, if applicable, for which to execute the
-  ///     function.
+  ///   - test: The test being run, for which to provide custom scope.
+  ///   - testCase: The test case, if applicable, for which to provide custom
+  ///     scope.
   ///   - body: A function to execute from within the
-  ///     ``TestExecuting/execute(_:for:testCase:)`` function of each non-`nil`
-  ///     test executor of the traits applied to `step.test`.
+  ///     ``TestScoping/provideScope(for:testCase:performing:)`` function of
+  ///     each non-`nil` scope provider of the traits applied to `test`.
   ///
   /// - Throws: Whatever is thrown by `body` or by any of the
-  ///   ``TestExecuting/execute(_:for:testCase:)`` functions.
-  private func _executeTraits(
-    for step: Plan.Step,
+  ///   ``TestScoping/provideScope(for:testCase:performing:)`` function calls.
+  private func _applyScopingTraits(
+    for test: Test,
     testCase: Test.Case?,
     _ body: @escaping @Sendable () async throws -> Void
   ) async throws {
     // If the test does not have any traits, exit early to avoid unnecessary
     // heap allocations below.
-    if step.test.traits.isEmpty {
-      return try await body()
-    }
-
-    if case .skip = step.action {
+    if test.traits.isEmpty {
       return try await body()
     }
 
@@ -88,13 +85,13 @@ extension Runner {
     // function. The order of the sequence is reversed so that the last trait is
     // the one that invokes body, then the second-to-last invokes the last, etc.
     // and ultimately the first trait is the first one to be invoked.
-    let executeAllTraits = step.test.traits.lazy
+    let executeAllTraits = test.traits.lazy
       .reversed()
-      .compactMap { $0.executor(for: step.test, testCase: testCase) }
-      .map { $0.execute(_:for:testCase:) }
-      .reduce(body) { executeAllTraits, testExecutor in
+      .compactMap { $0.scopeProvider(for: test, testCase: testCase) }
+      .map { $0.provideScope(for:testCase:performing:) }
+      .reduce(body) { executeAllTraits, provideScope in
         {
-          try await testExecutor(executeAllTraits, step.test, testCase)
+          try await provideScope(test, testCase, executeAllTraits)
         }
       }
 
@@ -200,7 +197,7 @@ extension Runner {
     if let step = stepGraph.value, case .run = step.action {
       await Test.withCurrent(step.test) {
         _ = await Issue.withErrorRecording(at: step.test.sourceLocation, configuration: configuration) {
-          try await _executeTraits(for: step, testCase: nil) {
+          try await _applyScopingTraits(for: step.test, testCase: nil) {
             // Run the test function at this step (if one is present.)
             if let testCases = step.test.testCases {
               try await _runTestCases(testCases, within: step)
@@ -336,7 +333,7 @@ extension Runner {
       let sourceLocation = step.test.sourceLocation
       await Issue.withErrorRecording(at: sourceLocation, configuration: configuration) {
         try await withTimeLimit(for: step.test, configuration: configuration) {
-          try await _executeTraits(for: step, testCase: testCase) {
+          try await _applyScopingTraits(for: step.test, testCase: testCase) {
             try await testCase.body()
           }
         } timeoutHandler: { timeLimit in

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -90,7 +90,7 @@ extension Runner {
     // and ultimately the first trait is the first one to be invoked.
     let executeAllTraits = step.test.traits.lazy
       .reversed()
-      .compactMap { $0.testExecutor }
+      .compactMap { $0.executor(for: step.test, testCase: testCase) }
       .map { $0.execute(_:for:testCase:) }
       .reduce(body) { executeAllTraits, testExecutor in
         {

--- a/Sources/Testing/Testing.docc/Traits.md
+++ b/Sources/Testing/Testing.docc/Traits.md
@@ -53,6 +53,7 @@ behavior of test functions.
 - ``Trait``
 - ``TestTrait``
 - ``SuiteTrait``
+- ``TestScoping``
 
 ### Supporting types
 

--- a/Sources/Testing/Testing.docc/Traits/Trait.md
+++ b/Sources/Testing/Testing.docc/Traits/Trait.md
@@ -46,8 +46,8 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 - ``Trait/prepare(for:)-3s3zo``
 
-### Customizing the execution of tests
+### Providing custom execution scope for tests
 
-- ``TestExecuting``
-- ``Trait/executor(for:testCase:)-26qgm``
-- ``Trait/TestExecutor``
+- ``TestScoping``
+- ``Trait/scopeProvider(for:testCase:)-cjmg``
+- ``Trait/TestScopeProvider``

--- a/Sources/Testing/Testing.docc/Traits/Trait.md
+++ b/Sources/Testing/Testing.docc/Traits/Trait.md
@@ -39,8 +39,15 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 - ``Trait/bug(_:id:_:)-3vtpl``
 
 ### Adding information to tests
+
 - ``Trait/comments``
 
 ### Preparing internal state
 
 - ``Trait/prepare(for:)-3s3zo``
+
+### Customizing the execution of tests
+
+- ``CustomTestExecuting``
+- ``Trait/customTestExecutor-1dwpt``
+- ``Trait/CustomTestExecutor``

--- a/Sources/Testing/Testing.docc/Traits/Trait.md
+++ b/Sources/Testing/Testing.docc/Traits/Trait.md
@@ -48,6 +48,6 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 ### Customizing the execution of tests
 
-- ``CustomTestExecuting``
-- ``Trait/customTestExecutor-1dwpt``
-- ``Trait/CustomTestExecutor``
+- ``TestExecuting``
+- ``Trait/testExecutor-714gp``
+- ``Trait/TestExecutor``

--- a/Sources/Testing/Testing.docc/Traits/Trait.md
+++ b/Sources/Testing/Testing.docc/Traits/Trait.md
@@ -49,5 +49,5 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 ### Customizing the execution of tests
 
 - ``TestExecuting``
-- ``Trait/testExecutor-714gp``
+- ``Trait/executor(for:testCase:)-26qgm``
 - ``Trait/TestExecutor``

--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -114,8 +114,8 @@ public protocol CustomTestExecuting: Sendable {
   func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws
 }
 
-extension Trait where CustomTestExecutor == Self {
-  public var customTestExecutor: CustomTestExecutor? {
+extension Trait where Self: CustomTestExecuting {
+  public var customTestExecutor: Self? {
     self
   }
 }

--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -41,6 +41,68 @@ public protocol Trait: Sendable {
   ///
   /// By default, the value of this property is an empty array.
   var comments: [Comment] { get }
+
+  /// The type of the custom test executor for this trait.
+  ///
+  /// The default type is `Never`.
+  associatedtype CustomTestExecutor: CustomTestExecuting = Never
+
+  /// The custom test executor for this trait, if any.
+  ///
+  /// If this trait's type conforms to ``CustomTestExecuting``, the default
+  /// value of this property is `self` and this trait will be used to customize
+  /// test execution. This is the most straightforward way to implement a trait
+  /// which customizes the execution of tests.
+  ///
+  /// However, if the value of this property is an instance of another type
+  /// conforming to ``CustomTestExecuting``, that instance will be used to
+  /// perform custom test execution instead.  Otherwise, the default value of
+  /// this property is `nil` (with the default type `Never?`), meaning that
+  /// custom test execution will not be performed for tests this trait is
+  /// applied to.
+  var customTestExecutor: CustomTestExecutor? { get }
+}
+
+/// A protocol that allows customizing the execution of a test function (and
+/// each of its cases) or a test suite by performing custom code before or after
+/// it runs.
+public protocol CustomTestExecuting: Sendable {
+  /// Execute a function for the specified test and/or test case.
+  ///
+  /// - Parameters:
+  ///   - function: The function to perform. If `test` represents a test suite,
+  ///     this function encapsulates running all the tests in that suite. If
+  ///     `test` represents a test function, this function is the body of that
+  ///     test function (including all cases if it is parameterized.)
+  ///   - test: The test under which `function` is being performed.
+  ///   - testCase: The test case, if any, under which `function` is being
+  ///     performed. This is `nil` when invoked on a suite.
+  ///
+  /// - Throws: Whatever is thrown by `function`, or an error preventing
+  ///   execution from running correctly.
+  ///
+  /// This function is called for each ``Trait`` on a test suite or test
+  /// function which has a non-`nil` value for ``Trait/customTestExecutor-1dwpt``.
+  /// It allows additional work to be performed before or after the test runs.
+  ///
+  /// This function is invoked once for the test its associated trait is applied
+  /// to, and then once for each test case in that test, if applicable. If a
+  /// test is skipped, this function is not invoked for that test or its cases.
+  ///
+  /// Issues recorded by this function are associated with `test`.
+  func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws
+}
+
+extension Trait where CustomTestExecutor == Self {
+  public var customTestExecutor: CustomTestExecutor? {
+    self
+  }
+}
+
+extension Never: CustomTestExecuting {
+  public func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
+    fatalError("Unreachable codepath: Never cannot be instantiated.")
+  }
 }
 
 /// A protocol describing traits that can be added to a test function.
@@ -70,45 +132,14 @@ extension Trait {
   public var comments: [Comment] {
     []
   }
+
+  public var customTestExecutor: CustomTestExecutor? {
+    nil
+  }
 }
 
 extension SuiteTrait {
   public var isRecursive: Bool {
     false
   }
-}
-
-/// A protocol extending ``Trait`` that offers an additional customization point
-/// for trait authors to execute code before and after each test function (if
-/// added to the traits of a test function), or before and after each test suite
-/// (if added to the traits of a test suite).
-@_spi(Experimental)
-public protocol CustomExecutionTrait: Trait {
-
-  /// Execute a function with the effects of this trait applied.
-  ///
-  /// - Parameters:
-  ///   - function: The function to perform. If `test` represents a test suite,
-  ///     this function encapsulates running all the tests in that suite. If
-  ///     `test` represents a test function, this function is the body of that
-  ///     test function (including all cases if it is parameterized.)
-  ///   - test: The test under which `function` is being performed.
-  ///   - testCase: The test case, if any, under which `function` is being
-  ///     performed. This is `nil` when invoked on a suite.
-  ///
-  /// - Throws: Whatever is thrown by `function`, or an error preventing the
-  ///   trait from running correctly.
-  ///
-  /// This function is called for each ``CustomExecutionTrait`` on a test suite
-  /// or test function and allows additional work to be performed before and
-  /// after the test runs.
-  ///
-  /// This function is invoked once for the test it is applied to, and then once
-  /// for each test case in that test, if applicable.
-  ///
-  /// Issues recorded by this function are recorded against `test`.
-  ///
-  /// - Note: If a test function or test suite is skipped, this function does
-  ///   not get invoked by the runner.
-  func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws
 }

--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -144,12 +144,36 @@ public protocol TestScoping: Sendable {
 }
 
 extension Trait where Self: TestScoping {
+  /// Get this trait's scope provider for the specified test and/or test case,
+  /// if any.
+  ///
+  /// - Parameters:
+  ///   - test: The test for which a scope provider is being requested.
+  ///   - testCase: The test case for which a scope provider is being requested,
+  ///     if any. When `test` represents a suite, the value of this argument is
+  ///     `nil`.
+  ///
+  /// This default implementation is used when this trait type conforms to
+  /// ``TestScoping`` and its return value is discussed in
+  /// ``Trait/scopeProvider(for:testCase:)-cjmg``.
   public func scopeProvider(for test: Test, testCase: Test.Case?) -> Self? {
     testCase == nil ? nil : self
   }
 }
 
 extension SuiteTrait where Self: TestScoping {
+  /// Get this trait's scope provider for the specified test and/or test case,
+  /// if any.
+  ///
+  /// - Parameters:
+  ///   - test: The test for which a scope provider is being requested.
+  ///   - testCase: The test case for which a scope provider is being requested,
+  ///     if any. When `test` represents a suite, the value of this argument is
+  ///     `nil`.
+  ///
+  /// This default implementation is used when this trait type conforms to
+  /// ``TestScoping`` and its return value is discussed in
+  /// ``Trait/scopeProvider(for:testCase:)-cjmg``.
   public func scopeProvider(for test: Test, testCase: Test.Case?) -> Self? {
     if test.isSuite {
       isRecursive ? nil : self
@@ -193,6 +217,18 @@ extension Trait {
 }
 
 extension Trait where TestScopeProvider == Never {
+  /// Get this trait's scope provider for the specified test and/or test case,
+  /// if any.
+  ///
+  /// - Parameters:
+  ///   - test: The test for which a scope provider is being requested.
+  ///   - testCase: The test case for which a scope provider is being requested,
+  ///     if any. When `test` represents a suite, the value of this argument is
+  ///     `nil`.
+  ///
+  /// This default implementation is used when this trait type's associated
+  /// ``Trait/TestScopeProvider`` type is the default value of `Never`, and its
+  /// return value is discussed in ``Trait/scopeProvider(for:testCase:)-cjmg``.
   public func scopeProvider(for test: Test, testCase: Test.Case?) -> Never? {
     nil
   }

--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -42,29 +42,29 @@ public protocol Trait: Sendable {
   /// By default, the value of this property is an empty array.
   var comments: [Comment] { get }
 
-  /// The type of the custom test executor for this trait.
+  /// The type of the test executor for this trait.
   ///
   /// The default type is `Never`, which cannot be instantiated. This means the
-  /// value of the ``customTestExecutor-1dwpt`` property for all traits with the
-  /// default custom executor type is `nil`, meaning such traits will not
+  /// value of the ``testExecutor-714gp`` property for all traits with
+  /// the default custom executor type is `nil`, meaning such traits will not
   /// perform any custom execution for the tests they're applied to.
-  associatedtype CustomTestExecutor: CustomTestExecuting = Never
+  associatedtype TestExecutor: TestExecuting = Never
 
-  /// The custom test executor for this trait, if any.
+  /// The test executor for this trait, if any.
   ///
-  /// If this trait's type conforms to ``CustomTestExecuting``, the default
-  /// value of this property is `self` and this trait will be used to customize
-  /// test execution. This is the most straightforward way to implement a trait
-  /// which customizes the execution of tests.
+  /// If this trait's type conforms to ``TestExecuting``, the default value of
+  /// this property is `self` and this trait will be used to customize test
+  /// execution. This is the most straightforward way to implement a trait which
+  /// customizes the execution of tests.
   ///
   /// If the value of this property is an instance of a different type
-  /// conforming to ``CustomTestExecuting``, that instance will be used to
-  /// perform custom test execution instead.
+  /// conforming to ``TestExecuting``, that instance will be used to perform
+  /// test execution instead.
   ///
   /// The default value of this property is `nil` (with the default type
   /// `Never?`), meaning that instances of this type will not perform any custom
   /// test execution for tests they are applied to.
-  var customTestExecutor: CustomTestExecutor? { get }
+  var testExecutor: TestExecutor? { get }
 }
 
 /// A protocol that allows customizing the execution of a test function (and
@@ -73,12 +73,12 @@ public protocol Trait: Sendable {
 ///
 /// Types conforming to this protocol may be used in conjunction with a
 /// ``Trait``-conforming type by implementing the
-/// ``Trait/customTestExecutor-1dwpt`` property, allowing custom traits to
+/// ``Trait/testExecutor-714gp`` property, allowing custom traits to
 /// customize the execution of tests. Consolidating common set-up and tear-down
 /// logic for tests which have similar needs allows each test function to be
 /// more succinct with less repetitive boilerplate so it can focus on what makes
 /// it unique.
-public protocol CustomTestExecuting: Sendable {
+public protocol TestExecuting: Sendable {
   /// Execute a function for the specified test and/or test case.
   ///
   /// - Parameters:
@@ -99,8 +99,8 @@ public protocol CustomTestExecuting: Sendable {
   /// When the testing library is preparing to run a test, it finds all traits
   /// applied to that test (including those inherited from containing suites)
   /// and asks each for the value of its
-  /// ``Trait/customTestExecutor-1dwpt`` property. It then calls this method on
-  /// all non-`nil` instances, giving each an opportunity to perform
+  /// ``Trait/testExecutor-714gp`` property. It then calls this method
+  /// on all non-`nil` instances, giving each an opportunity to perform
   /// arbitrary work before or after invoking `function`.
   ///
   /// This method should either invoke `function` once before returning or throw
@@ -114,13 +114,13 @@ public protocol CustomTestExecuting: Sendable {
   func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws
 }
 
-extension Trait where Self: CustomTestExecuting {
-  public var customTestExecutor: Self? {
+extension Trait where Self: TestExecuting {
+  public var testExecutor: Self? {
     self
   }
 }
 
-extension Never: CustomTestExecuting {
+extension Never: TestExecuting {
   public func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {}
 }
 
@@ -153,8 +153,8 @@ extension Trait {
   }
 }
 
-extension Trait where CustomTestExecutor == Never {
-  public var customTestExecutor: CustomTestExecutor? {
+extension Trait where TestExecutor == Never {
+  public var testExecutor: TestExecutor? {
     nil
   }
 }

--- a/Tests/TestingTests/Traits/CustomTestExecutingTraitTests.swift
+++ b/Tests/TestingTests/Traits/CustomTestExecutingTraitTests.swift
@@ -10,8 +10,8 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-@Suite("CustomExecutionTrait Tests")
-struct CustomExecutionTraitTests {
+@Suite("CustomTestExecuting-conforming Trait Tests")
+struct CustomTestExecutingTraitTests {
   @Test("Execute code before and after a non-parameterized test.")
   func executeCodeBeforeAndAfterNonParameterizedTest() async {
     // `expectedCount` is 2 because we run it both for the test and the test case
@@ -65,7 +65,7 @@ struct CustomExecutionTraitTests {
 
 // MARK: - Fixtures
 
-private struct CustomTrait: CustomExecutionTrait, TestTrait {
+private struct CustomTrait: TestTrait, CustomTestExecuting {
   var before: Confirmation
   var after: Confirmation
   func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
@@ -77,7 +77,7 @@ private struct CustomTrait: CustomExecutionTrait, TestTrait {
   }
 }
 
-private struct CustomThrowingErrorTrait: CustomExecutionTrait, TestTrait {
+private struct CustomThrowingErrorTrait: TestTrait, CustomTestExecuting {
   fileprivate struct CustomTraitError: Error {}
 
   func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
@@ -85,10 +85,10 @@ private struct CustomThrowingErrorTrait: CustomExecutionTrait, TestTrait {
   }
 }
 
-struct DoSomethingBeforeAndAfterTrait: CustomExecutionTrait, SuiteTrait, TestTrait {
+struct DoSomethingBeforeAndAfterTrait: SuiteTrait, TestTrait, CustomTestExecuting {
   static let state = Locked(rawValue: 0)
 
-  func execute(_ function: @Sendable () async throws -> Void, for test: Testing.Test, testCase: Testing.Test.Case?) async throws {
+  func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
     #expect(Self.state.increment() == 1)
 
     try await function()

--- a/Tests/TestingTests/Traits/TestExecutingTraitTests.swift
+++ b/Tests/TestingTests/Traits/TestExecutingTraitTests.swift
@@ -10,8 +10,8 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-@Suite("CustomTestExecuting-conforming Trait Tests")
-struct CustomTestExecutingTraitTests {
+@Suite("TestExecuting-conforming Trait Tests")
+struct TestExecutingTraitTests {
   @Test("Execute code before and after a non-parameterized test.")
   func executeCodeBeforeAndAfterNonParameterizedTest() async {
     // `expectedCount` is 2 because we run it both for the test and the test case
@@ -65,7 +65,7 @@ struct CustomTestExecutingTraitTests {
 
 // MARK: - Fixtures
 
-private struct CustomTrait: TestTrait, CustomTestExecuting {
+private struct CustomTrait: TestTrait, TestExecuting {
   var before: Confirmation
   var after: Confirmation
   func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
@@ -77,7 +77,7 @@ private struct CustomTrait: TestTrait, CustomTestExecuting {
   }
 }
 
-private struct CustomThrowingErrorTrait: TestTrait, CustomTestExecuting {
+private struct CustomThrowingErrorTrait: TestTrait, TestExecuting {
   fileprivate struct CustomTraitError: Error {}
 
   func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {
@@ -85,7 +85,7 @@ private struct CustomThrowingErrorTrait: TestTrait, CustomTestExecuting {
   }
 }
 
-struct DoSomethingBeforeAndAfterTrait: SuiteTrait, TestTrait, CustomTestExecuting {
+struct DoSomethingBeforeAndAfterTrait: SuiteTrait, TestTrait, TestExecuting {
   static let state = Locked(rawValue: 0)
 
   func execute(_ function: @Sendable () async throws -> Void, for test: Test, testCase: Test.Case?) async throws {


### PR DESCRIPTION
This includes an API proposal and code changes to introduce new API for custom traits to customize test execution.

View the [API proposal](https://github.com/stmontgomery/swift-testing/blob/publicize-CustomExecutionTrait/Documentation/Proposals/NNNN-custom-test-execution-traits.md) for more details.

### Motivation:

One of the primary motivations for the trait system in Swift Testing, as [described in the vision document](https://github.com/swiftlang/swift-evolution/blob/main/visions/swift-testing.md#trait-extensibility), is to provide a way to customize the behavior of tests which have things in common. If all the tests in a given suite type need the same custom behavior, `init` and/or `deinit` (if applicable) can be used today. But if only _some_ of the tests in a suite need custom behavior, or tests across different levels of the suite hierarchy need it, traits would be a good place to encapsulate common logic since they can be applied granularly per-test or per-suite. This aspect of the vision for traits hasn't been realized yet, though: the `Trait` protocol does not offer a way for a trait to customize the execution of the tests or suites it's applied to.

Customizing a test's behavior typically means running code either before or after it runs, or both. Consolidating common set-up and tear-down logic allows each test function to be more succinct with less repetitive boilerplate so it can focus on what makes it unique.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
