### PR TITLE
Fix macro expansion failure for a non-copyable suite type with a `test` method.

### DIFF
--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -568,7 +568,7 @@ public func __ifMainActorIsolationEnforced<R>(
   _ selector: __XCTestCompatibleSelector?,
   onInstanceOf type: T.Type,
   sourceLocation: SourceLocation
-) async throws -> Bool {
+) async throws -> Bool where T: ~Copyable {
   false
 }
 

--- a/Tests/TestingTests/NonCopyableSuiteTests.swift
+++ b/Tests/TestingTests/NonCopyableSuiteTests.swift
@@ -16,6 +16,7 @@ struct NonCopyableTests: ~Copyable {
   @Test borrowing func borrowMe() {}
   @Test consuming func consumeMe() {}
   @Test mutating func mutateMe() {}
+  @Test borrowing func testNotAnXCTestCaseMethod() {}
 
   @Test borrowing func typeComparison() {
     let lhs = TypeInfo(describing: Self.self)


### PR DESCRIPTION
If a non-copyable suite type has a test function whose name starts with `test`, we emit a call to `__invokeXCTestCaseMethod()` that's a no-op (but we can't tell during macro expansion if it will be.) This function needs to be updated to accept a non-copyable generic type.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
