### PR TITLE
Work around a compiler crash trying to demangle an expression macro inside an attached macro expansion.

### DIFF
--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -24,7 +24,7 @@ struct EventTests {
               differenceDescription: "Difference Description",
               isPassing: false,
               isRequired: true,
-              sourceLocation: #_sourceLocation
+              sourceLocation: SourceLocation(fileID: "M/f.swift", filePath: "/f.swift", line: 1, column: 1)
             )
           ),
           Event.Kind.testSkipped(
@@ -32,7 +32,7 @@ struct EventTests {
               comment: "Comment",
               sourceContext: SourceContext(
                 backtrace: Backtrace.current(),
-                sourceLocation: #_sourceLocation
+                sourceLocation: SourceLocation(fileID: "M/f.swift", filePath: "/f.swift", line: 1, column: 1)
               )
             )
           ),


### PR DESCRIPTION
We've started getting a crash expanding a test where `#_sourceLocation` is explicitly written inside the arguments array.

Works around rdar://137450977.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
