### PR TITLE
Update documentation for new `confirmation()` overload.

### DIFF
--- a/Sources/Testing/Issues/Confirmation.swift
+++ b/Sources/Testing/Issues/Confirmation.swift
@@ -160,7 +160,7 @@ public func confirmation<R>(
 /// preconditions have been met, and records an issue if they have not.
 ///
 /// If an exact count is expected, use
-/// ``confirmation(_:expectedCount:isolation:sourceLocation:_:)`` instead.
+/// ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-5mqz2`` instead.
 public func confirmation<R>(
   _ comment: Comment? = nil,
   expectedCount: some RangeExpression<Int> & Sequence<Int> & Sendable,
@@ -183,7 +183,7 @@ public func confirmation<R>(
   return try await body(confirmation)
 }
 
-/// An overload of ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-6bkl6``
+/// An overload of ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il``
 /// that handles the unbounded range operator (`...`).
 ///
 /// This overload is necessary because `UnboundedRange` does not conform to
@@ -200,7 +200,7 @@ public func confirmation<R>(
   fatalError("Unsupported")
 }
 
-/// An overload of ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-6bkl6``
+/// An overload of ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il``
 /// that handles the partial-range-through operator (`...n`).
 ///
 /// This overload is necessary because the lower bound of `PartialRangeThrough`
@@ -216,7 +216,7 @@ public func confirmation<R>(
   fatalError("Unsupported")
 }
 
-/// An overload of ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-6bkl6``
+/// An overload of ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il``
 /// that handles the partial-range-up-to operator (`..<n`).
 ///
 /// This overload is necessary because the lower bound of `PartialRangeUpTo` is

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -33,7 +33,7 @@ public struct Issue: Sendable {
     ///     ``Confirmation/confirm(count:)`` should have been called.
     ///
     /// This issue can occur when calling ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-5mqz2``
-    /// or ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-6bkl6``
+    /// or ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il``
     /// when the confirmation passed to these functions' `body` closures is
     /// confirmed too few or too many times.
     indirect case confirmationMiscounted(actual: Int, expected: any RangeExpression & Sendable)
@@ -306,9 +306,9 @@ extension Issue.Kind {
     ///     ``Confirmation/confirm(count:)`` should have been called.
     ///
     /// This issue can occur when calling
-    /// ``confirmation(_:expectedCount:isolation:sourceLocation:_:)`` when the
-    /// confirmation passed to these functions' `body` closures is confirmed too
-    /// few or too many times.
+    /// ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-5mqz2`` when
+    /// the confirmation passed to these functions' `body` closures is confirmed
+    /// too few or too many times.
     indirect case confirmationMiscounted(actual: Int, expected: Int)
 
     /// An issue due to an `Error` being thrown by a test function and caught by

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Issues/Confirmation.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Issues/Confirmation.md
@@ -2,5 +2,4 @@
 
 @Metadata {
   @Available(Swift, introduced: 6.1)
-  @Available(Xcode, introduced: 999.0)
 }

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Issues/Confirmation.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Issues/Confirmation.md
@@ -1,0 +1,6 @@
+# ``Testing/confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il``
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+  @Available(Xcode, introduced: 999.0)
+}

--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -76,7 +76,7 @@ the test when the code doesn't satisfy a requirement, use
 
 - <doc:testing-asynchronous-code>
 - ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-5mqz2``
-- ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-6bkl6``
+- ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il``
 - ``Confirmation``
 
 ### Retrieving information about checked expectations

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -678,7 +678,7 @@ of issues:
   @Column {
     ```swift
     // After
-    struct FoodTruckTests {
+    @Test func grillWorks() async {
       withKnownIssue("Grill is out of fuel") {
         try FoodTruck.shared.grill.start()
       } when: {

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -218,30 +218,24 @@ error if its condition isn't met:
   @Column {
     ```swift
     // Before
-    class FoodTruckTests: XCTestCase {
-      func testEngineWorks() throws {
-        let engine = FoodTruck.shared.engine
-        XCTAssertNotNil(engine.parts.first)
-        XCTAssertGreaterThan(engine.batteryLevel, 0)
-        try engine.start()
-        XCTAssertTrue(engine.isRunning)
-      }
-      ...
+    func testEngineWorks() throws {
+      let engine = FoodTruck.shared.engine
+      XCTAssertNotNil(engine.parts.first)
+      XCTAssertGreaterThan(engine.batteryLevel, 0)
+      try engine.start()
+      XCTAssertTrue(engine.isRunning)
     }
     ```
   }
   @Column {
     ```swift
     // After
-    struct FoodTruckTests {
-      @Test func engineWorks() throws {
-        let engine = FoodTruck.shared.engine
-        try #require(engine.parts.first != nil)
-        #expect(engine.batteryLevel > 0)
-        try engine.start()
-        #expect(engine.isRunning)
-      }
-      ...
+    @Test func engineWorks() throws {
+      let engine = FoodTruck.shared.engine
+      try #require(engine.parts.first != nil)
+      #expect(engine.batteryLevel > 0)
+      try engine.start()
+      #expect(engine.isRunning)
     }
     ```
   }
@@ -258,12 +252,9 @@ with optional expressions to unwrap them:
   @Column {
     ```swift
     // Before
-    class FoodTruckTests: XCTestCase {
-      func testEngineWorks() throws {
-        let engine = FoodTruck.shared.engine
-        let part = try XCTUnwrap(engine.parts.first)
-        ...
-      }
+    func testEngineWorks() throws {
+      let engine = FoodTruck.shared.engine
+      let part = try XCTUnwrap(engine.parts.first)
       ...
     }
     ```
@@ -271,12 +262,9 @@ with optional expressions to unwrap them:
   @Column {
     ```swift
     // After
-    struct FoodTruckTests {
-      @Test func engineWorks() throws {
-        let engine = FoodTruck.shared.engine
-        let part = try #require(engine.parts.first)
-        ...
-      }
+    @Test func engineWorks() throws {
+      let engine = FoodTruck.shared.engine
+      let part = try #require(engine.parts.first)
       ...
     }
     ```
@@ -295,14 +283,11 @@ function. To record an unconditional issue using the testing library, use the
   @Column {
     ```swift
     // Before
-    class FoodTruckTests: XCTestCase {
-      func testEngineWorks() {
-        let engine = FoodTruck.shared.engine
-        guard case .electric = engine else {
-          XCTFail("Engine is not electric")
-          return
-        }
-        ...
+    func testEngineWorks() {
+      let engine = FoodTruck.shared.engine
+      guard case .electric = engine else {
+        XCTFail("Engine is not electric")
+        return
       }
       ...
     }
@@ -311,14 +296,11 @@ function. To record an unconditional issue using the testing library, use the
   @Column {
     ```swift
     // After
-    struct FoodTruckTests {
-      @Test func engineWorks() {
-        let engine = FoodTruck.shared.engine
-        guard case .electric = engine else {
-          Issue.record("Engine is not electric")
-          return
-        }
-        ...
+    @Test func engineWorks() {
+      let engine = FoodTruck.shared.engine
+      guard case .electric = engine else {
+        Issue.record("Engine is not electric")
+        return
       }
       ...
     }
@@ -378,12 +360,9 @@ failure:
   @Column {
     ```swift
     // Before
-    class FoodTruckTests: XCTestCase {
-      func testTruck() async {
-        continueAfterFailure = false
-        XCTAssertTrue(FoodTruck.shared.isLicensed)
-        ...
-      }
+    func testTruck() async {
+      continueAfterFailure = false
+      XCTAssertTrue(FoodTruck.shared.isLicensed)
       ...
     }
     ```
@@ -391,11 +370,8 @@ failure:
   @Column {
     ```swift
     // After
-    struct FoodTruckTests {
-      @Test func truck() throws {
-        try #require(FoodTruck.shared.isLicensed)
-        ...
-      }
+    @Test func truck() throws {
+      try #require(FoodTruck.shared.isLicensed)
       ...
     }
     ```
@@ -429,29 +405,27 @@ be readily converted to use Swift concurrency. The testing library offers
 functionality called _confirmations_ which can be used to implement these tests.
 Instances of ``Confirmation`` are created and used within the scope of the
 functions ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-5mqz2``
-and ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-6bkl6``.
+and ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il``.
 
-Confirmations function similarly to the expectations API of XCTest, however, they don't
-block or suspend the caller while waiting for a condition to be fulfilled.
-Instead, the requirement is expected to be _confirmed_ (the equivalent of
-_fulfilling_ an expectation) before `confirmation()` returns, and records an issue otherwise:
+Confirmations function similarly to the expectations API of XCTest, however,
+they don't block or suspend the caller while waiting for a condition to be
+fulfilled. Instead, the requirement is expected to be _confirmed_ (the
+equivalent of _fulfilling_ an expectation) before `confirmation()` returns, and
+records an issue otherwise:
 
 @Row {
   @Column {
     ```swift
     // Before
-    class FoodTruckTests: XCTestCase {
-      func testTruckEvents() async {
-        let soldFood = expectation(description: "…")
-        FoodTruck.shared.eventHandler = { event in
-          if case .soldFood = event {
-            soldFood.fulfill()
-          }
+    func testTruckEvents() async {
+      let soldFood = expectation(description: "…")
+      FoodTruck.shared.eventHandler = { event in
+        if case .soldFood = event {
+          soldFood.fulfill()
         }
-        await Customer().buy(.soup)
-        await fulfillment(of: [soldFood])
-        ...
       }
+      await Customer().buy(.soup)
+      await fulfillment(of: [soldFood])
       ...
     }
     ```
@@ -459,23 +433,88 @@ _fulfilling_ an expectation) before `confirmation()` returns, and records an iss
   @Column {
     ```swift
     // After
-    struct FoodTruckTests {
-      @Test func truckEvents() async {
-        await confirmation("…") { soldFood in
-          FoodTruck.shared.eventHandler = { event in
-            if case .soldFood = event {
-              soldFood()
-            }
+    @Test func truckEvents() async {
+      await confirmation("…") { soldFood in
+        FoodTruck.shared.eventHandler = { event in
+          if case .soldFood = event {
+            soldFood()
           }
-          await Customer().buy(.soup)
         }
-        ...
+        await Customer().buy(.soup)
       }
       ...
     }
     ```
   }
 }
+
+By default, `XCTestExpectation` expects to be fulfilled exactly once, and will
+record an issue in the current test if it is not fulfilled or if it is fulfilled
+more than once. `Confirmation` behaves the same way and expects to be confirmed
+exactly once by default. You can configure the number of times an expectation
+should be fulfilled by setting its [`expectedFulfillmentCount`](https://developer.apple.com/documentation/xctest/xctestexpectation/2806572-expectedfulfillmentcount)
+property, and you can pass a value for the `expectedCount` argument of
+``confirmation(_:expectedCount:isolation:sourceLocation:_:)-5mqz2`` for the same
+purpose.
+
+`XCTestExpectation` has a property, [`assertForOverFulfill`](https://developer.apple.com/documentation/xctest/xctestexpectation/2806575-assertforoverfulfill),
+which when set to `false` allows an expectation to be fulfilled more times than
+expected without causing a test failure. When using a confirmation, you can pass
+a range to ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il`` as
+its expected count to indicate that it must be confirmed _at least_ some number
+of times:
+
+@Row {
+  @Column {
+    ```swift
+    // Before
+    func testRegularCustomerOrders() async {
+      let soldFood = expectation(description: "…")
+      soldFood.expectedFulfillmentCount = 10
+      soldFood.assertForOverFulfill = false
+      FoodTruck.shared.eventHandler = { event in
+        if case .soldFood = event {
+          soldFood.fulfill()
+        }
+      }
+      for customer in regularCustomers() {
+        await customer.buy(customer.regularOrder)
+      }
+      await fulfillment(of: [soldFood])
+      ...
+    }
+    ```
+  }
+  @Column {
+    ```swift
+    // After
+    @Test func regularCustomerOrders() async {
+      await confirmation(
+        "…",
+        expectedCount: 10...
+      ) { soldFood in
+        FoodTruck.shared.eventHandler = { event in
+          if case .soldFood = event {
+            soldFood()
+          }
+        }
+        for customer in regularCustomers() {
+          await customer.buy(customer.regularOrder)
+        }
+      }
+      ...
+    }
+    ```
+  }
+}
+
+Any range expression with a lower bound (that is, whose type conforms to
+both [`RangeExpression<Int>`](https://developer.apple.com/documentation/swift/rangeexpression)
+and [`Sequence<Int>`](https://developer.apple.com/documentation/swift/sequence))
+can be used with ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il``.
+You must specify a lower bound for the number of confirmations because, without
+one, the testing library cannot tell if an issue should be recorded when there
+have been zero confirmations. 
 
 ### Control whether a test runs
 
@@ -536,12 +575,9 @@ issue:
   @Column {
     ```swift
     // Before
-    class FoodTruckTests: XCTestCase {
-      func testGrillWorks() async {
-        XCTExpectFailure("Grill is out of fuel") {
-          try FoodTruck.shared.grill.start()
-        }
-        ...
+    func testGrillWorks() async {
+      XCTExpectFailure("Grill is out of fuel") {
+        try FoodTruck.shared.grill.start()
       }
       ...
     }
@@ -550,12 +586,9 @@ issue:
   @Column {
     ```swift
     // After
-    struct FoodTruckTests {
-      @Test func grillWorks() async {
-        withKnownIssue("Grill is out of fuel") {
-          try FoodTruck.shared.grill.start()
-        }
-        ...
+    @Test func grillWorks() async {
+      withKnownIssue("Grill is out of fuel") {
+        try FoodTruck.shared.grill.start()
       }
       ...
     }
@@ -577,15 +610,12 @@ instead:
   @Column {
     ```swift
     // Before
-    class FoodTruckTests: XCTestCase {
-      func testGrillWorks() async {
-        XCTExpectFailure(
-          "Grill may need fuel",
-          options: .nonStrict()
-        ) {
-          try FoodTruck.shared.grill.start()
-        }
-        ...
+    func testGrillWorks() async {
+      XCTExpectFailure(
+        "Grill may need fuel",
+        options: .nonStrict()
+      ) {
+        try FoodTruck.shared.grill.start()
       }
       ...
     }
@@ -594,15 +624,12 @@ instead:
   @Column {
     ```swift
     // After
-    struct FoodTruckTests {
-      @Test func grillWorks() async {
-        withKnownIssue(
-          "Grill may need fuel", 
-          isIntermittent: true
-        ) {
-          try FoodTruck.shared.grill.start()
-        }
-        ...
+    @Test func grillWorks() async {
+      withKnownIssue(
+        "Grill may need fuel", 
+        isIntermittent: true
+      ) {
+        try FoodTruck.shared.grill.start()
       }
       ...
     }
@@ -632,20 +659,17 @@ of issues:
   @Column {
     ```swift
     // Before
-    class FoodTruckTests: XCTestCase {
-      func testGrillWorks() async {
-        let options = XCTExpectedFailure.Options()
-        options.isEnabled = FoodTruck.shared.hasGrill
-        options.issueMatcher = { issue in
-          issue.type == thrownError
-        }
-        XCTExpectFailure(
-          "Grill is out of fuel",
-          options: options
-        ) {
-          try FoodTruck.shared.grill.start()
-        }
-        ...
+    func testGrillWorks() async {
+      let options = XCTExpectedFailure.Options()
+      options.isEnabled = FoodTruck.shared.hasGrill
+      options.issueMatcher = { issue in
+        issue.type == thrownError
+      }
+      XCTExpectFailure(
+        "Grill is out of fuel",
+        options: options
+      ) {
+        try FoodTruck.shared.grill.start()
       }
       ...
     }
@@ -655,15 +679,12 @@ of issues:
     ```swift
     // After
     struct FoodTruckTests {
-      @Test func grillWorks() async {
-        withKnownIssue("Grill is out of fuel") {
-          try FoodTruck.shared.grill.start()
-        } when: {
-          FoodTruck.shared.hasGrill
-        } matching: { issue in
-          issue.error != nil 
-        }
-        ...
+      withKnownIssue("Grill is out of fuel") {
+        try FoodTruck.shared.grill.start()
+      } when: {
+        FoodTruck.shared.hasGrill
+      } matching: { issue in
+        issue.error != nil 
       }
       ...
     }

--- a/Sources/Testing/Testing.docc/testing-asynchronous-code.md
+++ b/Sources/Testing/Testing.docc/testing-asynchronous-code.md
@@ -54,7 +54,7 @@ If you expect the event to happen more than once, set the
 test passes if the number of occurrences during the test matches the
 expected count, and fails otherwise.
 
-You can also pass a range to ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-6bkl6``
+You can also pass a range to ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il``
 if the exact number of times the event occurs may change over time or is random:
 
 ```swift


### PR DESCRIPTION
Follow-up to #691. Updates DocC links now that `confirmation()` is overloaded, specifies a minimum Swift version needed to use it, and adds content to "Migrating From XCTest" covering the new overload.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
