### PR TITLE
[WIP] Add an associated `AttachmentMetadata` type to `Attachable`.

### DIFF
--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/Attachment+AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/Attachment+AttachableAsCGImage.swift
@@ -11,12 +11,6 @@
 #if SWT_TARGET_OS_APPLE && canImport(CoreGraphics)
 @_spi(Experimental) public import Testing
 
-public import UniformTypeIdentifiers
-
-#if canImport(CoreServices_Private)
-private import CoreServices_Private
-#endif
-
 extension Attachment {
   /// Initialize an instance of this type that encloses the given image.
   ///
@@ -41,25 +35,9 @@ extension Attachment {
   public init<T>(
     _ attachableValue: T,
     named preferredName: String?,
-    metadata: ImageAttachmentMetadata? = nil,
+    metadata: ImageAttachmentMetadata = .init(),
     sourceLocation: SourceLocation = #_sourceLocation
   ) where AttachableValue == _AttachableImageWrapper<T> {
-    var preferredName = preferredName ?? Self.defaultPreferredName
-    var metadata = metadata ?? ImageAttachmentMetadata()
-
-    // Update the preferred name to include an extension appropriate for the
-    // given content type. (Note the `else` branch duplicates the logic in
-    // `preferredContentType(forEncodingQuality:)` but will go away once our
-    // minimum deployment targets include the UniformTypeIdentifiers framework.)
-    if #available(_uttypesAPI, *) {
-      preferredName = (preferredName as NSString).appendingPathExtension(for: metadata.contentType)
-    } else {
-#if canImport(CoreServices_Private)
-      // The caller can't provide a content type, so we'll pick one for them.
-      preferredName = _UTTypeCreateSuggestedFilename(preferredName as CFString, metadata.typeIdentifier)?.takeRetainedValue() ?? preferredName
-#endif
-    }
-
     let imageContainer = _AttachableImageWrapper(attachableValue)
     self.init(imageContainer, named: preferredName, metadata: metadata, sourceLocation: sourceLocation)
   }

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/ImageAttachmentMetadata.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/ImageAttachmentMetadata.swift
@@ -48,9 +48,10 @@ public struct ImageAttachmentMetadata: Sendable {
       }
     }
     set {
+      lazy var newValueDescription = newValue.localizedDescription ?? newValue.identifier
       precondition(
         newValue.conforms(to: .image),
-        "An image cannot be attached as an instance of type '\(newValue.identifier)'. Use a type that conforms to 'public.image' instead."
+        "An image cannot be attached as an instance of type '\(newValueDescription)'. Use a type that conforms to 'public.image' instead."
       )
       _contentType = newValue
     }

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/ImageAttachmentMetadata.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/ImageAttachmentMetadata.swift
@@ -1,0 +1,97 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if SWT_TARGET_OS_APPLE && canImport(CoreGraphics)
+@_spi(Experimental) public import Testing
+private import CoreGraphics
+
+public import UniformTypeIdentifiers
+
+/// A type defining metadata used when attaching an image to a test.
+///
+/// The following system-provided image types can be attached to a test:
+///
+/// - [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage)
+@_spi(Experimental)
+public struct ImageAttachmentMetadata: Sendable {
+  /// The encoding quality to use when encoding the represented image.
+  ///
+  /// If the image format used for encoding (specified by the ``contentType``
+  /// property) does not support variable-quality encoding, the value of this
+  /// property is ignored.
+  public var encodingQuality: Float
+
+  /// Storage for ``contentType``.
+  private var _contentType: (any Sendable)?
+
+  /// The content type to use when encoding the image.
+  ///
+  /// The testing library uses this property to determine which image format to
+  /// encode the associated image as when it is attached to a test.
+  ///
+  /// If the value of this property does not conform to [`UTType.image`](https://developer.apple.com/documentation/uniformtypeidentifiers/uttype-swift.struct/image),
+  /// the result is undefined.
+  @available(_uttypesAPI, *)
+  var contentType: UTType {
+    get {
+      if let contentType = _contentType as? UTType {
+        return contentType
+      } else {
+        return encodingQuality < 1.0 ? .jpeg : .png
+      }
+    }
+    set {
+      precondition(
+        newValue.conforms(to: .image),
+        "An image cannot be attached as an instance of type '\(newValue.identifier)'. Use a type that conforms to 'public.image' instead."
+      )
+      _contentType = newValue
+    }
+  }
+
+  /// The content type to use when encoding the image, substituting a concrete
+  /// type for `UTType.image`.
+  ///
+  /// This property is not part of the public interface of the testing library.
+  @available(_uttypesAPI, *)
+  var computedContentType: UTType {
+    if let contentType = _contentType as? UTType, contentType != .image {
+      contentType
+    } else {
+      encodingQuality < 1.0 ? .jpeg : .png
+    }
+  }
+
+  /// The type identifier (as a `CFString`) corresponding to this instance's
+  /// ``computedContentType`` property.
+  ///
+  /// The value of this property is used by ImageIO when serializing an image.
+  ///
+  /// This property is not part of the public interface of the testing library.
+  /// It is used by ImageIO below.
+  var typeIdentifier: CFString {
+    if #available(_uttypesAPI, *) {
+      computedContentType.identifier as CFString
+    } else {
+      encodingQuality < 1.0 ? kUTTypeJPEG : kUTTypePNG
+    }
+  }
+
+  public init(encodingQuality: Float = 1.0) {
+    self.encodingQuality = encodingQuality
+  }
+
+  @available(_uttypesAPI, *)
+  public init(encodingQuality: Float = 1.0, contentType: UTType) {
+    self.encodingQuality = encodingQuality
+    self.contentType = contentType
+  }
+}
+#endif

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/_AttachableImageWrapper.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/_AttachableImageWrapper.swift
@@ -13,7 +13,11 @@ public import Testing
 private import CoreGraphics
 
 private import ImageIO
-import UniformTypeIdentifiers
+private import UniformTypeIdentifiers
+
+#if canImport(CoreServices_Private)
+private import CoreServices_Private
+#endif
 
 /// ## Why can't images directly conform to Attachable?
 ///
@@ -75,7 +79,8 @@ extension _AttachableImageWrapper: AttachableWrapper {
     let attachableCGImage = try image.attachableCGImage
 
     // Create the image destination.
-    guard let dest = CGImageDestinationCreateWithData(data as CFMutableData, attachment.metadata.typeIdentifier, 1, nil) else {
+    let typeIdentifier = attachment.metadata.typeIdentifier
+    guard let dest = CGImageDestinationCreateWithData(data as CFMutableData, typeIdentifier, 1, nil) else {
       throw ImageAttachmentError.couldNotCreateImageDestination
     }
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
@@ -22,6 +22,8 @@ public import Foundation
 ///   @Available(Swift, introduced: 6.2)
 /// }
 extension Attachable where Self: Encodable & NSSecureCoding {
+  public typealias AttachmentMetadata = EncodableAttachmentMetadata
+
   @_documentation(visibility: private)
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<Self>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     try _Testing_Foundation.withUnsafeBytes(encoding: self, for: attachment, body)

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
@@ -21,9 +21,7 @@ public import Foundation
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
 /// }
-extension Attachable where Self: Encodable & NSSecureCoding {
-  public typealias AttachmentMetadata = EncodableAttachmentMetadata
-
+extension Attachable where Self: Encodable & NSSecureCoding, AttachmentMetadata == EncodableAttachmentMetadata? {
   @_documentation(visibility: private)
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<Self>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     try _Testing_Foundation.withUnsafeBytes(encoding: self, for: attachment, body)

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
@@ -26,5 +26,10 @@ extension Attachable where Self: Encodable & NSSecureCoding, AttachmentMetadata 
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<Self>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     try _Testing_Foundation.withUnsafeBytes(encoding: self, for: attachment, body)
   }
+
+  @_documentation(visibility: private)
+  public func preferredName(for attachment: borrowing Attachment<Self>, basedOn suggestedName: String) -> String {
+    makePreferredName(from: suggestedName, for: attachment, defaultFormat: .json)
+  }
 }
 #endif

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+NSSecureCoding.swift
@@ -20,8 +20,13 @@ public import Foundation
 ///   @Available(Swift, introduced: 6.2)
 /// }
 extension Attachable where Self: NSSecureCoding {
-  public typealias AttachmentMetadata = EncodableAttachmentMetadata
+  public typealias AttachmentMetadata = EncodableAttachmentMetadata?
+}
 
+/// @Metadata {
+///   @Available(Swift, introduced: 6.2)
+/// }
+extension Attachable where Self: NSSecureCoding, AttachmentMetadata == EncodableAttachmentMetadata? {
   /// Encode this object using [`NSKeyedArchiver`](https://developer.apple.com/documentation/foundation/nskeyedarchiver)
   /// into a buffer, then call a function and pass that buffer to it.
   ///

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+NSSecureCoding.swift
@@ -20,6 +20,8 @@ public import Foundation
 ///   @Available(Swift, introduced: 6.2)
 /// }
 extension Attachable where Self: NSSecureCoding {
+  public typealias AttachmentMetadata = EncodableAttachmentMetadata
+
   /// Encode this object using [`NSKeyedArchiver`](https://developer.apple.com/documentation/foundation/nskeyedarchiver)
   /// into a buffer, then call a function and pass that buffer to it.
   ///
@@ -54,7 +56,7 @@ extension Attachable where Self: NSSecureCoding {
   ///   @Available(Swift, introduced: 6.2)
   /// }
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<Self>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
-    let format = try EncodingFormat(for: attachment)
+    let format = try EncodableAttachmentMetadata.Format(for: attachment)
 
     var data = try NSKeyedArchiver.archivedData(withRootObject: self, requiringSecureCoding: true)
     switch format {

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Data+Attachable.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Data+Attachable.swift
@@ -19,6 +19,11 @@ extension Data: Attachable {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
   /// }
+  public typealias AttachmentMetadata = Never?
+
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.2)
+  /// }
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<Self>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     try withUnsafeBytes(body)
   }

--- a/Sources/Overlays/_Testing_Foundation/Attachments/EncodableAttachmentMetadata.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/EncodableAttachmentMetadata.swift
@@ -1,0 +1,191 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if canImport(Foundation)
+import Testing
+public import Foundation
+
+#if SWT_TARGET_OS_APPLE && canImport(UniformTypeIdentifiers)
+private import UniformTypeIdentifiers
+#endif
+
+/// An enumeration describing the encoding formats supported by default when
+/// encoding a value that conforms to ``Testing/Attachable`` and either
+/// [`Encodable`](https://developer.apple.com/documentation/swift/encodable)
+/// or [`NSSecureCoding`](https://developer.apple.com/documentation/foundation/nssecurecoding).
+public struct EncodableAttachmentMetadata: Sendable {
+  /// An enumeration describing the encoding formats supported by default when
+  /// encoding a value that conforms to ``Testing/Attachable`` and either
+  /// [`Encodable`](https://developer.apple.com/documentation/swift/encodable)
+  /// or [`NSSecureCoding`](https://developer.apple.com/documentation/foundation/nssecurecoding).
+  public enum Format: Sendable {
+    /// The encoding format to use by default.
+    ///
+    /// The specific format this case corresponds to depends on if we are encoding
+    /// an `Encodable` value or an `NSSecureCoding` value.
+    case `default`
+
+    /// A property list format.
+    ///
+    /// - Parameters:
+    ///   - format: The corresponding property list format.
+    ///
+    /// OpenStep-style property lists are not supported.
+    case propertyListFormat(_ format: PropertyListSerialization.PropertyListFormat)
+
+    /// The JSON format.
+    case json
+  }
+
+  /// The format the attachable value should be encoded as.
+  public var format: Format
+
+  /// A type describing the various JSON encoding options to use if
+  /// [`JSONEncoder`](https://developer.apple.com/documentation/foundation/jsonencoder)
+  /// is used to encode the attachable value.
+  public struct JSONEncodingOptions: Sendable {
+    /// The output format to produce.
+    public var outputFormatting: JSONEncoder.OutputFormatting
+
+    /// The strategy to use in encoding dates.
+    public var dateEncodingStrategy: JSONEncoder.DateEncodingStrategy
+
+    /// The strategy to use in encoding binary data.
+    public var dataEncodingStrategy: JSONEncoder.DataEncodingStrategy
+
+    /// The strategy to use in encoding non-conforming numbers.
+    public var nonConformingFloatEncodingStrategy: JSONEncoder.NonConformingFloatEncodingStrategy
+
+    /// The strategy to use for encoding keys.
+    public var keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy
+  }
+
+  /// JSON encoding options to use if [`JSONEncoder`](https://developer.apple.com/documentation/foundation/jsonencoder)
+  /// is used to encode the attachable value.
+  ///
+  /// The default value of this property is `nil`, meaning that the default
+  /// options are used when encoding an attachable value as JSON. If an
+  /// attachable value is encoded in a format other than JSON, the value of this
+  /// property is ignored.
+  public var jsonEncodingOptions: JSONEncodingOptions?
+
+  /// A user info dictionary to provide to the property list encoder or JSON
+  /// encoder when encoding the attachable value.
+  ///
+  /// The value of this property is ignored when encoding an attachable value
+  /// that conforms to [`NSSecureCoding`](https://developer.apple.com/documentation/foundation/nssecurecoding)
+  /// but does not conform to [`Encodable`](https://developer.apple.com/documentation/swift/encodable).
+  public var userInfo: [CodingUserInfoKey: any Sendable]
+
+  public init(format: Format, jsonEncodingOptions: JSONEncodingOptions? = nil, userInfo: [CodingUserInfoKey: any Sendable] = [:]) {
+    self.format = format
+    self.jsonEncodingOptions = jsonEncodingOptions
+    self.userInfo = userInfo
+  }
+}
+
+// MARK: -
+
+extension EncodableAttachmentMetadata.JSONEncodingOptions {
+  public init(
+    outputFormatting: JSONEncoder.OutputFormatting? = nil,
+    dateEncodingStrategy: JSONEncoder.DateEncodingStrategy? = nil,
+    dataEncodingStrategy: JSONEncoder.DataEncodingStrategy? = nil,
+    nonConformingFloatEncodingStrategy: JSONEncoder.NonConformingFloatEncodingStrategy? = nil,
+    keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy? = nil
+  ) {
+    self = .default
+    self.outputFormatting = outputFormatting ?? self.outputFormatting
+    self.dateEncodingStrategy = dateEncodingStrategy ?? self.dateEncodingStrategy
+    self.dataEncodingStrategy = dataEncodingStrategy ?? self.dataEncodingStrategy
+    self.nonConformingFloatEncodingStrategy = nonConformingFloatEncodingStrategy ?? self.nonConformingFloatEncodingStrategy
+    self.keyEncodingStrategy = keyEncodingStrategy ?? self.keyEncodingStrategy
+  }
+
+  /// An instance of this type representing the default JSON encoding options
+  /// used by [`JSONEncoder`](https://developer.apple.com/documentation/foundation/jsonencoder).
+  public static let `default`: Self = {
+    // Get the default values from a real JSONEncoder for max authenticity!
+    let encoder = JSONEncoder()
+
+    return Self(
+      outputFormatting: encoder.outputFormatting,
+      dateEncodingStrategy: encoder.dateEncodingStrategy,
+      dataEncodingStrategy: encoder.dataEncodingStrategy,
+      nonConformingFloatEncodingStrategy: encoder.nonConformingFloatEncodingStrategy,
+      keyEncodingStrategy: encoder.keyEncodingStrategy
+    )
+  }()
+}
+
+// MARK: -
+
+extension EncodableAttachmentMetadata.Format {
+  /// Initialize an instance of this type representing the content type or media
+  /// type of the specified attachment.
+  ///
+  /// - Parameters:
+  ///   - attachment: The attachment that will be encoded.
+  ///
+  /// - Throws: If the attachment's content type or media type is unsupported.
+  init(for attachment: borrowing Attachment<some Attachable>) throws {
+    if let metadata = attachment.metadata {
+      if let format = metadata as? Self {
+        self = format
+        return
+      } else if let metadata = metadata as? EncodableAttachmentMetadata {
+        self = metadata.format
+        return
+      } else if let propertyListFormat = metadata as? PropertyListSerialization.PropertyListFormat {
+        self = .propertyListFormat(propertyListFormat)
+        return
+      }
+    }
+
+    let ext = (attachment.preferredName as NSString).pathExtension
+
+#if SWT_TARGET_OS_APPLE && canImport(UniformTypeIdentifiers)
+    // If the caller explicitly wants to encode their data as either XML or as a
+    // property list, use PropertyListEncoder. Otherwise, we'll fall back to
+    // JSONEncoder below.
+    if #available(_uttypesAPI, *), let contentType = UTType(filenameExtension: ext) {
+      if contentType == .data {
+        self = .default
+      } else if contentType.conforms(to: .json) {
+        self = .json
+      } else if contentType.conforms(to: .xml) {
+        self = .propertyListFormat(.xml)
+      } else if contentType.conforms(to: .binaryPropertyList) || contentType == .propertyList {
+        self = .propertyListFormat(.binary)
+      } else if contentType.conforms(to: .propertyList) {
+        self = .propertyListFormat(.openStep)
+      } else {
+        let contentTypeDescription = contentType.localizedDescription ?? contentType.identifier
+        throw CocoaError(.propertyListWriteInvalid, userInfo: [NSLocalizedDescriptionKey: "The content type '\(contentTypeDescription)' cannot be used to attach an instance of \(type(of: self)) to a test."])
+      }
+      return
+    }
+#endif
+
+    if ext.isEmpty {
+      // No path extension? No problem! Default data.
+      self = .default
+    } else if ext.caseInsensitiveCompare("plist") == .orderedSame {
+      self = .propertyListFormat(.binary)
+    } else if ext.caseInsensitiveCompare("xml") == .orderedSame {
+      self = .propertyListFormat(.xml)
+    } else if ext.caseInsensitiveCompare("json") == .orderedSame {
+      self = .json
+    } else {
+      throw CocoaError(.propertyListWriteInvalid, userInfo: [NSLocalizedDescriptionKey: "The path extension '.\(ext)' cannot be used to attach an instance of \(type(of: self)) to a test."])
+    }
+  }
+}
+#endif

--- a/Sources/Overlays/_Testing_Foundation/Attachments/EncodableAttachmentMetadata.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/EncodableAttachmentMetadata.swift
@@ -135,18 +135,10 @@ extension EncodableAttachmentMetadata.Format {
   ///   - attachment: The attachment that will be encoded.
   ///
   /// - Throws: If the attachment's content type or media type is unsupported.
-  init(for attachment: borrowing Attachment<some Attachable>) throws {
+  init<A>(for attachment: borrowing Attachment<A>) throws where A: Attachable, A.AttachmentMetadata == EncodableAttachmentMetadata? {
     if let metadata = attachment.metadata {
-      if let format = metadata as? Self {
-        self = format
-        return
-      } else if let metadata = metadata as? EncodableAttachmentMetadata {
-        self = metadata.format
-        return
-      } else if let propertyListFormat = metadata as? PropertyListSerialization.PropertyListFormat {
-        self = .propertyListFormat(propertyListFormat)
-        return
-      }
+      self = metadata.format
+      return
     }
 
     let ext = (attachment.preferredName as NSString).pathExtension

--- a/Sources/Testing/Attachments/Attachable.swift
+++ b/Sources/Testing/Attachments/Attachable.swift
@@ -31,6 +31,24 @@
 ///   @Available(Swift, introduced: 6.2)
 /// }
 public protocol Attachable: ~Copyable {
+  /// A type containing additional metadata about an instance of this attachable
+  /// type that a developer can optionally include when creating an attachment.
+  ///
+  /// Instances of this type can contain metadata that is not contained directly
+  /// in the attachable value itself. An instance of this type can be passed to
+  /// the initializers of ``Attachment`` and then accessed later via
+  /// ``Attachment/metadata``. Metadata is always optional; if your attachable
+  /// value _must_ include some value, consider adding it as a property of that
+  /// type instead of adding it as metadata.
+  ///
+  /// When implementing ``withUnsafeBufferPointer(for:_:)``, you can access the
+  /// attachment's ``Attachment/metadata`` property to get the metadata that was
+  /// passed when the attachment was created.
+  ///
+  /// By default, this type is equal to [`Never`](https://developer.apple.com/documentation/swift/never),
+  /// meaning that an attachable value has no metadata associated with it.
+  associatedtype AttachmentMetadata: Sendable & Copyable = Never
+
   /// An estimate of the number of bytes of memory needed to store this value as
   /// an attachment.
   ///

--- a/Sources/Testing/Attachments/Attachable.swift
+++ b/Sources/Testing/Attachments/Attachable.swift
@@ -37,17 +37,16 @@ public protocol Attachable: ~Copyable {
   /// Instances of this type can contain metadata that is not contained directly
   /// in the attachable value itself. An instance of this type can be passed to
   /// the initializers of ``Attachment`` and then accessed later via
-  /// ``Attachment/metadata``. Metadata is always optional; if your attachable
-  /// value _must_ include some value, consider adding it as a property of that
-  /// type instead of adding it as metadata.
+  /// ``Attachment/metadata``.
   ///
   /// When implementing ``withUnsafeBufferPointer(for:_:)``, you can access the
   /// attachment's ``Attachment/metadata`` property to get the metadata that was
   /// passed when the attachment was created.
   ///
-  /// By default, this type is equal to [`Never`](https://developer.apple.com/documentation/swift/never),
+  /// This type can be [`Optional`](https://developer.apple.com/documentation/swift/optional).
+  /// By default, this type is equal to [`Never?`](https://developer.apple.com/documentation/swift/never),
   /// meaning that an attachable value has no metadata associated with it.
-  associatedtype AttachmentMetadata: Sendable & Copyable = Never
+  associatedtype AttachmentMetadata: Sendable & Copyable = Never?
 
   /// An estimate of the number of bytes of memory needed to store this value as
   /// an attachment.

--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -30,7 +30,7 @@ public struct Attachment<AttachableValue>: ~Copyable where AttachableValue: Atta
   ///
   /// The type of this property depends on the type of the attachment's
   /// ``attachableValue-7dyjv`` property.
-  public var metadata: AttachableValue.AttachmentMetadata
+  public internal(set) var metadata: AttachableValue.AttachmentMetadata
 
   /// The path to which the this attachment was written, if any.
   ///
@@ -110,7 +110,7 @@ extension Attachment where AttachableValue: ~Copyable {
     sourceLocation: SourceLocation = #_sourceLocation
   ) {
     self._attachableValue = attachableValue
-    self._preferredName = preferredName ?? Self.defaultPreferredName
+    self._preferredName = preferredName
     self.metadata = metadata
     self.sourceLocation = sourceLocation
   }
@@ -138,7 +138,7 @@ extension Attachment where AttachableValue: ~Copyable {
     sourceLocation: SourceLocation = #_sourceLocation
   ) where AttachableValue.AttachmentMetadata == M? {
     self._attachableValue = attachableValue
-    self._preferredName = preferredName ?? Self.defaultPreferredName
+    self._preferredName = preferredName
     self.metadata = nil
     self.sourceLocation = sourceLocation
   }
@@ -580,7 +580,7 @@ extension Attachment where AttachableValue: ~Copyable {
   borrowing func write(toFileInDirectoryAtPath directoryPath: String, usingPreferredName: Bool = true, appending suffix: @autoclosure () -> String) throws -> String {
     let result: String
 
-    let preferredName = usingPreferredName ? preferredName : Self.defaultPreferredName
+    let preferredName = try usingPreferredName ? preferredName : Self.defaultPreferredName
 
     var file: FileHandle?
     do {

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -415,9 +415,9 @@ struct AttachmentTests {
       let attachment = Attachment(attachableValue, named: name)
       try open(attachment)
     } else {
-      let attachableValue = MyCodableAttachable(string: "stringly speaking")
-      let attachment = Attachment(attachableValue, named: name)
-      try open(attachment)
+//      let attachableValue = MyCodableAttachable(string: "stringly speaking")
+//      let attachment = Attachment(attachableValue, named: name)
+//      try open(attachment)
     }
   }
 
@@ -611,8 +611,7 @@ extension AttachmentTests {
     @available(_uttypesAPI, *)
     @Test func cannotAttachCGImageWithNonImageType() async {
       await #expect(processExitsWith: .failure) {
-        let attachment = Attachment(try Self.cgImage.get(), named: "diamond", metadata: .init(contentType: .mp3))
-        try attachment.attachableValue.withUnsafeBytes(for: attachment) { _ in }
+        _ = Attachment(try Self.cgImage.get(), named: "diamond", metadata: .init(contentType: .mp3))
       }
     }
 #endif


### PR DESCRIPTION
This PR adds a new associated type to `Attachable` that can be used to supply additional metadata to an attachment that is specific to that type. Metadata is always optional and the default type is `Never` (i.e. by default there is no metadata.)

The `Encodable` and `NSSecureCoding` conformances in the Foundation cross-import overlay have been updated such that this type equals a new structure that describes the format to use as well as options to pass to the JSON encoder (if one is used) and user info to pass to the plist or JSON encoders (if used.) We must use this type even for types that conform only to `NSSecureCoding`, otherwise we get compile-time errors about the type being ambiguous if a type conforms to both protocols and to `Attachable`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
