### PR TITLE
Do not perform full expansion of `#expect()` when `try` or `await` is present.

### DIFF
--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -123,6 +123,15 @@ struct SendableTests: Sendable {
 
   @Test(.hidden, arguments: FixtureData.stringReturningClosureArray)
   func parameterizedAcceptingFunction(f: @Sendable () -> String) {}
+
+  @Test(.hidden) func throwKeywordInExpectation() throws {
+    #expect(UInt() == UInt(try #require(Int("0"))))
+  }
+
+  @Test(.hidden) func asyncKeywordInExpectation() async {
+    func f() async -> Int { 0 }
+    #expect(UInt() == UInt(await f()))
+  }
 }
 
 @Suite("Named Sendable test type", .hidden)


### PR DESCRIPTION
For reasons that have been documented at length (see #162), we aren't able to correctly expand conditions on `#expect()` or `#require()` that have effects (`try` or `await`.) We aren't currently detecting all possible patterns that expand incorrectly. This PR causes us to back out of the full expansion if the `try` or `await` keyword is present _anywhere_ inside an expectation condition expression.

Resolves #783.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
