### PR TITLE
Test cleanup: Remove an obsolete fixture suite and add .hidden to a few tests

### DIFF
--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -439,7 +439,7 @@ private import _TestingInternals
 }
 
 #if false // intentionally fails to compile
-@Test(arguments: 100 ..< 200)
+@Test(.hidden, arguments: 100 ..< 200)
 func sellIceCreamCones(count: Int) async throws {
   try await #require(exitsWith: .failure) {
     precondition(count < 10, "Too many ice cream cones")

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -224,11 +224,13 @@ struct TestsWithAsyncArguments {
 }
 
 @Test(
+  .hidden,
   arguments: [0] // Meaningful trivia: This line comment should be omitted during macro expansion
 )
 func parameterizedTestWithTrailingComment(value: Int) {}
 
 @Suite(
+  .hidden,
   .serialized // Meaningful trivia: This line comment should be omitted during macro expansion
 )
 private struct SuiteWithTraitContainingTrailingComment {}

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -456,20 +456,6 @@ private struct DummyRecursiveTrait: TestTrait, SuiteTrait {
   }
 }
 
-struct IndependentlyRunnableTests {
-  struct A {
-    @Suite(.hidden) struct B {
-      @Test(.hidden) func c() {}
-      struct D {
-        @Test(.hidden) func e() {}
-      }
-    }
-    @Suite(.hidden) struct F {
-      @Test(.hidden) func g() {}
-    }
-  }
-}
-
 @Suite(.hidden)
 struct RelativeTraitOrderingTests {
   @Suite(.hidden, BasicRecursiveTrait("A"))


### PR DESCRIPTION
A few small cleanups to the project's unit tests:

- Remove the obsolete fixture suite type `IndependentlyRunnableTests`. The test which used to reference it has been deleted.
- Add the `.hidden` trait to a few eligible `@Test` functions.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
