### PR TITLE
Ensure trailing trivia is trimmed from @Suite trait expressions

### DIFF
--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -174,7 +174,7 @@ struct AttributeInfo {
     }
     arguments.append(Argument(label: .identifier("traits"), expression: ArrayExprSyntax {
       for traitExpr in traits {
-        ArrayElementSyntax(expression: traitExpr)
+        ArrayElementSyntax(expression: traitExpr).trimmed
       }
     }))
 

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -228,6 +228,11 @@ struct TestsWithAsyncArguments {
 )
 func parameterizedTestWithTrailingComment(value: Int) {}
 
+@Suite(
+  .serialized // Meaningful trivia: This line comment should be omitted during macro expansion
+)
+private struct SuiteWithTraitContainingTrailingComment {}
+
 @Test(.hidden) func // Meaningful trivia: intentional newline before name
 globalMultiLineTestDecl() async {}
 


### PR DESCRIPTION
This ensures that if a `@Suite` includes one or more trait expression which includes trailing trivia, such as a `//`-style line comment, it is trimmed so that the macro expands to valid code.

Resolves #777

### Checklist:

- [X] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [X] If public symbols are renamed or modified, DocC references should be updated.
