### PR TITLE
Add a return type for exit tests.

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(Testing
   Events/TimeValue.swift
   ExitTests/ExitCondition.swift
   ExitTests/ExitTest.swift
+  ExitTests/ExitTest.Result.swift
   ExitTests/SpawnProcess.swift
   ExitTests/WaitFor.swift
   Expectations/Expectation.swift

--- a/Sources/Testing/ExitTests/ExitTest.Result.swift
+++ b/Sources/Testing/ExitTests/ExitTest.Result.swift
@@ -1,0 +1,86 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if SWT_NO_EXIT_TESTS
+@available(*, unavailable, message: "Exit tests are not available on this platform.")
+#endif
+extension ExitTest {
+  /// A type representing the result of an exit test after it has exited and
+  /// returned control to the calling test function.
+  ///
+  /// Both ``expect(exitsWith:_:sourceLocation:performing:)`` and
+  /// ``require(exitsWith:_:sourceLocation:performing:)`` return instances of
+  /// this type.
+  public struct Result: Sendable {
+    /// The exit condition the exit test exited with.
+    ///
+    /// When the exit test passes, the value of this property is equal to the
+    /// value of the `expectedExitCondition` argument passed to
+    /// ``expect(exitsWith:_:sourceLocation:performing:)`` or to
+    /// ``require(exitsWith:_:sourceLocation:performing:)``. You can compare two
+    /// instances of ``ExitCondition`` with ``ExitCondition/==(lhs:rhs:)``.
+    public var exitCondition: ExitCondition
+
+    /// Whatever error might have been thrown when trying to invoke the exit
+    /// test that produced this result.
+    ///
+    /// This property is not part of the public interface of the testing
+    /// library.
+    var caughtError: (any Error)?
+
+    @_spi(ForToolsIntegrationOnly)
+    public init(exitCondition: ExitCondition) {
+      self.exitCondition = exitCondition
+    }
+
+    /// Initialize an instance of this type representing the result of an exit
+    /// test that failed to run due to a system error or other failure.
+    ///
+    /// - Parameters:
+    ///   - exitCondition: The exit condition the exit test exited with, if
+    ///     available. The default value of this argument is
+    ///     ``ExitCondition/failure`` for lack of a more accurate one.
+    ///   - error: The error associated with the exit test on failure, if any.
+    ///
+    /// If an error (e.g. a failure calling `posix_spawn()`) occurs in the exit
+    /// test handler configured by the exit test's host environment, the exit
+    /// test handler should throw that error. The testing library will then
+    /// record it appropriately.
+    ///
+    /// When used with `#require(exitsWith:)`, an instance initialized with this
+    /// initializer will throw `error`.
+    ///
+    /// This initializer is not part of the public interface of the testing
+    /// library.
+    init(exitCondition: ExitCondition = .failure, catching error: any Error) {
+      self.exitCondition = exitCondition
+      self.caughtError = error
+    }
+
+    /// Handle this instance as if it were returned from a call to `#expect()`.
+    ///
+    /// - Warning: This function is used to implement the `#expect()` and
+    ///   `#require()` macros. Do not call it directly.
+    @inlinable public func __expected() -> Self {
+      self
+    }
+
+    /// Handle this instance as if it were returned from a call to `#require()`.
+    ///
+    /// - Warning: This function is used to implement the `#expect()` and
+    ///   `#require()` macros. Do not call it directly.
+    public func __required() throws -> Self {
+      if let caughtError {
+        throw caughtError
+      }
+      return self
+    }
+  }
+}

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -207,8 +207,8 @@ func callExitTest(
     let backtrace = Backtrace(forFirstThrowOf: error) ?? .current()
     let issue = Issue(
       kind: .system,
-      comments: ["\(String(describingForTest: error))"] + comments(),
-      sourceContext: .init(backtrace: backtrace, sourceLocation: sourceLocation)
+      comments: comments() + CollectionOfOne(Comment(rawValue: String(describingForTest: error))),
+      sourceContext: SourceContext(backtrace: backtrace, sourceLocation: sourceLocation)
     )
     issue.record(configuration: configuration)
 

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -422,6 +422,10 @@ public macro require<R>(
 ///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///
+/// - Returns: An instance of ``ExitTest/Result`` describing the state of the
+///   exit test when it exited including the actual exit condition that it
+///   reported to the testing library.
+///
 /// Use this overload of `#expect()` when an expression will cause the current
 /// process to terminate and the nature of that termination will determine if
 /// the test passes or fails. For example, to test that calling `fatalError()`
@@ -485,7 +489,7 @@ public macro require<R>(
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: @convention(thin) () async throws -> Void
-) -> ExitTest.Result? = #externalMacro(module: "TestingMacros", type: "ExitTestExpectMacro")
+) -> ExitTest.Result = #externalMacro(module: "TestingMacros", type: "ExitTestExpectMacro")
 
 /// Check that an expression causes the process to terminate in a given fashion
 /// and throw an error if it did not.
@@ -496,6 +500,10 @@ public macro require<R>(
 ///   - sourceLocation: The source location to which recorded expectations and
 ///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
+///
+/// - Returns: An instance of ``ExitTest/Result`` describing the state of the
+///   exit test when it exited including the actual exit condition that it
+///   reported to the testing library.
 ///
 /// - Throws: An instance of ``ExpectationFailedError`` if the exit condition of
 ///   the child process does not equal `expectedExitCondition`.

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -479,12 +479,13 @@ public macro require<R>(
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
+@discardableResult
 @freestanding(expression) public macro expect(
   exitsWith expectedExitCondition: ExitCondition,
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: @convention(thin) () async throws -> Void
-) = #externalMacro(module: "TestingMacros", type: "ExitTestExpectMacro")
+) -> ExitTest.Result? = #externalMacro(module: "TestingMacros", type: "ExitTestExpectMacro")
 
 /// Check that an expression causes the process to terminate in a given fashion
 /// and throw an error if it did not.
@@ -556,9 +557,10 @@ public macro require<R>(
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
+@discardableResult
 @freestanding(expression) public macro require(
   exitsWith expectedExitCondition: ExitCondition,
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: @convention(thin) () async throws -> Void
-) = #externalMacro(module: "TestingMacros", type: "ExitTestRequireMacro")
+) -> ExitTest.Result = #externalMacro(module: "TestingMacros", type: "ExitTestRequireMacro")

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1148,7 +1148,7 @@ public func __checkClosureCall(
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
   sourceLocation: SourceLocation
-) async -> Result<Void, any Error> {
+) async -> Result<ExitTest.Result, any Error> {
   await callExitTest(
     exitsWith: expectedExitCondition,
     expression: expression,

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1148,7 +1148,7 @@ public func __checkClosureCall(
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
   sourceLocation: SourceLocation
-) async -> Result<ExitTest.Result, any Error> {
+) async -> ExitTest.Result {
   await callExitTest(
     exitsWith: expectedExitCondition,
     expression: expression,

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -32,7 +32,7 @@ extension Issue {
     if case let .errorCaught(error) = kind, let error = error as? SystemError {
       var selfCopy = self
       selfCopy.kind = .system
-      selfCopy.comments.append(Comment(rawValue: String(describing: error)))
+      selfCopy.comments.append(Comment(rawValue: String(describingForTest: error)))
       return selfCopy.record(configuration: configuration)
     }
 

--- a/Sources/Testing/Support/Additions/ResultAdditions.swift
+++ b/Sources/Testing/Support/Additions/ResultAdditions.swift
@@ -23,16 +23,3 @@ extension Result {
     try get()
   }
 }
-
-#if !SWT_NO_EXIT_TESTS
-@_spi(Experimental)
-extension Result where Success == ExitTest.Result {
-  /// Handle this instance as if it were returned from a call to `#expect()`.
-  ///
-  /// - Warning: This function is used to implement the `#expect()` and
-  ///   `#require()` macros. Do not call it directly.
-  @inlinable public func __expected() -> Success? {
-    try? get()
-  }
-}
-#endif

--- a/Sources/Testing/Support/Additions/ResultAdditions.swift
+++ b/Sources/Testing/Support/Additions/ResultAdditions.swift
@@ -24,6 +24,7 @@ extension Result {
   }
 }
 
+#if !SWT_NO_EXIT_TESTS
 @_spi(Experimental)
 extension Result where Success == ExitTest.Result {
   /// Handle this instance as if it were returned from a call to `#expect()`.
@@ -34,3 +35,4 @@ extension Result where Success == ExitTest.Result {
     try? get()
   }
 }
+#endif

--- a/Sources/Testing/Support/Additions/ResultAdditions.swift
+++ b/Sources/Testing/Support/Additions/ResultAdditions.swift
@@ -23,3 +23,14 @@ extension Result {
     try get()
   }
 }
+
+@_spi(Experimental)
+extension Result where Success == ExitTest.Result {
+  /// Handle this instance as if it were returned from a call to `#expect()`.
+  ///
+  /// - Warning: This function is used to implement the `#expect()` and
+  ///   `#require()` macros. Do not call it directly.
+  @inlinable public func __expected() -> Success? {
+    try? get()
+  }
+}

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -89,7 +89,7 @@ private import _TestingInternals
 
       // Mock an exit test where the process exits successfully.
       configuration.exitTestHandler = { _ in
-        return .exitCode(EXIT_SUCCESS)
+        return ExitTest.Result(exitCondition: .exitCode(EXIT_SUCCESS))
       }
       await Test {
         await #expect(exitsWith: .success) {}
@@ -97,7 +97,7 @@ private import _TestingInternals
 
       // Mock an exit test where the process exits with a generic failure.
       configuration.exitTestHandler = { _ in
-        return .failure
+        return ExitTest.Result(exitCondition: .failure)
       }
       await Test {
         await #expect(exitsWith: .failure) {}
@@ -113,7 +113,7 @@ private import _TestingInternals
 
       // Mock an exit test where the process exits with a particular error code.
       configuration.exitTestHandler = { _ in
-        return .exitCode(123)
+        return ExitTest.Result(exitCondition: .exitCode(123))
       }
       await Test {
         await #expect(exitsWith: .failure) {}
@@ -122,7 +122,7 @@ private import _TestingInternals
 #if !os(Windows)
       // Mock an exit test where the process exits with a signal.
       configuration.exitTestHandler = { _ in
-        return .signal(SIGABRT)
+        return ExitTest.Result(exitCondition: .signal(SIGABRT))
       }
       await Test {
         await #expect(exitsWith: .signal(SIGABRT)) {}
@@ -151,7 +151,7 @@ private import _TestingInternals
 
       // Mock exit tests that were expected to fail but passed.
       configuration.exitTestHandler = { _ in
-        return .exitCode(EXIT_SUCCESS)
+        return ExitTest.Result(exitCondition: .exitCode(EXIT_SUCCESS))
       }
       await Test {
         await #expect(exitsWith: .failure) {}
@@ -168,7 +168,7 @@ private import _TestingInternals
 #if !os(Windows)
       // Mock exit tests that unexpectedly signalled.
       configuration.exitTestHandler = { _ in
-        return .signal(SIGABRT)
+        return ExitTest.Result(exitCondition: .signal(SIGABRT))
       }
       await Test {
         await #expect(exitsWith: .exitCode(EXIT_SUCCESS)) {}


### PR DESCRIPTION
This PR adds a new structure, `ExitTest.Result`, that is returned from a call to `#expect(exitsWith:)` or `#require(exitsWith:)`. It currently contains the actual exit condition of the test (which should equal the expected exit condition on success) but in the future we can add additional properties such as the standard output and standard error streams.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
