### PR TITLE
Disable reformatting of macro expansions.

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -63,6 +63,10 @@ extension ConditionMacro {
     return try expansion(of: macro, primaryExpression: nil, in: context)
   }
 
+  public static var formatMode: FormatMode {
+    .disabled
+  }
+
   /// Perform the expansion of this condition macro.
   ///
   /// - Parameters:

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -40,6 +40,10 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
     return []
   }
 
+  public static var formatMode: FormatMode {
+    .disabled
+  }
+
   /// Diagnose issues with a `@Suite` declaration.
   ///
   /// - Parameters:

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -31,6 +31,10 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     return _createTestContainerDecls(for: functionDecl, on: typeName, testAttribute: node, in: context)
   }
 
+  public static var formatMode: FormatMode {
+    .disabled
+  }
+
   /// Diagnose issues with a `@Test` declaration.
   ///
   /// - Parameters:


### PR DESCRIPTION
This PR turns off automatic reformatting of our macro expansions. I noticed that at-desk, the compiler was spending an inordinate amount of time in reformatting:

```
Call graph:
    7149 Thread_709950   DispatchQueue_1: com.apple.main-thread  (serial)
      7149 start  (in dyld) + 2840  [0x18dafc274]
        7149 main  (in TestingMacros) + 28  [0x1029291d4]  TestingMacrosMain.swift:18
          7149 static TestingMacrosMain.$main()  (in TestingMacros) + 160  [0x1029290c4]  /<compiler-generated>:0
            7149 static CompilerPlugin.main()  (in TestingMacros) + 544  [0x10337f64c]  CompilerPlugin.swift:115
              6702 CompilerPluginMessageListener.main()  (in TestingMacros) + 536  [0x1033cc85c]  CompilerPluginMessageHandler.swift:96
              + 6692 CompilerPluginMessageHandler.handleMessage(_:)  (in TestingMacros) + 2320  [0x1033ce32c]  CompilerPluginMessageHandler.swift:169
              + ! 6375 CompilerPluginMessageHandler.expandAttachedMacro(macro:macroRole:discriminator:attributeSyntax:declSyntax:parentDeclSyntax:extendedTypeSyntax:conformanceListSyntax:lexicalContext:)  (in TestingMacros) + 1572  [0x1033fec00]  Macros.swift:155
              + ! : 3284 expandAttachedMacroWithoutCollapsing<A>(definition:macroRole:attributeNode:declarationNode:parentDeclNode:extendedType:conformanceList:in:indentationWidth:)  (in TestingMacros) + 3132  [0x1033a96d0]  MacroExpansion.swift:280
              + ! : | 3284 Collection.map<A, B>(_:)  (in TestingMacros) + 1656  [0x1033a7eec]  /<compiler-generated>:0
              + ! : |   3284 partial apply for closure #4 in expandAttachedMacroWithoutCollapsing<A>(definition:macroRole:attributeNode:declarationNode:parentDeclNode:extendedType:conformanceList:in:indentationWidth:)  (in TestingMacros) + 36  [0x1033ac83c]  /<compiler-generated>:0
              + ! : |     3284 closure #4 in expandAttachedMacroWithoutCollapsing<A>(definition:macroRole:attributeNode:declarationNode:parentDeclNode:extendedType:conformanceList:in:indentationWidth:)  (in TestingMacros) + 180  [0x1033aaaa8]  MacroExpansion.swift:281
              + ! : |       3243 SyntaxProtocol.formattedExpansion(_:indentationWidth:)  (in TestingMacros) + 188  [0x1033a81f4]  MacroExpansion.swift:409
`

3243 samples is significantly more than what we spend in test macro expansion:

```
+ ! : 2277 expandAttachedMacroWithoutCollapsing<A>(definition:macroRole:attributeNode:declarationNode:parentDeclNode:extendedType:conformanceList:in:indentationWidth:)  (in TestingMacros) + 2932  [0x1033a9608]  MacroExpansion.swift:273
+ ! : | 2277 protocol witness for static PeerMacro.expansion<A, B>(of:providingPeersOf:in:) in conformance TestDeclarationMacro  (in TestingMacros) + 20  [0x102928ad0]  /<compiler-generated>:0
+ ! : |   2258 static TestDeclarationMacro.expansion<A, B>(of:providingPeersOf:in:)  (in TestingMacros) + 316  [0x10291f73c]  TestDeclarationMacro.swift:31
+ ! : |   + 966 static TestDeclarationMacro._createTestContainerDecls<A>(for:on:testAttribute:in:)  (in TestingMacros) + 2184  [0x1029213b8]  TestDeclarationMacro.swift:410
```

These samples are in a debug build—I fully expect the performance to be better
in a release build—but they still significantly impact our build time when used
as a package or tested at desk.

Works around rdar://137132570.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
