### PR TITLE
Fix a non-portable target reference in CMake helper function

### DIFF
--- a/cmake/modules/SwiftModuleInstallation.cmake
+++ b/cmake/modules/SwiftModuleInstallation.cmake
@@ -43,7 +43,7 @@ function(get_swift_testing_install_lib_dir type result_var_name)
 endfunction()
 
 function(_swift_testing_install_target module)
-  target_compile_options(Testing PRIVATE "-no-toolchain-stdlib-rpath")
+  target_compile_options(${module} PRIVATE "-no-toolchain-stdlib-rpath")
 
   if(APPLE)
     set_target_properties(${module} PROPERTIES


### PR DESCRIPTION
This fixes an oversight in a helper function in the project’s CMake rules: `_swift_testing_install_target()` has a hard-coded reference to the target named ”Testing” but it should instead refer to whatever target was passed in via the `module` argument to the function.

Discovered while working on #825.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
