### PR TITLE
Work around a crash importing FoundationXML.

### DIFF
--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -15,7 +15,7 @@ import RegexBuilder
 #if canImport(Foundation)
 import Foundation
 #endif
-#if canImport(FoundationXML)
+#if SWT_FIXED_138761752 && canImport(FoundationXML)
 import FoundationXML
 #endif
 
@@ -299,7 +299,7 @@ struct EventRecorderTests {
   }
 #endif
 
-#if canImport(Foundation) || canImport(FoundationXML)
+#if canImport(Foundation) || (SWT_FIXED_138761752 && canImport(FoundationXML))
   @Test(
     "JUnitXMLRecorder outputs valid XML",
     .bug("https://github.com/swiftlang/swift-testing/issues/254")


### PR DESCRIPTION
This PR works around a new crash importing FoundationXML See:

https://ci-external.swift.org/job/swift-testing-pull-request-windows/832/ https://ci.swift.org/job/pr-swift-testing-linux-5.10/1319/console

Works around rdar://138761752.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
