### PR TITLE
Fix some compiler conditional uses (`SWT_NO_*`).

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -533,7 +533,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
   return configuration
 }
 
-#if canImport(Foundation) && !SWT_NO_FILE_IO
+#if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
 /// Create an event handler that streams events to the given file using the
 /// specified ABI version.
 ///

--- a/Sources/Testing/ABI/v0/ABIv0.Record+Streaming.swift
+++ b/Sources/Testing/ABI/v0/ABIv0.Record+Streaming.swift
@@ -21,17 +21,17 @@ extension ABIv0.Record {
     // We don't actually expect the JSON encoder to produce output containing
     // newline characters, so in debug builds we'll log a diagnostic message.
     if _slowPath(json.contains(where: \.isASCIINewline)) {
-  #if DEBUG
+#if DEBUG && !SWT_NO_FILE_IO
       let message = Event.ConsoleOutputRecorder.warning(
         "JSON encoder produced one or more newline characters while encoding an event to JSON. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new",
         options: .for(.stderr)
       )
-  #if SWT_TARGET_OS_APPLE
+#if SWT_TARGET_OS_APPLE
       try? FileHandle.stderr.write(message)
-  #else
+#else
       print(message)
-  #endif
-  #endif
+#endif
+#endif
 
       // Remove the newline characters to conform to JSON lines specification.
       var json = Array(json)

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -11,6 +11,9 @@
 private import _TestingInternals
 
 #if !SWT_NO_EXIT_TESTS
+#if SWT_NO_FILE_IO
+#error("Platform-specific misconfiguration: support for exit tests requires support for file I/O")
+#endif
 #if SWT_NO_PIPES
 #error("Platform-specific misconfiguration: support for exit tests requires support for (anonymous) pipes")
 #endif

--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -11,6 +11,10 @@
 internal import _TestingInternals
 
 #if !SWT_NO_PROCESS_SPAWNING
+#if SWT_NO_FILE_IO
+#error("Platform-specific misconfiguration: support for process spawning requires support for file I/O")
+#endif
+
 /// A platform-specific value identifying a process running on the current
 /// system.
 #if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD)


### PR DESCRIPTION
This PR fixes a few edge cases where combinations of feature-disabling compiler conditionals would make the build fail.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
