### PR TITLE
Add `.index-build` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/.index-build
 /build
 /Packages
 /*.xcodeproj


### PR DESCRIPTION
### Motivation:

The `.index-build` directory is created by SourceKit-LSP when background indexing is enabled, contains auto-generated transient files similar in purpose to `.build`, and it should be ignored.
  
### Modifications:

Updated `.gitignore` file accordingly.

### Result:

Developers no longer need to exclude `.index-build` manually from their commits when editing the package with SourceKit-LSP.

### Checklist:

~- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).~
~- [ ] If public symbols are renamed or modified, DocC references should be updated.~
