### PR TITLE
Fix missing newlines in error JSON propagated from an exit test.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -312,7 +312,7 @@ extension ExitTest {
     let eventHandler = ABIv0.Record.eventHandler(encodeAsJSONLines: true) { json in
       _ = try? _backChannelForEntryPoint?.withLock {
         try _backChannelForEntryPoint?.write(json)
-        try _backChannelForEntryPoint.write("\n")
+        try _backChannelForEntryPoint?.write("\n")
       }
     }
     configuration.eventHandler = { event, eventContext in

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -310,7 +310,10 @@ extension ExitTest {
     // Only forward issue-recorded events. (If we start handling other kinds of
     // events in the future, we can forward them too.)
     let eventHandler = ABIv0.Record.eventHandler(encodeAsJSONLines: true) { json in
-      try? _backChannelForEntryPoint?.write(json)
+      _ = try? _backChannelForEntryPoint?.withLock {
+        try _backChannelForEntryPoint?.write(json)
+        try _backChannelForEntryPoint.write("\n")
+      }
     }
     configuration.eventHandler = { event, eventContext in
       if case .issueRecorded = event.kind {


### PR DESCRIPTION
We weren't emitting newlines between exit test backchannel JSON blobs. Oops.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
