### PR TITLE
Use @Test function parameters to explicitly type array literal argument expressions

### DIFF
--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -199,13 +199,33 @@ extension [Test.__Parameter] {
 ///
 /// ## See Also
 ///
-/// - ``Test(_:arguments:)-35dat``
+/// - ``Test(_:_:arguments:)-8kn7a``
 @attached(peer)
 @_documentation(visibility: private)
 public macro Test<C>(
   _ traits: any TestTrait...,
   arguments collection: C
 ) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C: Collection & Sendable, C.Element: Sendable
+
+/// This macro declaration is necessary to allow non-`Sendable` collections to
+/// be passed as test arguments.
+///
+/// This macro declaration is similar to the above overload, but with all
+/// `Sendable` constraints removed, so it does not need to be documented
+/// separately. This macro's expansion code still calls APIs from the testing
+/// library which require `Sendable`, however, so despite its relaxed generic
+/// constraints, callers must still pass sendable collections to avoid compiler
+/// diagnostics.
+///
+/// ## See Also
+///
+/// - ``Test(_:_:arguments:)-8kn7a``
+@attached(peer)
+@_documentation(visibility: private)
+public macro Test<C>(
+  _ traits: any TestTrait...,
+  arguments collection: C
+) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C: Collection
 
 /// Declare a test parameterized over a collection of values.
 ///
@@ -233,6 +253,27 @@ public macro Test<C>(
   _ traits: any TestTrait...,
   arguments collection: C
 ) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C: Collection & Sendable, C.Element: Sendable
+
+/// This macro declaration is necessary to allow non-`Sendable` collections to
+/// be passed as test arguments.
+///
+/// This macro declaration is similar to the above overload, but with all
+/// `Sendable` constraints removed, so it does not need to be documented
+/// separately. This macro's expansion code still calls APIs from the testing
+/// library which require `Sendable`, however, so despite its relaxed generic
+/// constraints, callers must still pass sendable collections to avoid compiler
+/// diagnostics.
+///
+/// ## See Also
+///
+/// - ``Test(_:_:arguments:)-8kn7a``
+@attached(peer)
+@_documentation(visibility: private)
+public macro Test<C>(
+  _ displayName: _const String? = nil,
+  _ traits: any TestTrait...,
+  arguments collection: C
+) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C: Collection
 
 extension Test {
   /// Create an instance of ``Test`` for a parameterized function.
@@ -280,6 +321,7 @@ extension Test {
 ///
 /// ## See Also
 ///
+/// - ``Test(_:_:arguments:_:)-40xp7``
 /// - <doc:DefiningTests>
 @attached(peer)
 @_documentation(visibility: private)
@@ -287,6 +329,26 @@ public macro Test<C1, C2>(
   _ traits: any TestTrait...,
   arguments collection1: C1, _ collection2: C2
 ) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable
+
+/// This macro declaration is necessary to allow non-`Sendable` collections to
+/// be passed as test arguments.
+///
+/// This macro declaration is similar to the above overload, but with all
+/// `Sendable` constraints removed, so it does not need to be documented
+/// separately. This macro's expansion code still calls APIs from the testing
+/// library which require `Sendable`, however, so despite its relaxed generic
+/// constraints, callers must still pass sendable collections to avoid compiler
+/// diagnostics.
+///
+/// ## See Also
+///
+/// - ``Test(_:_:arguments:_:)-40xp7``
+@attached(peer)
+@_documentation(visibility: private)
+public macro Test<C1, C2>(
+  _ traits: any TestTrait...,
+  arguments collection1: C1, _ collection2: C2
+) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C1: Collection, C2: Collection
 
 /// Declare a test parameterized over two collections of values.
 ///
@@ -314,6 +376,27 @@ public macro Test<C1, C2>(
   _ traits: any TestTrait...,
   arguments collection1: C1, _ collection2: C2
 ) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C1: Collection & Sendable, C1.Element: Sendable, C2: Collection & Sendable, C2.Element: Sendable
+
+/// This macro declaration is necessary to allow non-`Sendable` collections to
+/// be passed as test arguments.
+///
+/// This macro declaration is similar to the above overload, but with all
+/// `Sendable` constraints removed, so it does not need to be documented
+/// separately. This macro's expansion code still calls APIs from the testing
+/// library which require `Sendable`, however, so despite its relaxed generic
+/// constraints, callers must still pass sendable collections to avoid compiler
+/// diagnostics.
+///
+/// ## See Also
+///
+/// - ``Test(_:_:arguments:_:)-40xp7``
+@attached(peer)
+@_documentation(visibility: private)
+public macro Test<C1, C2>(
+  _ displayName: _const String? = nil,
+  _ traits: any TestTrait...,
+  arguments collection1: C1, _ collection2: C2
+) = #externalMacro(module: "TestingMacros", type: "TestDeclarationMacro") where C1: Collection, C2: Collection
 
 // MARK: - @Test(arguments: zip(...))
 

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -142,10 +142,7 @@ private func _diagnoseIssuesWithParallelizationTrait(_ traitExpr: MemberAccessEx
     return
   }
 
-  let hasArguments = attributeInfo.otherArguments.lazy
-    .compactMap(\.label?.textWithoutBackticks)
-    .contains("arguments")
-  if !hasArguments {
+  if !attributeInfo.hasFunctionArguments {
     // Serializing a non-parameterized test function has no effect.
     context.diagnose(.traitHasNoEffect(traitExpr, in: attributeInfo.attribute))
   }

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -423,9 +423,8 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
       // case the availability checks fail below.
       let unavailableTestName = context.makeUniqueName(thunking: functionDecl)
 
-      // TODO: don't assume otherArguments is only parameterized function arguments
       var attributeInfo = attributeInfo
-      attributeInfo.otherArguments = []
+      attributeInfo.testFunctionArguments = nil
       result.append(
         """
         @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -369,7 +369,8 @@ struct TestDeclarationMacroTests {
 
   @Test("Self. in @Test attribute is removed")
   func removeSelfKeyword() throws {
-    let (output, _) = try parse("@Test(arguments: Self.nested.uniqueArgsName, NoTouching.thisOne) func f() {}")
+    let (output, diagnostics) = try parse("@Test(arguments: Self.nested.uniqueArgsName, NoTouching.thisOne) func f(a: A, b: B) {}")
+    try #require(diagnostics.isEmpty)
     #expect(output.contains("nested.uniqueArgsName"))
     #expect(!output.contains("Self.nested.uniqueArgsName"))
     #expect(output.contains("NoTouching.thisOne"))
@@ -468,6 +469,33 @@ struct TestDeclarationMacroTests {
     for diagnostic in diagnostics {
       #expect(diagnostic.diagMessage.severity == .warning)
       #expect(diagnostic.message == #"URL "\#(id)" is invalid and cannot be used with trait 'bug' in attribute 'Test'"#)
+    }
+  }
+
+  @Suite("Test function arguments")
+  struct Arguments {
+    @Test("A heterogeneous array literal ([...]) without an explicit type")
+    func heterogeneousArrayLiteral() throws {
+      let input = """
+        @Test(arguments: [
+          (String.self, "1"),
+          (Int.self, "2"),
+        ])
+        func example(type: Any.Type, label: String) {}
+        """
+      let (output, _) = try parse(input)
+      #expect(output.contains("as [(Any.Type, String)]"))
+    }
+
+    @Test("A heterogeneous array literal ([...]) with explicit 'as ...' type")
+    func heterogeneousArrayLiteralWithExplicitAs() throws {
+      let input = """
+        @Test(arguments: [Child.self, Child.self] as [Parent])
+        func example(type: Grandparent.Type) {}
+        """
+      let (output, _) = try parse(input)
+      #expect(output.contains("as [Parent]"))
+      #expect(!output.contains("as [Grandparent.Type]"))
     }
   }
 }

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -572,3 +572,23 @@ struct MiscellaneousTests {
     #expect(duration < .seconds(1))
   }
 }
+
+@Test(.hidden, arguments: [String.self, Int.self])
+func heterogeneousArray(type: Any.Type) {}
+
+@Test(.hidden, arguments: [
+  (String.self, "1"),
+  (Int.self, "2"),
+])
+func heterogeneousTupleArray(type: Any.Type, label: String) {}
+
+@Test(.hidden, arguments:
+        [(String.self, 1), (Int.self, 2)],
+        ["A", "B", "C"])
+func heterogeneousCombinatoric(tuple: (Any.Type, Int), letter: Character) {}
+
+@Test(.hidden, arguments: [
+  "1": ["one", 1],
+  "2": ["two", 2],
+])
+func heterogeneousDictionary(label: String, type: [any Sendable]) {}

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -34,7 +34,7 @@ struct TypeInfoTests {
       (() -> String).self,
       TypeInfo(fullyQualifiedName: "() -> Swift.String", unqualifiedName: "() -> String", mangledName: "")
     ),
-  ] as [(Any.Type, TypeInfo)])
+  ])
   func initWithType(type: Any.Type, expectedTypeInfo: TypeInfo) {
     let typeInfo = TypeInfo(describing: type)
     #expect(typeInfo == expectedTypeInfo)


### PR DESCRIPTION
This solves a problem that users who pass array literals to `@Test(arguments: ...)` may encounter if the array's elements are heterogeneous. For example:

```swift
@Test(arguments: [  // ❌ error: type 'Any' does not conform to the 'Sendable' protocol
  (Int.self, nominalName: "Int"),
  (String.self, nominalName: "String"),
])
func name1(type: Any.Type, nominalName: String) {
  #expect(API.name(type) == nominalName)
}
```

Due to the use of heterogeneous elements `Int.self` and `String.self`, the overall array's type is inferred as `[Any]`. This leads to two problems:

1. The `@Test(arguments:)` macro requires a `Collection` which is `Sendable`, and `[Any]` is not `Sendable`. This prevents passing the array to the macro at all, since arguments to a macro must typecheck successfully before the macro is expanded.
2. The test function's parameters are of type `Any.Type` and `String`, respectively. For the macro expansion to produce valid code, the array literal needs to have type `[(Any.Type, String)]`.

This PR makes two changes to address those problems:

- First, it introduces overloads of some of the `@Test` macro declarations _without_ their `Sendable` requirements. This solves problem 1 above. (See the considerations below for discussion about why I believe this is safe and reasonable.)
- Second, it modifies the macro expansion logic to add an `as ...` cast to array literal expressions passed to `arguments: ...` (unless they already have one) to provide an explicit type.

Continuing the example above, this results in the expanded code behaving as though the array expression had `as [(Any.Type, String)]` at the end, and the original code now compiles successfully.

> Thank you to @ApolloZhu for suggesting the fix to use `as ...` in the macro expansion!

### Concurrency safety

The expanded code from the new `@Test` overloads is no less concurrency safe than before, because it still calls APIs from the testing library which require `Sendable`. This means that passing a non-`Sendable` collection will still result in a compiler diagnostic, just with a different source location than before:

```swift
// With the changes in this PR:
struct NonSendable {}

@Test(arguments: [NonSendable()])  // ❌: @__swiftmacro_12TestingTests6unsafe4TestfMp_.swift:14:4: error: type 'NonSendable' does not conform to the 'Sendable' protocol
func unsafe(_ x: NonSendable) {}
```

### Documentation

The new `@Test` overloads are necessarily `public` but are hidden from rendered DocC documentation using `@_documentation(visibility: private)`. From an end user's perspective, `@Test(arguments:)` did, and still does, require `Sendable`; the only thing changing is where that enforcement occurs. So in terms of documentation, the only overloads we need to document are those that _do_ require `Sendable`. In fact, for similar reasons, we already hide many of our `@Test` overloads from documentation so this has precedent.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Fixes swiftlang/swift#76637