### PR TITLE
Combine the test discovery implementations for WASI and static Mach-O.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -162,6 +162,13 @@ extension Array where Element == PackageDescription.CXXSetting {
   static var packageSettings: Self {
     var result = Self()
 
+    result += [
+      .define("SWT_NO_EXIT_TESTS", .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android])),
+      .define("SWT_NO_SNAPSHOT_TYPES", .when(platforms: [.linux, .windows, .wasi])),
+      .define("SWT_NO_DYNAMIC_LINKING", .when(platforms: [.wasi])),
+      .define("SWT_NO_PIPES", .when(platforms: [.wasi])),
+    ]
+
     // Capture the testing library's version as a C++ string constant.
     if let git = Context.gitInformation {
       let testingLibraryVersion = if let tag = git.currentTag {

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -488,6 +488,8 @@ extern "C" const char sectionBegin __asm__("__start_swift5_type_metadata");
 extern "C" const char sectionEnd __asm__("__stop_swift5_type_metadata");
 #else
 #warning Platform-specific implementation missing: Runtime test discovery unavailable (static)
+static const char sectionBegin = 0;
+static const char& sectionEnd = sectionBegin;
 #endif
 
 template <typename SectionEnumerator>


### PR DESCRIPTION
This PR reduces code duplication between the two supported platforms that do not use dynamic linking during test discovery.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
