### PR TITLE
Ensure the `Bool` overload of `__checkBinaryOperation()` is still preferred.

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -770,7 +770,7 @@ public func __checkValue<T>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-public func __checkBinaryOperation<T>(
+@_disfavoredOverload public func __checkBinaryOperation<T>(
   _ lhs: T?, _ op: (T?, () -> T?) -> T?, _ rhs: @autoclosure () -> T?,
   expression: __Expression,
   comments: @autoclosure () -> [Comment],

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1552,6 +1552,23 @@ struct IssueCodingTests {
     #expect(String(describing: issueSnapshot) == String(describing: issue))
     #expect(String(reflecting: issueSnapshot) == String(reflecting: issue))
   }
+
+  @Test func binaryOperatorExpansionPrefersBooleanOverOptional() async throws {
+    await confirmation("Issue recorded", expectedCount: 3) { issueRecorded in
+      var configuration = Configuration()
+      configuration.eventHandler = { event, _ in
+        if case .issueRecorded = event.kind {
+          issueRecorded()
+        }
+      }
+
+      await Test {
+        #expect(true == false)
+        #expect(false != false)
+        try #require(true != true)
+      }.run(configuration: configuration)
+    }
+  }
 }
 #endif
 


### PR DESCRIPTION
We noticed that in some conditions, boolean arguments to `#expect()` would compile to use the _optional_ overload of `__checkBinaryOperation()`, which would result in a pass when a failure should have occurred because the boolean value never evaluated to `nil`. This PR should resolve that issue.

Resolves rdar://138964155.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
