### PR TITLE
Ensure the identifier of a "seen" object is only removed if the object's children were recursively reflected

### DIFF
--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -190,9 +190,9 @@ public struct __Expression: Sendable {
     ///     This is used to halt further recursion if a previously-seen object
     ///     is encountered again.
     private init(
-        _reflecting subject: Any,
-        label: String?,
-        seenObjects: inout [ObjectIdentifier: AnyObject]
+      _reflecting subject: Any,
+      label: String?,
+      seenObjects: inout [ObjectIdentifier: AnyObject]
     ) {
       let mirror = Mirror(reflecting: subject)
 
@@ -214,7 +214,7 @@ public struct __Expression: Sendable {
       // `type(of:)`, which is inexpensive. The object itself is stored as the
       // value in the dictionary to ensure it is retained for the duration of
       // the recursion.
-      var objectIdentifierTeRemove: ObjectIdentifier?
+      var objectIdentifierToRemove: ObjectIdentifier?
       var shouldIncludeChildren = true
       if mirror.displayStyle == .class, type(of: subject) is AnyObject.Type {
         let object = subject as AnyObject
@@ -222,16 +222,17 @@ public struct __Expression: Sendable {
         let oldValue = seenObjects.updateValue(object, forKey: objectIdentifier)
         if oldValue != nil {
           shouldIncludeChildren = false
+        } else {
+          objectIdentifierToRemove = objectIdentifier
         }
-        objectIdentifierTeRemove = objectIdentifier
       }
       defer {
-        if let objectIdentifierTeRemove {
+        if let objectIdentifierToRemove {
           // Remove the object from the set of previously-seen objects after
           // (potentially) recursing to reflect children. This is so that
           // repeated references to the same object are still included multiple
           // times; only _cyclic_ object references should be avoided.
-          seenObjects[objectIdentifierTeRemove] = nil
+          seenObjects[objectIdentifierToRemove] = nil
         }
       }
 

--- a/Tests/TestingTests/Expression.ValueTests.swift
+++ b/Tests/TestingTests/Expression.ValueTests.swift
@@ -166,4 +166,50 @@ struct Expression_ValueTests {
     #expect(oneChildChildrenOptionalChild.children == nil)
   }
 
+  @Test("Value reflecting an object with two back-references to itself",
+        .bug("https://github.com/swiftlang/swift-testing/issues/785#issuecomment-2440222995"))
+  func multipleSelfReferences() {
+    class A {
+      weak var one: A?
+      weak var two: A?
+    }
+
+    let a = A()
+    a.one = a
+    a.two = a
+
+    let value = Expression.Value(reflecting: a)
+    #expect(value.children?.count == 2)
+  }
+
+  @Test("Value reflecting an object in a complex graph which includes back-references",
+        .bug("https://github.com/swiftlang/swift-testing/issues/785"))
+  func complexObjectGraphWithCyclicReferences() throws {
+    class A {
+      var c1: C!
+      var c2: C!
+      var b: B!
+    }
+    class B {
+      weak var a: A!
+      var c: C!
+    }
+    class C {
+      weak var a: A!
+    }
+
+    let a = A()
+    let b = B()
+    let c = C()
+    a.c1 = c
+    a.c2 = c
+    a.b = b
+    b.a = a
+    b.c = c
+    c.a = a
+
+    let value = Expression.Value(reflecting: a)
+    #expect(value.children?.count == 3)
+  }
+
 }


### PR DESCRIPTION
This fixes a crash which can occur if an object has certain cyclic references and it's included in an expectation expression which fails.

The bug is that the identifier of a "seen" object passed to `Expression.Value.init(_reflecting:label:seenObjects:)` should only be removed from the tracking dictionary if the object's children were recursively reflected. If recursion did not occur, that indicates that the object has been seen so it should be left in the tracking dictionary to prevent subsequent recursion. I added new unit tests to validate this.

Fixes #785

### Result:

The scenarios described in #785 no longer crash.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
