### PR TITLE
[release/6.0] Testing: add some force unwraps for Android

### DIFF
--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -257,7 +257,7 @@ extension FileHandle {
     try withUnsafeCFILEHandle { file in
       try withUnsafeTemporaryAllocation(byteCount: 1024, alignment: 1) { buffer in
         repeat {
-          let countRead = fread(buffer.baseAddress, 1, buffer.count, file)
+          let countRead = fread(buffer.baseAddress!, 1, buffer.count, file)
           if 0 != ferror(file) {
             throw CError(rawValue: swt_errno())
           }
@@ -295,7 +295,7 @@ extension FileHandle {
         }
       }
 
-      let countWritten = fwrite(bytes.baseAddress, MemoryLayout<UInt8>.stride, bytes.count, file)
+      let countWritten = fwrite(bytes.baseAddress!, MemoryLayout<UInt8>.stride, bytes.count, file)
       if countWritten < bytes.count {
         throw CError(rawValue: swt_errno())
       }


### PR DESCRIPTION
Add some force unwraps to address nullability differences on Android from other platforms.

(cherry picked from commit d080ee2ff59e4a66109e9823aa91ca67b8dca7e7)

### Motivation:

This is needed to build the release/6.0 branch of testing for Android.

### Modifications:

Add force unwraps where they were needed.

### Result:

Android swift-testing builds on the release/6.0 branch.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
