### PR TITLE
WASI: Access to `EEXIST` through a stub getter function

### DIFF
--- a/Sources/Testing/Attachments/Test.Attachment.swift
+++ b/Sources/Testing/Attachments/Test.Attachment.swift
@@ -246,7 +246,7 @@ extension Test.Attachment {
           file = try FileHandle(atPath: preferredPath, mode: "wxb")
           result = preferredPath
           break
-        } catch let error as CError where error.rawValue == EEXIST {
+        } catch let error as CError where error.rawValue == swt_EEXIST() {
           // Try again with a new suffix.
           continue
         } catch where usingPreferredName {

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -154,6 +154,14 @@ static int swt_siginfo_t_si_status(const siginfo_t *siginfo) {
 #endif
 #endif
 
+/// Get the value of `EEXIST`.
+///
+/// This function is provided because `EEXIST` is a complex macro in wasi-libc
+/// and cannot be imported directly into Swift.
+static int swt_EEXIST(void) {
+  return EEXIST;
+}
+
 SWT_ASSUME_NONNULL_END
 
 #endif


### PR DESCRIPTION
Build fix for WASI

### Motivation:

Use of errno values in Swift without libc overlay is not supported with wasi-libc.

https://ci.swift.org/job/oss-swift-pr-test-crosscompile-wasm-ubuntu-20_04/1784/console

```
/home/build-user/swift-testing/Sources/Testing/Attachments/Test.Attachment.swift:249:61: error: cannot find 'EEXIST' in scope
247 |           result = preferredPath
248 |           break
249 |         } catch let error as CError where error.rawValue == EEXIST {
    |                                                             `- error: cannot find 'EEXIST' in scope
250 |           // Try again with a new suffix.
251 |           continue
```

### Modifications:

This change introduces a new function `swt_EEXIST` to get the value of `EEXIST` because it is a complex macro in wasi-libc and cannot be imported directly into Swift.

### Result:

WASI build will be repaired.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
