### PR TITLE
Fix how we check if a range expression covers one value.

### DIFF
--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -204,7 +204,7 @@ extension Issue.Kind: CustomStringConvertible {
           // bound." That's sufficient for us to determine if the range contains
           // a single value.
           let upperBound = expected.first { $0 > lowerBound }
-          if let upperBound, upperBound > lowerBound && lowerBound == upperBound - 1 {
+          if upperBound == nil {
             return "Confirmation was confirmed \(actual.counting("time")), but expected to be confirmed \(lowerBound.counting("time"))"
           }
         }


### PR DESCRIPTION
My previous fix, #806, had the wrong logic to determine if a confirmation's expected count as-a-`RangeExpression` had exactly one value, so we were printing sub-optimal messages on test failures. Specifically, this:

```swift
await confirmation(expectedCount: 1) { // transformed to 1...1
  // fail to confirm
}
```

Would report "1...1 time(s)" instead of "1 time".

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
