### PR TITLE
Simplify the thunk names we generate for test functions.

### DIFF
--- a/Tests/TestingMacrosTests/UniqueIdentifierTests.swift
+++ b/Tests/TestingMacrosTests/UniqueIdentifierTests.swift
@@ -27,16 +27,9 @@ struct UniqueIdentifierTests {
     return BasicMacroExpansionContext().makeUniqueName(thunking: functionDecl).text
   }
 
-  @Test("Thunk identifiers contain a function's name")
-  func thunkNameContainsFunctionName() throws {
-    let uniqueName = try makeUniqueName("func someDistinctFunctionName() async throws")
-    #expect(uniqueName.contains("someDistinctFunctionName"))
-  }
-
   @Test("Thunk identifiers do not contain backticks")
   func noBackticks() throws {
     let uniqueName = try makeUniqueName("func `someDistinctFunctionName`() async throws")
-    #expect(uniqueName.contains("someDistinctFunctionName"))
 
     #expect(!uniqueName.contains("`"))
   }
@@ -44,19 +37,15 @@ struct UniqueIdentifierTests {
   @Test("Thunk identifiers do not contain arbitrary Unicode")
   func noArbitraryUnicode() throws {
     let uniqueName = try makeUniqueName("func someDistinctFunction🌮Name🐔() async throws")
-    #expect(uniqueName.contains("someDistinctFunction"))
 
     #expect(!uniqueName.contains("🌮"))
     #expect(!uniqueName.contains("🐔"))
-    #expect(uniqueName.contains("Name"))
   }
 
   @Test("Argument types influence generated identifiers")
   func argumentTypes() throws {
     let uniqueNameWithInt = try makeUniqueName("func someDistinctFunctionName(i: Int) async throws")
-    #expect(uniqueNameWithInt.contains("someDistinctFunctionName"))
     let uniqueNameWithUInt = try makeUniqueName("func someDistinctFunctionName(i: UInt) async throws")
-    #expect(uniqueNameWithUInt.contains("someDistinctFunctionName"))
 
     #expect(uniqueNameWithInt != uniqueNameWithUInt)
   }
@@ -64,13 +53,9 @@ struct UniqueIdentifierTests {
   @Test("Effects influence generated identifiers")
   func effects() throws {
     let uniqueName = try makeUniqueName("func someDistinctFunctionName()")
-    #expect(uniqueName.contains("someDistinctFunctionName"))
     let uniqueNameAsync = try makeUniqueName("func someDistinctFunctionName() async")
-    #expect(uniqueNameAsync.contains("someDistinctFunctionName"))
     let uniqueNameThrows = try makeUniqueName("func someDistinctFunctionName() throws")
-    #expect(uniqueNameThrows.contains("someDistinctFunctionName"))
     let uniqueNameAsyncThrows = try makeUniqueName("func someDistinctFunctionName() async throws")
-    #expect(uniqueNameAsyncThrows.contains("someDistinctFunctionName"))
 
     #expect(uniqueName != uniqueNameAsync)
     #expect(uniqueName != uniqueNameThrows)
@@ -88,5 +73,12 @@ struct UniqueIdentifierTests {
     #expect(uniqueName1 != uniqueName2)
     #expect(uniqueName1 != uniqueName3)
     #expect(uniqueName2 != uniqueName3)
+  }
+
+  @Test("Body does not influence generated identifiers")
+  func body() throws {
+    let uniqueName1 = try makeUniqueName("func f() { abc() }")
+    let uniqueName2 = try makeUniqueName("func f() { def() }")
+    #expect(uniqueName1 == uniqueName2)
   }
 }


### PR DESCRIPTION
Parameterized test functions with the same name but different argument types currently get the same generated names from swift-syntax, so we do some additional decorating to ensure uniqueness. This results in very long symbol names that `swift-demangle` has trouble with.

This PR changes the decorating formula. Previously, we would include a copy of the test function's signature (stripped of whitespace, Unicode, and non-identifier-friendly ASCII) and, if the identifier contained non-ASCII characters, the CRC32 of the identifier for further uniqueness. This change drops the copy of the identifier name and always includes the CRC32. Collisions are only possible for fully-qualified test function names that are _identical_, and I naïvely judge the risk of those collisions to be sufficiently low that we can make this change.

For `ZipTests.allElementsEqual😀(i:j:)` we currently generate a thunk named:

```
$s12TestingTests03ZipB0V0022allElementsEqual_oxFJo4TestfMp_43funcallElementsEqual__i_Int_j_Int__5bcb7b35fMu_
```

This change would change it to:

```
$s12TestingTests03ZipB0V0022allElementsEqual_oxFJo4TestfMp_9Z5bcb7b35fMu_
```

Which demangles to:

```
$s12TestingTests03ZipB0V0022allElementsEqual_oxFJo4TestfMp_9Z5bcb7b35fMu_ ---> unique name #1 of Z5bcb7b35 in peer macro @Test expansion #1 of allElementsEqual😀 in TestingTests.ZipTests
```

The benefit of the change is that the generated names are shorter and easier to read when expanding a macro, and play better with the demangler. There may also be some benefit on Windows where the linker has a 65KB symbol name cap, although we're not exporting these symbols so probably not.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
