### PR TITLE
Inherit isolation in `#expect(exitsWith:)`.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -153,6 +153,7 @@ extension ExitTest {
 ///   - isRequired: Whether or not the expectation is required. The value of
 ///     this argument does not affect whether or not an error is thrown on
 ///     failure.
+///   - isolation: The actor to which the exit test is isolated, if any.
 ///   - sourceLocation: The source location of the expectation.
 ///
 /// This function contains the common implementation for all
@@ -160,10 +161,10 @@ extension ExitTest {
 /// convention.
 func callExitTest(
   exitsWith expectedExitCondition: ExitCondition,
-  performing _: @escaping @Sendable () async throws -> Void,
   expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
+  isolation: isolated (any Actor)? = #isolation,
   sourceLocation: SourceLocation
 ) async -> Result<Void, any Error> {
   guard let configuration = Configuration.current ?? Configuration.all.first else {

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1142,15 +1142,15 @@ public func __checkClosureCall<R>(
 @_spi(Experimental)
 public func __checkClosureCall(
   exitsWith expectedExitCondition: ExitCondition,
-  performing body: @convention(thin) () async throws -> Void,
+  performing body: @convention(thin) () -> Void,
   expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
+  isolation: isolated (any Actor)? = #isolation,
   sourceLocation: SourceLocation
 ) async -> Result<Void, any Error> {
   await callExitTest(
     exitsWith: expectedExitCondition,
-    performing: { try await body() },
     expression: expression,
     comments: comments(),
     isRequired: isRequired,

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -280,6 +280,20 @@ private import _TestingInternals
     #expect(ExitCondition.signal(SIGTERM) !== .signal(SIGINT))
 #endif
   }
+
+  @MainActor static func someMainActorFunction() {
+    MainActor.assertIsolated()
+  }
+
+  @Test("Exit test can be main-actor-isolated")
+  @MainActor
+  func mainActorIsolation() async {
+    await #expect(exitsWith: .success) {
+      await Self.someMainActorFunction()
+      _ = 0
+      exit(EXIT_SUCCESS)
+    }
+  }
 }
 
 // MARK: - Fixtures


### PR DESCRIPTION
This PR ensures the body of _the implementation of_ `#expect(exitsWith:)` inherits isolation from the caller. The actual body closure passed to the macro cannot inherit isolation as it runs in a separate process, but the glue code we emit needs to inherit so that if the caller is actor-isolated, the code compiles cleanly. Without this change, the following test fails to compile:

```swift
@MainActor @Test func f() async {
  await #expect(exitsWith: .failure) { /* ... */ }
  // 🛑 ^ ^ ^ sending main actor-isolated value of type '() -> [Comment]' with later accesses to nonisolated context risks causing data races
}
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
