### PR TITLE
Disable formatting for more macros.

### DIFF
--- a/Sources/TestingMacros/SourceLocationMacro.swift
+++ b/Sources/TestingMacros/SourceLocationMacro.swift
@@ -22,4 +22,8 @@ public struct SourceLocationMacro: ExpressionMacro, Sendable {
   ) throws -> ExprSyntax {
     createSourceLocationExpr(of: macro, context: context)
   }
+
+  public static var formatMode: FormatMode {
+    .disabled
+  }
 }

--- a/Sources/TestingMacros/TagMacro.swift
+++ b/Sources/TestingMacros/TagMacro.swift
@@ -102,4 +102,8 @@ public struct TagMacro: PeerMacro, AccessorMacro, Sendable {
     }
     return []
   }
+
+  public static var formatMode: FormatMode {
+    .disabled
+  }
 }


### PR DESCRIPTION
Follow-on to #743. Disables formatting for `#_sourceLocation` and `@Tag`. Although I haven't seen either in a sample/spindump, every little bit counts and neither of these macros needs the formatting to build correctly.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
