### PR TITLE
Temporarily give `defaultPreferredName` internal access level

### DIFF
--- a/Sources/Testing/Attachments/Test.Attachment.swift
+++ b/Sources/Testing/Attachments/Test.Attachment.swift
@@ -34,7 +34,7 @@ extension Test {
     public var sourceLocation: SourceLocation
 
     /// The default preferred name to use if the developer does not supply one.
-    package static var defaultPreferredName: String {
+    static var defaultPreferredName: String {
       "untitled"
     }
 


### PR DESCRIPTION
To fix a build regression for [Swift](https://github.com/swiftlang/swift), temporarily give  `defaultPreferredName` an `internal` access level instead of `package`.

### Motivation:

The Swift compiler build is broken.

### Checklist:

- [X] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [X] If public symbols are renamed or modified, DocC references should be updated.
