### PR TITLE
Add support for platform-specific unconditional availability.

### DIFF
--- a/Sources/Testing/Traits/ConditionTrait+Macro.swift
+++ b/Sources/Testing/Traits/ConditionTrait+Macro.swift
@@ -92,9 +92,16 @@ extension Trait where Self == ConditionTrait {
     _ condition: @escaping @Sendable () -> Bool
   ) -> Self {
     // TODO: Semantic capture of platform name/version (rather than just a comment)
-    Self(
+    let message: Comment = if let message {
+      message
+    } else if let version {
+      "Obsolete as of \(_description(ofPlatformName: platformName, version: version))"
+    } else {
+      "Unavailable on \(_description(ofPlatformName: platformName, version: nil))"
+    }
+    return Self(
       kind: .conditional(condition),
-      comments: [message ?? "Obsolete as of \(_description(ofPlatformName: platformName, version: version))"],
+      comments: [message],
       sourceLocation: sourceLocation
     )
   }

--- a/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
@@ -80,10 +80,14 @@ extension WithAttributesSyntax {
             if let lastPlatformName, whenKeyword == .introduced {
               return Availability(attribute: attribute, platformName: lastPlatformName, version: nil, message: message)
             }
-          } else if case let .keyword(keyword) = token.tokenKind, keyword == whenKeyword, asteriskEncountered {
-            // Match the "always this availability" construct, i.e.
-            // `@available(*, deprecated)` and `@available(*, unavailable)`.
-            return Availability(attribute: attribute, platformName: lastPlatformName, version: nil, message: message)
+          } else if case let .keyword(keyword) = token.tokenKind, keyword == whenKeyword {
+            if asteriskEncountered {
+              // Match the "always this availability" construct, i.e.
+              // `@available(*, deprecated)` and `@available(*, unavailable)`.
+              return Availability(attribute: attribute, platformName: lastPlatformName, version: nil, message: message)
+            } else if keyword == .unavailable {
+              return Availability(attribute: attribute, platformName: lastPlatformName, version: nil, message: message)
+            }
           }
         case let .availabilityLabeledArgument(argument):
           if argument.label.tokenKind == .keyword(whenKeyword), case let .version(version) = argument.value {

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -252,7 +252,9 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
 
     // Generate a thunk function that invokes the actual function.
     var thunkBody: CodeBlockItemListSyntax
-    if functionDecl.availability(when: .unavailable).first != nil {
+    if functionDecl.availability(when: .unavailable).first(where: { $0.platformVersion == nil }) != nil {
+      // The function is unconditionally disabled, so don't bother emitting a
+      // thunk body that calls it.
       thunkBody = ""
     } else if let typeName {
       if functionDecl.isStaticOrClass {

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -307,6 +307,11 @@ struct TestDeclarationMacroTests {
           #".__available("Swift", obsoleted: (2, 0, nil), "#,
           #"#if swift(>=1.0) && swift(<2.0)"#,
         ],
+      #"@available(moofOS, unavailable, message: "Moof!") @Test func f() {}"#:
+        [
+          #"#if os(moofOS)"#,
+          #".__available("moofOS", obsoleted: nil, message: "Moof!", "#,
+        ]
     ]
   )
   func availabilityAttributeCapture(input: String, expectedOutputs: [String]) throws {

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -638,6 +638,14 @@ final class RunnerTests: XCTestCase {
     func futureAvailable() {}
 
     @Test(.hidden)
+    @available(macOS, unavailable)
+    @available(iOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(visionOS, unavailable)
+    func perPlatformUnavailable() {}
+
+    @Test(.hidden)
     @available(macOS, introduced: 999.0)
     @available(iOS, introduced: 999.0)
     @available(watchOS, introduced: 999.0)
@@ -674,7 +682,7 @@ final class RunnerTests: XCTestCase {
     let testSkipped = expectation(description: "Test skipped")
 #if SWT_TARGET_OS_APPLE
     testStarted.expectedFulfillmentCount = 4
-    testSkipped.expectedFulfillmentCount = 7
+    testSkipped.expectedFulfillmentCount = 8
 #else
     testStarted.expectedFulfillmentCount = 2
     testSkipped.expectedFulfillmentCount = 2
@@ -719,6 +727,14 @@ final class RunnerTests: XCTestCase {
     func unavailable() {}
 
 #if SWT_TARGET_OS_APPLE
+    @Test(.hidden)
+    @available(macOS, unavailable, message: "Expected Message")
+    @available(iOS, unavailable, message: "Expected Message")
+    @available(watchOS, unavailable, message: "Expected Message")
+    @available(tvOS, unavailable, message: "Expected Message")
+    @available(visionOS, unavailable, message: "Expected Message")
+    func perPlatformUnavailable() {}
+
     @Test(.hidden)
     @available(macOS, introduced: 999.0, message: "Expected Message")
     @available(iOS, introduced: 999.0, message: "Expected Message")


### PR DESCRIPTION
This PR adds support for the following variant of `@available`:

```swift
@available(macOS, unavailable)
@Test func f() {}
```

Previously, we were simply ignoring these availability attributes.

Resolves rdar://137776333.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
