### PR TITLE
Add a `Bundle.testTarget` property.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,6 +104,7 @@ let package = Package(
       name: "_Testing_Foundation",
       dependencies: [
         "Testing",
+        "_TestingInternals"
       ],
       path: "Sources/Overlays/_Testing_Foundation",
       swiftSettings: .packageSettings

--- a/Sources/Overlays/_Testing_Foundation/CMakeLists.txt
+++ b/Sources/Overlays/_Testing_Foundation/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(_Testing_Foundation
   Attachments/Attachable+Encodable+NSSecureCoding.swift
   Attachments/Attachable+Encodable.swift
   Events/Clock+Date.swift
+  Support/Additions/BundleAdditions.swift
   ReexportTesting.swift)
 
 target_link_libraries(_Testing_Foundation PUBLIC

--- a/Sources/Overlays/_Testing_Foundation/Support/Additions/BundleAdditions.swift
+++ b/Sources/Overlays/_Testing_Foundation/Support/Additions/BundleAdditions.swift
@@ -1,0 +1,83 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if canImport(Foundation)
+@_spi(ForSwiftTestingOnly) private import Testing
+public import Foundation
+
+extension Bundle {
+#if SWT_TARGET_OS_APPLE && !SWT_NO_DYNAMIC_LINKING && !SWT_NO_FILE_IO
+  /// A string that appears within all auto-generated types conforming to the
+  /// `__TestContainer` protocol.
+  private static let _testContainerTypeNameMagic = "__🟠$test_container__"
+
+  /// Storage for ``testTarget``.
+  ///
+  /// On Apple platforms, the bundle containing test content is a loadable
+  /// XCTest bundle. By the time this property is read, the bundle should have
+  /// already been loaded.
+  private static let _testTarget: Bundle? = {
+    // If the calling environment sets "XCTestBundlePath" (as Xcode does), then
+    // we can rely on that variable rather than walking loaded images looking
+    // for test content.
+    if let envBundlePath = Environment.variable(named: "XCTestBundlePath"),
+       let bundle = Bundle(path: envBundlePath) {
+      return bundle
+    }
+
+    // Find the first image loaded into the current process that contains any
+    // test content.
+    var imageAddress: UnsafeRawPointer?
+    enumerateTypes(withNamesContaining: _testContainerTypeNameMagic) { thisImageAddress, _, stop in
+      imageAddress = thisImageAddress
+      stop = true
+    }
+
+    // Get the path to the image we found.
+    var info = Dl_info()
+    guard let imageAddress, 0 != dladdr(imageAddress, &info), let imageName = info.dli_fname else {
+      return nil
+    }
+
+    // Construct a lazy sequence of URLs corresponding to the directories that
+    // contain the loaded image.
+    let imageURL = URL(fileURLWithFileSystemRepresentation: imageName, isDirectory: false, relativeTo: nil)
+    let containingDirectoryURLs = sequence(first: imageURL) { url in
+      try? url.resourceValues(forKeys: [.parentDirectoryURLKey]).parentDirectory
+    }.dropFirst()
+
+    // Find the directory most likely to contain our test content and return it.
+    return containingDirectoryURLs.lazy
+      .filter { $0.pathExtension.caseInsensitiveCompare("xctest") == .orderedSame }
+      .compactMap(Bundle.init(url:))
+      .first { _ in true }
+  }()
+#endif
+
+  /// A bundle representing the currently-running test target.
+  ///
+  /// On Apple platforms, this bundle represents the test bundle built by Xcode
+  /// or Swift Package Manager. On other platforms, it is equal to the main
+  /// bundle and represents the test executable built by Swift Package Manager.
+  ///
+  /// If more than one test bundle has been loaded into the current process, the
+  /// value of this property represents the first test bundle found by the
+  /// testing library at runtime.
+  @_spi(Experimental)
+  public static var testTarget: Bundle {
+#if SWT_TARGET_OS_APPLE && !SWT_NO_DYNAMIC_LINKING && !SWT_NO_FILE_IO
+    _testTarget ?? main
+#else
+    // On other platforms, the main executable contains test content.
+    main
+#endif
+  }
+}
+#endif

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -15,7 +15,7 @@ private import _TestingInternals
 /// This type can be used to access the current process' environment variables.
 ///
 /// This type is not part of the public interface of the testing library.
-enum Environment {
+package enum Environment {
 #if SWT_NO_ENVIRONMENT_VARIABLES
   /// Storage for the simulated environment.
   ///
@@ -92,7 +92,7 @@ enum Environment {
   /// Get all environment variables in the current process.
   ///
   /// - Returns: A copy of the current process' environment dictionary.
-  static func get() -> [String: String] {
+  package static func get() -> [String: String] {
 #if SWT_NO_ENVIRONMENT_VARIABLES
     simulatedEnvironment.rawValue
 #elseif SWT_TARGET_OS_APPLE
@@ -140,7 +140,7 @@ enum Environment {
   ///
   /// - Returns: The value of the specified environment variable, or `nil` if it
   ///   is not set for the current process.
-  static func variable(named name: String) -> String? {
+  package static func variable(named name: String) -> String? {
 #if SWT_NO_ENVIRONMENT_VARIABLES
     simulatedEnvironment.rawValue[name]
 #elseif SWT_TARGET_OS_APPLE && !SWT_NO_DYNAMIC_LINKING
@@ -221,7 +221,7 @@ enum Environment {
   /// - String values beginning with the letters `"t"`, `"T"`, `"y"`, or `"Y"`
   ///   are interpreted as `true`; and
   /// - All other non-`nil` string values are interpreted as `false`.
-  static func flag(named name: String) -> Bool? {
+  package static func flag(named name: String) -> Bool? {
     variable(named: name).map {
       if let signedValue = Int64($0) {
         return signedValue != 0

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -58,7 +58,8 @@ extension Test {
 ///   - stop: An `inout` boolean variable indicating whether type enumeration
 ///     should stop after the function returns. Set `stop` to `true` to stop
 ///     type enumeration.
-typealias TypeEnumerator = (_ imageAddress: UnsafeRawPointer?, _ type: Any.Type, _ stop: inout Bool) -> Void
+@_spi(ForSwiftTestingOnly)
+public typealias TypeEnumerator = (_ imageAddress: UnsafeRawPointer?, _ type: Any.Type, _ stop: inout Bool) -> Void
 
 /// Enumerate all types known to Swift found in the current process whose names
 /// contain a given substring.
@@ -66,7 +67,8 @@ typealias TypeEnumerator = (_ imageAddress: UnsafeRawPointer?, _ type: Any.Type,
 /// - Parameters:
 ///   - nameSubstring: A string which the names of matching classes all contain.
 ///   - body: A function to invoke, once per matching type.
-func enumerateTypes(withNamesContaining nameSubstring: String, _ typeEnumerator: TypeEnumerator) {
+@_spi(ForSwiftTestingOnly)
+public func enumerateTypes(withNamesContaining nameSubstring: String, _ typeEnumerator: TypeEnumerator) {
   withoutActuallyEscaping(typeEnumerator) { typeEnumerator in
     withUnsafePointer(to: typeEnumerator) { context in
       swt_enumerateTypes(withNamesContaining: nameSubstring, .init(mutating: context)) { imageAddress, type, stop, context in

--- a/Tests/TestingTests/_Testing_Foundation/FoundationTests.swift
+++ b/Tests/TestingTests/_Testing_Foundation/FoundationTests.swift
@@ -8,17 +8,29 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_UTC_CLOCK
+#if canImport(Foundation)
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import _Testing_Foundation
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 import Foundation
 
 struct FoundationTests {
+#if !SWT_NO_UTC_CLOCK
   @Test("Casting Test.Clock.Instant to Date")
   func castTestClockInstantToDate() {
     let instant = Test.Clock.Instant.now
     let date = Date(instant)
     #expect(TimeInterval(instant.timeComponentsSince1970.seconds) == date.timeIntervalSince1970.rounded(.down))
   }
+#endif
+
+#if !SWT_NO_DYNAMIC_LINKING && !SWT_NO_FILE_IO
+  @Test("Test content bundle")
+  func testTargetBundle() {
+    let reportedTestTargetBundle = Bundle.testTarget
+    final class C {}
+    let actualTestTargetBundle = Bundle(for: C.self)
+    #expect(actualTestTargetBundle == reportedTestTargetBundle)
+  }
+#endif
 }
 #endif


### PR DESCRIPTION
This PR adds an experimental class property to `Bundle` in the Foundation cross-import overlay. The property's value represents the bundle containing the test target. On Apple platforms, this is an XCTest bundle. Elsewhere, it's just the main bundle.

This is an experimental interface only.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
