### PR TITLE
Simplify the configuration option for synchronous test isolation.

### DIFF
--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -105,14 +105,13 @@ public struct Configuration: Sendable {
   /// By default, the value of this property allows for a single iteration.
   public var repetitionPolicy: RepetitionPolicy = .once
 
-  // MARK: - Main actor isolation
+  // MARK: - Isolation context for synchronous tests
 
-#if !SWT_NO_GLOBAL_ACTORS
-  /// Whether or not synchronous test functions need to run on the main actor.
+  /// The isolation context to use for synchronous test functions.
   ///
-  /// This property is available on platforms where UI testing is implemented.
-  public var isMainActorIsolationEnforced = false
-#endif
+  /// If the value of this property is `nil`, synchronous test functions run in
+  /// an unspecified isolation context.
+  public var defaultIsolationContext: (any Actor)? = nil
 
   // MARK: - Time limits
 
@@ -232,4 +231,24 @@ public struct Configuration: Sendable {
 
   /// The test case filter to which test cases should be filtered when run.
   public var testCaseFilter: TestCaseFilter = { _, _ in true }
+}
+
+// MARK: - Deprecated
+
+extension Configuration {
+#if !SWT_NO_GLOBAL_ACTORS
+  @available(*, deprecated, message: "Set defaultIsolationContext instead.")
+  public var isMainActorIsolationEnforced: Bool {
+    get {
+      defaultIsolationContext === MainActor.shared
+    }
+    set {
+      if newValue {
+        defaultIsolationContext = MainActor.shared
+      } else {
+        defaultIsolationContext = nil
+      }
+    }
+  }
+#endif
 }

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -111,7 +111,7 @@ public struct Configuration: Sendable {
   ///
   /// If the value of this property is `nil`, synchronous test functions run in
   /// an unspecified isolation context.
-  public var defaultIsolationContext: (any Actor)? = nil
+  public var defaultSynchronousIsolationContext: (any Actor)? = nil
 
   // MARK: - Time limits
 
@@ -237,16 +237,16 @@ public struct Configuration: Sendable {
 
 extension Configuration {
 #if !SWT_NO_GLOBAL_ACTORS
-  @available(*, deprecated, message: "Set defaultIsolationContext instead.")
+  @available(*, deprecated, message: "Set defaultSynchronousIsolationContext instead.")
   public var isMainActorIsolationEnforced: Bool {
     get {
-      defaultIsolationContext === MainActor.shared
+      defaultSynchronousIsolationContext === MainActor.shared
     }
     set {
       if newValue {
-        defaultIsolationContext = MainActor.shared
+        defaultSynchronousIsolationContext = MainActor.shared
       } else {
-        defaultIsolationContext = nil
+        defaultSynchronousIsolationContext = nil
       }
     }
   }

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -504,25 +504,12 @@ extension Test {
   value
 }
 
-/// Invoke a function isolated to the default isolation context.
+/// The current default isolation context.
 ///
-/// - Parameters:
-///   - body: The function to invoke.
-///
-/// - Returns: Whatever is returned by `body`.
-///
-/// - Throws: Whatever is thrown by `body`.
-///
-/// This function invokes `body` isolated to the default isolation context as
-/// specified when configuring the test run.
-///
-/// - Warning: This function is used to implement the `@Test` macro. Do not call
+/// - Warning: This property is used to implement the `@Test` macro. Do not call
 ///   it directly.
-public func __withDefaultIsolationContext<R>(
-  isolation: isolated (any Actor)? = #isolation,
-  _ body: (isolated (any Actor)?) async throws -> R
-) async throws -> R where R: Sendable {
-  try await body(Configuration.current?.defaultIsolationContext ?? isolation)
+public var __defaultIsolationContext: (any Actor)? {
+  Configuration.current?.defaultIsolationContext ?? #isolation
 }
 
 /// Run a test function as an `XCTestCase`-compatible method.

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -504,36 +504,7 @@ extension Test {
   value
 }
 
-#if !SWT_NO_GLOBAL_ACTORS
-/// Invoke a function isolated to the main actor if appropriate.
-///
-/// - Parameters:
-///   - thenBody: The function to invoke, isolated to the main actor, if actor
-///     isolation is required.
-///   - elseBody: The function to invoke if actor isolation is not required.
-///
-/// - Returns: Whatever is returned by `thenBody` or `elseBody`.
-///
-/// - Throws: Whatever is thrown by `thenBody` or `elseBody`.
-///
-/// `thenBody` and `elseBody` should represent the same function with differing
-/// actor isolation. Which one is invoked depends on whether or not synchronous
-/// test functions need to run on the main actor.
-///
-/// - Warning: This function is used to implement the `@Test` macro. Do not call
-///   it directly.
-public func __ifMainActorIsolationEnforced<R>(
-  _ thenBody: @Sendable @MainActor () async throws -> R,
-  else elseBody: @Sendable () async throws -> R
-) async throws -> R where R: Sendable {
-  if Configuration.current?.isMainActorIsolationEnforced == true {
-    try await thenBody()
-  } else {
-    try await elseBody()
-  }
-}
-#else
-/// Invoke a function.
+/// Invoke a function isolated to the default isolation context.
 ///
 /// - Parameters:
 ///   - body: The function to invoke.
@@ -542,20 +513,17 @@ public func __ifMainActorIsolationEnforced<R>(
 ///
 /// - Throws: Whatever is thrown by `body`.
 ///
-/// This function simply invokes `body`. Its signature matches that of the same
-/// function when `SWT_NO_GLOBAL_ACTORS` is not defined so that it can be used
-/// during expansion of the `@Test` macro without knowing the value of that
-/// compiler conditional on the target platform.
+/// This function invokes `body` isolated to the default isolation context as
+/// specified when configuring the test run.
 ///
 /// - Warning: This function is used to implement the `@Test` macro. Do not call
 ///   it directly.
-@inlinable public func __ifMainActorIsolationEnforced<R>(
-  _: @Sendable () async throws -> R,
-  else body: @Sendable () async throws -> R
+public func __withDefaultIsolationContext<R>(
+  isolation: isolated (any Actor)? = #isolation,
+  _ body: (isolated (any Actor)?) async throws -> R
 ) async throws -> R where R: Sendable {
-  try await body()
+  try await body(Configuration.current?.defaultIsolationContext ?? isolation)
 }
-#endif
 
 /// Run a test function as an `XCTestCase`-compatible method.
 ///

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -508,8 +508,8 @@ extension Test {
 ///
 /// - Warning: This property is used to implement the `@Test` macro. Do not call
 ///   it directly.
-public var __defaultIsolationContext: (any Actor)? {
-  Configuration.current?.defaultIsolationContext ?? #isolation
+public var __defaultSynchronousIsolationContext: (any Actor)? {
+  Configuration.current?.defaultSynchronousIsolationContext ?? #isolation
 }
 
 /// Run a test function as an `XCTestCase`-compatible method.

--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -26,6 +26,28 @@ extension FunctionDeclSyntax {
       .contains(.keyword(.mutating))
   }
 
+  /// Whether or not this function is a `nonisolated` function.
+  var isNonisolated: Bool {
+    modifiers.lazy
+      .map(\.name.tokenKind)
+      .contains(.keyword(.nonisolated))
+  }
+
+  /// The `isolated` parameter of this function, if any.
+  var isolatedParameter: FunctionParameterSyntax? {
+    signature.parameterClause.parameters.first { parameter in
+      guard let type = parameter.type.as(AttributedTypeSyntax.self) else {
+        return false
+      }
+      return type.specifiers.contains { specifier in
+        guard case let .simpleTypeSpecifier(specifier) = specifier else {
+          return false
+        }
+        return specifier.specifier.tokenKind == .keyword(.isolated)
+      }
+    }
+  }
+
   /// The name of this function including parentheses, parameter labels, and
   /// colons.
   var completeName: String {

--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -33,21 +33,6 @@ extension FunctionDeclSyntax {
       .contains(.keyword(.nonisolated))
   }
 
-  /// The `isolated` parameter of this function, if any.
-  var isolatedParameter: FunctionParameterSyntax? {
-    signature.parameterClause.parameters.first { parameter in
-      guard let type = parameter.type.as(AttributedTypeSyntax.self) else {
-        return false
-      }
-      return type.specifiers.contains { specifier in
-        guard case let .simpleTypeSpecifier(specifier) = specifier else {
-          return false
-        }
-        return specifier.specifier.tokenKind == .keyword(.isolated)
-      }
-    }
-  }
-
   /// The name of this function including parentheses, parameter labels, and
   /// colons.
   var completeName: String {

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -258,7 +258,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
       if functionDecl.isStaticOrClass {
         thunkBody = "_ = \(forwardCall("\(typeName).\(functionDecl.name.trimmed)\(forwardedParamsExpr)"))"
       } else {
-        let instanceName = context.makeUniqueName(thunking: functionDecl)
+        let instanceName = context.makeUniqueName("")
         let varOrLet = functionDecl.isMutating ? "var" : "let"
         thunkBody = """
         \(raw: varOrLet) \(raw: instanceName) = \(forwardInit("\(typeName)()"))

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -292,7 +292,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     // default isolation context. If the suite type is an actor, this will cause
     // a hop off the actor followed by an immediate hop back on, but otherwise
     // should be harmless. Note that we do not support specifying an `isolated`
-    // argument on a test function at this time.
+    // parameter on a test function at this time.
     //
     // We use a second, inner thunk function here instead of just adding the
     // isolation parameter to the "real" thunk because adding it there prevents
@@ -317,7 +317,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
           modifiers: [DeclModifierSyntax(name: .keyword(.isolated))],
           firstName: .wildcardToken(),
           type: "isolated (any Actor)?" as TypeSyntax,
-          defaultValue: InitializerClauseSyntax(value: "Testing.__defaultIsolationContext" as ExprSyntax)
+          defaultValue: InitializerClauseSyntax(value: "Testing.__defaultSynchronousIsolationContext" as ExprSyntax)
         )
       }
 

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -291,12 +291,13 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     // not explicitly isolated to some actor, it should run in the configured
     // default isolation context. If the suite type is an actor, this will cause
     // a hop off the actor followed by an immediate hop back on, but otherwise
-    // should be harmless.
+    // should be harmless. Note that we do not support specifying an `isolated`
+    // argument on a test function at this time.
     //
     // We use a second, inner thunk function here instead of just adding the
     // isolation parameter to the "real" thunk because adding it there prevents
     // correct tuple desugaring of the "real" arguments to the thunk.
-    if functionDecl.signature.effectSpecifiers?.asyncSpecifier == nil && !isMainActorIsolated && !functionDecl.isNonisolated && functionDecl.isolatedParameter == nil {
+    if functionDecl.signature.effectSpecifiers?.asyncSpecifier == nil && !isMainActorIsolated && !functionDecl.isNonisolated {
       // Get a unique name for this secondary thunk. We don't need it to be
       // uniqued against functionDecl because it's interior to the "real" thunk,
       // so its name can't conflict with any other names visible in this scope.

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -325,8 +325,6 @@ struct TestDeclarationMacroTests {
       ("@Test @_unavailableFromAsync @MainActor func f() {}", nil, "MainActor.run"),
       ("@Test @available(*, noasync) func f() {}", nil, "__requiringTry"),
       ("@Test @_unavailableFromAsync func f() {}", nil, "__requiringTry"),
-      ("@Test(arguments: []) func f(i: borrowing Int) {}", nil, "copy"),
-      ("@Test(arguments: []) func f(_ i: borrowing Int) {}", nil, "copy"),
       ("@Test(arguments: []) func f(f: () -> String) {}", "(() -> String).self", nil),
       ("struct S {\n\t@Test func testF() {} }", nil, "__invokeXCTestCaseMethod"),
       ("struct S {\n\t@Test func testF() throws {} }", nil, "__invokeXCTestCaseMethod"),

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -99,11 +99,27 @@ struct SendableTests: Sendable {
   @Test(.hidden, arguments: FixtureData.zeroUpTo100)
   func parameterizedBorrowingAsync(i: borrowing Int) async {}
 
+  @MainActor
+  @Test(.hidden, arguments: FixtureData.zeroUpTo100)
+  func parameterizedBorrowingMainActor(i: borrowing Int) {}
+
+  @available(*, noasync)
+  @Test(.hidden, arguments: FixtureData.zeroUpTo100)
+  func parameterizedBorrowingNoasync(i: borrowing Int) {}
+
   @Test(.hidden, arguments: FixtureData.zeroUpTo100)
   func parameterizedConsuming(i: consuming Int) {}
 
   @Test(.hidden, arguments: FixtureData.zeroUpTo100)
   func parameterizedConsumingAsync(i: consuming Int) async { }
+
+  @MainActor
+  @Test(.hidden, arguments: FixtureData.zeroUpTo100)
+  func parameterizedConsumingMainActor(i: consuming Int) {}
+
+  @available(*, noasync)
+  @Test(.hidden, arguments: FixtureData.zeroUpTo100)
+  func parameterizedConsumingNoasync(i: consuming Int) {}
 
   @Test(.hidden, arguments: FixtureData.stringReturningClosureArray)
   func parameterizedAcceptingFunction(f: @Sendable () -> String) {}

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -822,6 +822,10 @@ final class RunnerTests: XCTestCase {
     @Test(.hidden) @MainActor func asyncButRunsOnMainActor() async {
       XCTAssertTrue(Thread.isMainThread)
     }
+
+    @Test(.hidden) nonisolated func runsNonisolated() {
+      XCTAssertFalse(Thread.isMainThread)
+    }
   }
 
   @available(*, deprecated)

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -824,6 +824,7 @@ final class RunnerTests: XCTestCase {
     }
   }
 
+  @available(*, deprecated)
   func testSynchronousTestFunctionRunsOnMainActorWhenEnforced() async {
     var configuration = Configuration()
     configuration.isMainActorIsolationEnforced = true
@@ -832,6 +833,19 @@ final class RunnerTests: XCTestCase {
     }
 
     configuration.isMainActorIsolationEnforced = false
+    await Self.$isMainActorIsolationEnforced.withValue(false) {
+      await runTest(for: MainActorIsolationTests.self, configuration: configuration)
+    }
+  }
+
+  func testSynchronousTestFunctionRunsInDefaultIsolationContext() async {
+    var configuration = Configuration()
+    configuration.defaultIsolationContext = MainActor.shared
+    await Self.$isMainActorIsolationEnforced.withValue(true) {
+      await runTest(for: MainActorIsolationTests.self, configuration: configuration)
+    }
+
+    configuration.defaultIsolationContext = nil
     await Self.$isMainActorIsolationEnforced.withValue(false) {
       await runTest(for: MainActorIsolationTests.self, configuration: configuration)
     }

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -848,12 +848,12 @@ final class RunnerTests: XCTestCase {
 
   func testSynchronousTestFunctionRunsInDefaultIsolationContext() async {
     var configuration = Configuration()
-    configuration.defaultIsolationContext = MainActor.shared
+    configuration.defaultSynchronousIsolationContext = MainActor.shared
     await Self.$isMainActorIsolationEnforced.withValue(true) {
       await runTest(for: MainActorIsolationTests.self, configuration: configuration)
     }
 
-    configuration.defaultIsolationContext = nil
+    configuration.defaultSynchronousIsolationContext = nil
     await Self.$isMainActorIsolationEnforced.withValue(false) {
       await runTest(for: MainActorIsolationTests.self, configuration: configuration)
     }

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -807,7 +807,11 @@ final class RunnerTests: XCTestCase {
   @TaskLocal static var isMainActorIsolationEnforced = false
 
   @Suite(.hidden) struct MainActorIsolationTests {
-    @Test(.hidden) func mustRunOnMainActor() {
+    @Test(.hidden) func mightRunOnMainActor() {
+      XCTAssertEqual(Thread.isMainThread, isMainActorIsolationEnforced)
+    }
+
+    @Test(.hidden, arguments: 0 ..< 10) func mightRunOnMainActor(arg: Int) {
       XCTAssertEqual(Thread.isMainThread, isMainActorIsolationEnforced)
     }
 


### PR DESCRIPTION
This PR replaces `Configuration.isMainActorIsolationEnforced` with a new property `Configuration.defaultIsolationContext` which can be set to any actor, not just the main actor. This property is then used as the isolation context for synchronous test functions that are not otherwise actor-isolated.

The typical use case for this property would be to set it to `MainActor.shared` so that synchronous test functions run on the main actor, but a testing tool might want to instead run them all on another actor or serial executor for performance (or other) reasons.

This change isn't just speculative: it allows us to simplify the macro-generated thunk for synchronous test functions so that it does not need to emit the body of the thunk twice (once for the main actor, once for non-isolated.) This change wasn't possible before `#isolation` was introduced, but we'd already added `Configuration.isMainActorIsolationEnforced` when that happened so the timing didn't line up.

By rewriting this part of the macro expansion, we're able to toss a bunch of support code that isn't needed anymore. Yay!

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
