### PR TITLE
Update documentation to explain misconfigurations of `SWT_` conditions.

### DIFF
--- a/Documentation/Porting.md
+++ b/Documentation/Porting.md
@@ -58,6 +58,16 @@ These warnings may be emitted by our internal C++ module (`_TestingInternals`)
 or by our library module (`Testing`). Both indicate areas of our code that need
 platform-specific attention.
 
+> [!NOTE]
+> Rarely, you may encounter errors of a similar form:
+> 
+> > 🛑 ERROR: Platform-specific misconfiguration: ...
+> 
+> These errors are produced when the configuration you're trying to build has
+> conflicting requirements (for example, attempting to enable support for pipes
+> without also enabling support for file I/O.) You should be able to resolve
+> these issues by updating Package.swift and/or CompilerSettings.cmake.
+
 Most platform dependencies can be resolved through the use of platform-specific
 API. For example, Swift Testing uses the C11 standard [`timespec`](https://en.cppreference.com/w/c/chrono/timespec)
 type to accurately track the durations of test runs. If you are porting Swift

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -10,6 +10,15 @@
 
 private import _TestingInternals
 
+#if !SWT_NO_EXIT_TESTS
+#if SWT_NO_PIPES
+#error("Platform-specific misconfiguration: support for exit tests requires support for (anonymous) pipes")
+#endif
+#if SWT_NO_PROCESS_SPAWNING
+#error("Platform-specific misconfiguration: support for exit tests requires support for process spawning")
+#endif
+#endif
+
 /// A type describing an exit test.
 ///
 /// Instances of this type describe an exit test defined by the test author and
@@ -19,7 +28,6 @@ private import _TestingInternals
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 public struct ExitTest: Sendable, ~Copyable {
-#if !SWT_NO_EXIT_TESTS
   /// The expected exit condition of the exit test.
   @_spi(ForToolsIntegrationOnly)
   public var expectedExitCondition: ExitCondition
@@ -33,7 +41,12 @@ public struct ExitTest: Sendable, ~Copyable {
   /// processes, so it can be used to uniquely identify an exit test at runtime.
   @_spi(ForToolsIntegrationOnly)
   public var sourceLocation: SourceLocation
+}
 
+#if !SWT_NO_EXIT_TESTS
+// MARK: - Invocation
+
+extension ExitTest {
   /// Disable crash reporting, crash logging, or core dumps for the current
   /// process.
   private static func _disableCrashReporting() {
@@ -100,13 +113,8 @@ public struct ExitTest: Sendable, ~Copyable {
     let expectingFailure = expectedExitCondition == .failure
     exit(expectingFailure ? EXIT_SUCCESS : EXIT_FAILURE)
   }
-#endif
 }
 
-#if !SWT_NO_EXIT_TESTS
-#if SWT_NO_PIPES
-#error("Support for exit tests requires support for (anonymous) pipes.")
-#endif
 // MARK: - Discovery
 
 /// A protocol describing a type that contains an exit test.

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -10,6 +10,12 @@
 
 internal import _TestingInternals
 
+#if !SWT_NO_PIPES
+#if SWT_NO_FILE_IO
+#error("Platform-specific misconfiguration: support for (anonymous) pipes requires support for file I/O")
+#endif
+#endif
+
 #if !SWT_NO_FILE_IO
 /// A type representing a file handle.
 ///


### PR DESCRIPTION
This PR was supposed to be part of #769, but I must have blown away a local commit because it didn't make it into that PR.

This PR updates Porting.md to explain when a developer might encounter an error due to mismatched `SWT_` conditions. It ensures that exit tests require process spawning to be enabled/implemented by adding a dependency between `SWT_NO_PROCESS_SPAWNING` and `SWT_NO_EXIT_TESTS`.

This PR also tweaks which bits of `ExitTest` are exposed on platforms that do not support exit tests at all. The type needs to be exposed so that `ExitTest.Result` is exposed so that we can correctly expose `#expect(exitsWith:)` and `#require(exitsWith:)` while marking them unavailable, as opposed to hiding the macros and not giving a developer clear diagnostics.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
