### PR TITLE
[6.0] Update install to ensure the build directory is not added to the rpath

### DIFF
--- a/cmake/modules/SwiftModuleInstallation.cmake
+++ b/cmake/modules/SwiftModuleInstallation.cmake
@@ -32,12 +32,14 @@ function(_swift_testing_install_target module)
 
   if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(lib_destination_dir "lib/${swift}/${swift_os}/testing")
-    set_property(TARGET ${module} PROPERTY
-      INSTALL_RPATH "@loader_path/..")
+    set_target_properties(${module} PROPERTIES
+      INSTALL_RPATH "@loader_path/.."
+      INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
   else()
     set(lib_destination_dir "lib/${swift}/${swift_os}")
-    set_property(TARGET ${module} PROPERTY
-      INSTALL_RPATH "$ORIGIN")
+    set_target_properties(${module} PROPERTIES
+      INSTALL_RPATH "$ORIGIN"
+      INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
   endif()
 
   install(TARGETS ${module}


### PR DESCRIPTION
Per @bnbarham:

> This seems to be fine with the existing CMake, but in 3.29 (possibly earlier) the rpath of libTesting still has the build directory. Make sure to remove any existing build rpath.

  - **Explanation**: Cherry-picks changes to ensure the build directory is not added to the rpath.
  - **Scope**: Toolchain build.
  - **Issues**: N/A
  - **Original PRs**: https://github.com/swiftlang/swift-testing/pull/792
  - **Risk**: Low
  - **Testing**: Local CI run, will presumably need a complete toolchain build to very
  - **Reviewers**: @bnbarham @shahmishal @etcwilde @briancroom @stmontgomery