### PR TITLE
Provide an environment flag to disable error backtrace capturing.

### DIFF
--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -353,24 +353,25 @@ extension Backtrace {
   /// This value is named oddly so that it shows up clearly in symbolicated
   /// backtraces.
   private static let __SWIFT_TESTING_IS_CAPTURING_A_BACKTRACE_FOR_A_THROWN_ERROR__: Void = {
-    if Environment.flag(named: "SWT_ERROR_BACKTRACING_ENABLED") == false {
-      // Backtraces have been explicitly disabled in the current environment.
-      return
+#if SWT_TARGET_OS_APPLE && !SWT_NO_DYNAMIC_LINKING
+    if Environment.flag(named: "SWT_FOUNDATION_ERROR_BACKTRACING_ENABLED") != false {
+      _ = isFoundationCaptureEnabled
     }
+#endif
 
-    _ = isFoundationCaptureEnabled
-
-    _oldWillThrowHandler.withLock { oldWillThrowHandler in
-      oldWillThrowHandler = swt_setWillThrowHandler { errorAddress in
-        let backtrace = Backtrace.current()
-        _willThrow(errorAddress, from: backtrace)
-      }
-    }
-    if #available(_typedThrowsAPI, *) {
-      _oldWillThrowTypedHandler.withLock { oldWillThrowTypedHandler in
-        oldWillThrowTypedHandler = swt_setWillThrowTypedHandler { errorAddress, errorType, errorConformance in
+    if Environment.flag(named: "SWT_SWIFT_ERROR_BACKTRACING_ENABLED") != false {
+      _oldWillThrowHandler.withLock { oldWillThrowHandler in
+        oldWillThrowHandler = swt_setWillThrowHandler { errorAddress in
           let backtrace = Backtrace.current()
-          _willThrowTyped(errorAddress, errorType, errorConformance, from: backtrace)
+          _willThrow(errorAddress, from: backtrace)
+        }
+      }
+      if #available(_typedThrowsAPI, *) {
+        _oldWillThrowTypedHandler.withLock { oldWillThrowTypedHandler in
+          oldWillThrowTypedHandler = swt_setWillThrowTypedHandler { errorAddress, errorType, errorConformance in
+            let backtrace = Backtrace.current()
+            _willThrowTyped(errorAddress, errorType, errorConformance, from: backtrace)
+          }
         }
       }
     }

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -353,6 +353,11 @@ extension Backtrace {
   /// This value is named oddly so that it shows up clearly in symbolicated
   /// backtraces.
   private static let __SWIFT_TESTING_IS_CAPTURING_A_BACKTRACE_FOR_A_THROWN_ERROR__: Void = {
+    if Environment.flag(named: "SWT_ERROR_BACKTRACING_ENABLED") == false {
+      // Backtraces have been explicitly disabled in the current environment.
+      return
+    }
+
     _ = isFoundationCaptureEnabled
 
     _oldWillThrowHandler.withLock { oldWillThrowHandler in


### PR DESCRIPTION
In performance-sensitive environments that throw many errors, the cost of capturing a backtrace for each one may be prohibitive. This PR allows disabling backtrace capture in environments where this is a problem.

Resolves #791.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
