### PR TITLE
Change archive format for directories to .zip and add iOS/etc. support.

### DIFF
--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
@@ -241,6 +241,7 @@ private func compressContentsOfDirectory(at directoryURL: URL) async throws -> D
         continuation.resume(throwing: error)
       }
     }
+
     do {
       try process.run()
     } catch {

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
@@ -106,7 +106,7 @@ extension Attachment where AttachableValue == Data {
     }
 #else
     let data = if isDirectory {
-      try await compressContentsOfDirectory(at: url)
+      try await _compressContentsOfDirectory(at: url)
     } else {
       // Load the file.
       try Data(contentsOf: url, options: [.mappedIfSafe])
@@ -170,7 +170,7 @@ private let _archiverPath: String? = {
 ///
 /// This function asynchronously compresses the contents of `directoryURL` into
 /// an archive (currently of `.zip` format, although this is subject to change.)
-private func compressContentsOfDirectory(at directoryURL: URL) async throws -> Data {
+private func _compressContentsOfDirectory(at directoryURL: URL) async throws -> Data {
 #if !SWT_NO_PROCESS_SPAWNING
   let temporaryName = "\(UUID().uuidString).zip"
   let temporaryURL = FileManager.default.temporaryDirectory.appendingPathComponent(temporaryName)

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -275,7 +275,13 @@ struct AttachmentTests {
           return
         }
 
-        #expect(attachment.preferredName == "\(temporaryDirectoryName).tgz")
+        #expect(attachment.preferredName == "\(temporaryDirectoryName).zip")
+        try! attachment.withUnsafeBufferPointer { buffer in
+          #expect(buffer.count > 32)
+          #expect(buffer[0] == UInt8(ascii: "P"))
+          #expect(buffer[1] == UInt8(ascii: "K"))
+          #expect(buffer.contains("loremipsum.txt".utf8))
+        }
         valueAttached()
       }
 


### PR DESCRIPTION
This PR switches from .tar.gz as the preferred archive format for compressed directories to .zip and uses `NSFileCoordinator` on Darwin to enable support for iOS, watchOS, tvOS, and visionOS.

This feature remains experimental.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
