### PR TITLE
Don't install the binary Swift module when building for Apple platforms

### DIFF
--- a/cmake/modules/SwiftModuleInstallation.cmake
+++ b/cmake/modules/SwiftModuleInstallation.cmake
@@ -86,13 +86,17 @@ function(_swift_testing_install_target module)
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
     DESTINATION "${module_dir}"
     RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftdoc)
-  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
-    DESTINATION "${module_dir}"
-    RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftmodule)
   if(APPLE)
     # Only Darwin has stable ABI. 
     install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftinterface
       DESTINATION "${module_dir}"
       RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftinterface)
+  else()
+    # Only install the binary .swiftmodule on platforms which do not have a
+    # stable ABI. Other platforms will use the textual .swiftinterface
+    # (installed above) and this limits access to this module's SPIs.
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+      DESTINATION "${module_dir}"
+      RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftmodule)
   endif()
 endfunction()


### PR DESCRIPTION
This modifies the CMake rules to stop installing binary .swiftmodule files when building for Apple platforms.

### Motivation:

Apple platforms have a stable ABI and modules for those platforms should instead use the textual .swiftinterface which is already installed by CMake. The binary .swiftmodule permits access to [SPI](https://github.com/swiftlang/swift-testing/blob/main/Documentation/SPI.md) declarations from the testing library, and these are not intended to be exposed in distribution builds. Although this PR only removes access to these on macOS, since it's the only platform which has a textual .swiftinterface currently, we intend to investigate ways to match this behavior for other platforms in the future.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://136083081