### PR TITLE
Stub out symbolication on platforms without dynamic linking/loading.

### DIFF
--- a/Sources/Testing/SourceAttribution/Backtrace+Symbolication.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace+Symbolication.swift
@@ -61,6 +61,7 @@ extension Backtrace {
   public func symbolicate(_ mode: SymbolicationMode) -> [SymbolicatedAddress] {
     var result = addresses.map { SymbolicatedAddress(address: $0) }
 
+#if !SWT_NO_DYNAMIC_LINKING
 #if SWT_TARGET_OS_APPLE
     for (i, address) in addresses.enumerated() {
       var info = Dl_info()
@@ -94,8 +95,6 @@ extension Backtrace {
         }
       }
     }
-#elseif os(WASI)
-    // WASI does not currently support backtracing let alone symbolication.
 #else
 #warning("Platform-specific implementation missing: backtrace symbolication unavailable")
 #endif
@@ -109,6 +108,7 @@ extension Backtrace {
         return symbolicatedAddress
       }
     }
+#endif
 
     return result
   }

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -150,6 +150,7 @@ struct BacktraceTests {
   }
 #endif
 
+#if !SWT_NO_DYNAMIC_LINKING
   @Test("Symbolication", arguments: [Backtrace.SymbolicationMode.mangled, .demangled])
   func symbolication(mode: Backtrace.SymbolicationMode) {
     let backtrace = Backtrace.current()
@@ -159,4 +160,5 @@ struct BacktraceTests {
       print(symbolNames.map(String.init(describingForTest:)).joined(separator: "\n"))
     }
   }
+#endif
 }


### PR DESCRIPTION
For instance, WASI doesn't have symbolication, so this code is dead there.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
