### PR TITLE
Fix a crash when describing a confirmation failure with a range.

### DIFF
--- a/Tests/TestingTests/ConfirmationTests.swift
+++ b/Tests/TestingTests/ConfirmationTests.swift
@@ -47,6 +47,19 @@ struct ConfirmationTests {
     }
   }
 
+  @Test func confirmationFailureCanBeDescribed() async {
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      if case let .issueRecorded(issue) = event.kind {
+        #expect(String(describing: issue) != "")
+      }
+    }
+
+    await Test {
+      await confirmation(expectedCount: 1...) { _ in }
+    }.run(configuration: configuration)
+  }
+
 #if !SWT_NO_EXIT_TESTS
   @Test("Confirmation requires positive count")
   func positiveCount() async {


### PR DESCRIPTION
I was using `relative(to:)` to convert any arbitrary `RangeExpression` to one with an upper and lower bound, but that function may produce invalid ranges for expressions like `1...` that cause crashes.

This PR switches to a different, somewhat sillier implementation that should not run into this issue.

Resolves #805.
Resolves rdar://139222774.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
