### PR TITLE
Document the steps for building & installing the project for macOS using CMake

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,48 @@ To learn how to run only specific tests or other testing options, run `swift
 test --help` to view the usage documentation.
 -->
 
+## Using CMake to build the project for macOS
+
+1. Install [CMake](https://cmake.org/) and [Ninja](https://ninja-build.org/).
+   - See the [Installing Dependencies](https://github.com/swiftlang/swift/blob/main/docs/HowToGuides/GettingStarted.md#macos)
+     section of the Swift [Getting Started](https://github.com/swiftlang/swift/blob/main/docs/HowToGuides/GettingStarted.md)
+     guide for instructions.
+
+1. Run the following command from the root of this repository to configure the
+   project to build using CMake (using the Ninja generator):
+
+   ```bash
+   cmake -G Ninja -B build
+   ```
+
+1. Run the following command to perform the build:
+
+   ```bash
+   cmake --build build
+   ```
+
+### Installing built content using CMake
+
+You can use the steps in this section to perform an install. This is primarily
+useful to validate the built content from this project which will be included in
+a Swift toolchain.
+
+1. Run the following command to (re-)configure the project with an install
+   prefix specified:
+
+   ```bash
+   cmake -G Ninja --install-prefix "$(pwd)/build/install" -B build
+   ```
+
+1. Perform the CMake build step as described in the previous section.
+
+1. Run the following command to install the built content into the
+   `build/install/` subdirectory:
+
+   ```bash
+   cmake --install build
+   ```
+
 ## Using Docker on macOS to test for Linux
 
 1. Install [Docker Desktop for Mac](https://www.docker.com/products/docker-desktop).


### PR DESCRIPTION
This adds documentation to `CONTRIBUTING.md` describing steps for building and installing the project for macOS using CMake.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
