### PR TITLE
Make `ExitTestArtifacts.observedValues` properly sendable.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -39,7 +39,7 @@ public struct ExitTest: Sendable, ~Copyable {
   /// Key paths are not sendable because the properties they refer to may or may
   /// not be, so this property needs to be `nonisolated(unsafe)`. It is safe to
   /// use it in this fashion because `ExitTestArtifacts` is sendable.
-  fileprivate nonisolated(unsafe) var _observedValues = [PartialKeyPath<ExitTestArtifacts>]()
+  fileprivate var _observedValues = [any PartialKeyPath<ExitTestArtifacts> & Sendable]()
 
   /// Key paths representing results from within this exit test that should be
   /// observed and returned to the caller.
@@ -56,7 +56,7 @@ public struct ExitTest: Sendable, ~Copyable {
   /// Within a child process running an exit test, the value of this property is
   /// otherwise unspecified.
   @_spi(ForToolsIntegrationOnly)
-  public var observedValues: [PartialKeyPath<ExitTestArtifacts>] {
+  public var observedValues: [any PartialKeyPath<ExitTestArtifacts> & Sendable] {
     get {
       var result = _observedValues
       if !result.contains(\.exitCondition) { // O(n), but n <= 3 (no Set needed)
@@ -237,7 +237,7 @@ extension ExitTest {
 /// convention.
 func callExitTest(
   exitsWith expectedExitCondition: ExitCondition,
-  observing observedValues: [PartialKeyPath<ExitTestArtifacts>],
+  observing observedValues: [any PartialKeyPath<ExitTestArtifacts> & Sendable],
   expression: __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -518,7 +518,7 @@ public macro require<R>(
 @discardableResult
 @freestanding(expression) public macro expect(
   exitsWith expectedExitCondition: ExitCondition,
-  observing observedValues: [PartialKeyPath<ExitTestArtifacts>] = [],
+  observing observedValues: [any PartialKeyPath<ExitTestArtifacts> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: @convention(thin) () async throws -> Void
@@ -630,7 +630,7 @@ public macro require<R>(
 @discardableResult
 @freestanding(expression) public macro require(
   exitsWith expectedExitCondition: ExitCondition,
-  observing observedValues: [PartialKeyPath<ExitTestArtifacts>] = [],
+  observing observedValues: [any PartialKeyPath<ExitTestArtifacts> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: @convention(thin) () async throws -> Void

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1142,7 +1142,7 @@ public func __checkClosureCall<R>(
 @_spi(Experimental)
 public func __checkClosureCall(
   exitsWith expectedExitCondition: ExitCondition,
-  observing observedValues: [PartialKeyPath<ExitTestArtifacts>],
+  observing observedValues: [any PartialKeyPath<ExitTestArtifacts> & Sendable],
   performing body: @convention(thin) () -> Void,
   expression: __Expression,
   comments: @autoclosure () -> [Comment],


### PR DESCRIPTION
I was using `nonisolated(unsafe)`. @stmontgomery reminded me that keypaths can now be conditionally sendable per [SE-418](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0418-inferring-sendable-for-methods.md).

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
