### PR TITLE
Specify the module to find the ABI entry point function in (in our own tests).

### DIFF
--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -173,7 +173,7 @@ private func withTestingLibraryImageAddress<R>(_ body: (ImageAddress?) throws ->
   let addressInTestingLibrary = unsafeBitCast(ABIv0.entryPoint, to: UnsafeRawPointer.self)
 
   var testingLibraryAddress: ImageAddress?
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android)
+#if SWT_TARGET_OS_APPLE
   var info = Dl_info()
   try #require(0 != dladdr(addressInTestingLibrary, &info))
 
@@ -182,6 +182,8 @@ private func withTestingLibraryImageAddress<R>(_ body: (ImageAddress?) throws ->
   defer {
     dlclose(testingLibraryAddress)
   }
+#elseif os(Linux) || os(FreeBSD) || os(Android)
+  // When using glibc, dladdr() is only available if __USE_GNU is specified.
 #elseif os(Windows)
   let flags = DWORD(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS)
   try addressInTestingLibrary.withMemoryRebound(to: wchar_t.self, capacity: MemoryLayout<UnsafeRawPointer>.stride / MemoryLayout<wchar_t>.stride) { addressInTestingLibrary in

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -53,11 +53,13 @@ struct ABIEntryPointTests {
     recordHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void = { _ in }
   ) async throws -> CInt {
     // Get the ABI entry point by dynamically looking it up at runtime.
-    let copyABIEntryPoint_v0 = try #require(
-      symbol(named: "swt_copyABIEntryPoint_v0").map {
-        unsafeBitCast($0, to: (@convention(c) () -> UnsafeMutableRawPointer).self)
-      }
-    )
+    let copyABIEntryPoint_v0 = try withTestingLibraryImageAddress { testingLibrary in
+      try #require(
+        symbol(in: testingLibrary, named: "swt_copyABIEntryPoint_v0").map {
+          unsafeBitCast($0, to: (@convention(c) () -> UnsafeMutableRawPointer).self)
+        }
+      )
+    }
     let abiEntryPoint = copyABIEntryPoint_v0().assumingMemoryBound(to: ABIEntryPoint_v0.self)
     defer {
       abiEntryPoint.deinitialize(count: 1)
@@ -133,11 +135,13 @@ struct ABIEntryPointTests {
     // NOTE: The standard Linux linker does not allow exporting symbols from
     // executables, so dlsym() does not let us find this function on that
     // platform when built as an executable rather than a dynamic library.
-    let abiv0_getEntryPoint = try #require(
-      symbol(named: "swt_abiv0_getEntryPoint").map {
-        unsafeBitCast($0, to: (@convention(c) () -> UnsafeRawPointer).self)
-      }
-    )
+    let abiv0_getEntryPoint = try withTestingLibraryImageAddress { testingLibrary in
+      try #require(
+        symbol(in: testingLibrary, named: "swt_abiv0_getEntryPoint").map {
+          unsafeBitCast($0, to: (@convention(c) () -> UnsafeRawPointer).self)
+        }
+      )
+    }
 #endif
     let abiEntryPoint = unsafeBitCast(abiv0_getEntryPoint(), to: ABIv0.EntryPoint.self)
 
@@ -163,4 +167,34 @@ struct ABIEntryPointTests {
   }
 #endif
 }
+
+#if !SWT_NO_DYNAMIC_LINKING
+private func withTestingLibraryImageAddress<R>(_ body: (ImageAddress?) throws -> R) throws -> R {
+  let addressInTestingLibrary = unsafeBitCast(ABIv0.entryPoint, to: UnsafeRawPointer.self)
+
+  var testingLibraryAddress: ImageAddress?
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android)
+  var info = Dl_info()
+  try #require(0 != dladdr(addressInTestingLibrary, &info))
+
+  testingLibraryAddress = dlopen(info.dli_fname, RTLD_NOLOAD)
+  try #require(testingLibraryAddress != nil)
+  defer {
+    dlclose(testingLibraryAddress)
+  }
+#elseif os(Windows)
+  let flags = DWORD(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS)
+  try addressInTestingLibrary.withMemoryRebound(to: wchar_t.self, capacity: MemoryLayout<UnsafeRawPointer>.stride / MemoryLayout<wchar_t>.stride) { addressInTestingLibrary in
+    try #require(GetModuleHandleExW(flags, addressInTestingLibrary, &testingLibraryAddress))
+  }
+  defer {
+    FreeLibrary(testingLibraryAddress)
+  }
+#else
+#warning("Platform-specific implementation missing: cannot find the testing library image the test suite is linked against")
+#endif
+
+  return try body(testingLibraryAddress)
+}
+#endif
 #endif


### PR DESCRIPTION
The order in which Xcode loads the Apple-vendored copy of Swift Testing vs. a developer-supplied XCTest bundle is unspecified. Our tests assume that the "current" copy of Swift Testing (that is, the copy they linked against) is the first one loaded, which is not always true when running tests in Xcode. The modified tests end up finding the wrong entry point functions when called within Xcode if the load order has changed.

This PR explicitly specifies that we are looking for the entry point functions in the module the tests are linked against. The change is applied across all platforms that support dynamic linking for the sake of consistency as any of them might have linked a copy of Swift Testing from the toolchain _and_ the package itself.

Resolves rdar://139140302.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
