### PR TITLE
Revert "Eagerly move attachable values to the heap. (#809)"

### DIFF
--- a/Sources/Testing/Attachments/Test.Attachment.swift
+++ b/Sources/Testing/Attachments/Test.Attachment.swift
@@ -68,11 +68,7 @@ extension Test {
       named preferredName: String? = nil,
       sourceLocation: SourceLocation = #_sourceLocation
     ) {
-      if _shouldMoveValueToHeap(attachableValue) {
-        self.attachableValue = _HeapAllocatedAttachableProxy(rawValue: attachableValue)
-      } else {
-        self.attachableValue = attachableValue
-      }
+      self.attachableValue = attachableValue
       self.preferredName = preferredName ?? Self.defaultPreferredName
       self.sourceLocation = sourceLocation
     }
@@ -99,71 +95,10 @@ extension Test.Attachment {
   }
 }
 
-// MARK: - Heap allocation optimizations
-
-/// A type that stands in for an attachable value of value type (as opposed to
-/// reference type.)
-///
-/// We don't know the in-memory layout of an attachable value; it may be very
-/// expensive to make the typical copies Swift makes over the course of a test
-/// run if a value is large or contains lots of references to objects. So we
-/// eagerly move attachments of value type to the heap by ensconcing them in
-/// instances of this type.
-private final class _HeapAllocatedAttachableProxy<RawValue>: RawRepresentable, Test.Attachable, Sendable where RawValue: Test.Attachable & Sendable {
-  let rawValue: RawValue
-
-  init(rawValue: RawValue) {
-    self.rawValue = rawValue
-  }
-
-  var estimatedAttachmentByteCount: Int? {
-    rawValue.estimatedAttachmentByteCount
-  }
-
-  func withUnsafeBufferPointer<R>(for attachment: borrowing Test.Attachment, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
-    try rawValue.withUnsafeBufferPointer(for: attachment, body)
-  }
-}
-
-/// Whether or not an attachable value should be moved to the heap when adding
-/// it to an attachment.
-///
-/// - Parameters:
-///   - attachableValue: The value that is being attached.
-///
-/// - Returns: Whether or not `attachableValue` should be boxed in an instance
-///   of `_HeapAllocatedAttachableProxy`.
-private func _shouldMoveValueToHeap<T>(_ attachableValue: borrowing T) -> Bool where T: Test.Attachable {
-  // Do not (redundantly) move existing heap-allocated objects to the heap.
-  if T.self is AnyClass {
-    return false
-  }
-
-  // Do not move small POD value types to the heap.
-  //
-  // _isPOD() is defined in the standard library and is approximately equivalent
-  // to testing for conformance to BitwiseCopyable, but it's a marker protocol
-  // which means we can't test for conformance in a generic context.
-  //
-  // The size limit used is the size of an existential box's inline storage (see
-  // NumWords_ValueBuffer in the Swift repository.) Such values can be directly
-  // stored inside an `Attachment` and are cheap to copy.
-  if _isPOD(T.self) && MemoryLayout<T>.stride <= (MemoryLayout<Int>.stride * 3) {
-    return false
-  }
-
-  return true
-}
-
 // MARK: - Non-sendable and move-only attachments
 
-/// A type that stands in for an attachable value that is not also sendable.
-///
-/// This type is a value type so that we can mutate its properties while
-/// transferring information from the original attachable value. Consequently,
-/// instances will be boxed in an instance of `_HeapAllocatedAttachableProxy`
-/// when they are used to initialize instances of ``Test/Attachment``.
-private struct _EagerlyCopiedAttachableProxy: Test.Attachable, Sendable {
+/// A type that stands in for an attachable type that is not also sendable.
+private struct _AttachableProxy: Test.Attachable, Sendable {
   /// The result of `withUnsafeBufferPointer(for:_:)` from the original
   /// attachable value.
   var encodedValue = [UInt8]()
@@ -200,7 +135,7 @@ extension Test.Attachment {
     named preferredName: String? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
   ) {
-    var proxyAttachable = _EagerlyCopiedAttachableProxy()
+    var proxyAttachable = _AttachableProxy()
     proxyAttachable.estimatedAttachmentByteCount = attachableValue.estimatedAttachmentByteCount
 
     // BUG: the borrow checker thinks that withErrorRecording() is consuming


### PR DESCRIPTION
This reverts commit 3a537b8f4b590ae868e563276b7d45d0503034e3.

@grynspan should have done more digging before implementing this change, because it turns out the compiler/runtime already refcounts large existential boxes, so this work is redundant. 🫠

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
