### PR TITLE
Remove unintentional label from 'isolated' parameter on a thunk emitted by @Test

### DIFF
--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -314,7 +314,6 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
           thunkParam
         }
         FunctionParameterSyntax(
-          modifiers: [DeclModifierSyntax(name: .keyword(.isolated))],
           firstName: .wildcardToken(),
           type: "isolated (any Actor)?" as TypeSyntax,
           defaultValue: InitializerClauseSyntax(value: "Testing.__defaultSynchronousIsolationContext" as ExprSyntax)


### PR DESCRIPTION
Small cleanup from the changes in #747: Remove an unintentional parameter label which resulted in a parameter being named `isolated_` when it should be just `_`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
