### PR TITLE
Fix a test that fails to compile on 32-bit targets.

### DIFF
--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1120,7 +1120,7 @@ final class IssueTests: XCTestCase {
     await Test {
       let range_int8: ClosedRange<Int> = Int(Int8.min)...Int(Int8.max)
       let range_uint16: ClosedRange<Int> = Int(UInt16.min)...Int(UInt16.max)
-      let range_int64: ClosedRange<Int> = Int(Int64.min)...Int(Int64.max)
+      let range_int64: ClosedRange<Int64> = Int64.min...Int64.max
 
       #expect(range_int8 == (-127)...127, "incorrect min")
       #expect(range_int8 == (-128)...128, "incorrect max")


### PR DESCRIPTION
An expression in `testCollectionDifferenceSkippedForRanges()` overflows on 32-bit targets like watchOS. This fixes that.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
