### PR TITLE
Make `Attachment` conform to `CustomStringConvertible`.

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -148,6 +148,21 @@ public struct AnyAttachable: AttachableContainer, Copyable, Sendable {
   }
 }
 
+// MARK: - Describing an attachment
+
+extension Attachment where AttachableValue: ~Copyable {
+  public var description: String {
+    let typeInfo = TypeInfo(describing: AttachableValue.self)
+    return #""\#(preferredName)": instance of '\#(typeInfo.unqualifiedName)'"#
+  }
+}
+
+extension Attachment: CustomStringConvertible {
+  public var description: String {
+    #""\#(preferredName)": \#(String(describingForTest: attachableValue))"#
+  }
+}
+
 // MARK: - Getting an attachable value from an attachment
 
 @_spi(Experimental)

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -30,6 +30,20 @@ struct AttachmentTests {
     attachment.attach()
   }
 
+  @Test func description() {
+    let attachableValue = MySendableAttachable(string: "<!doctype html>")
+    let attachment = Attachment(attachableValue, named: "AttachmentTests.saveValue.html")
+    #expect(String(describing: attachment).contains(#""\#(attachment.preferredName)""#))
+    #expect(attachment.description.contains("MySendableAttachable("))
+  }
+
+  @Test func moveOnlyDescription() {
+    let attachableValue = MyAttachable(string: "<!doctype html>")
+    let attachment = Attachment(attachableValue, named: "AttachmentTests.saveValue.html")
+    #expect(attachment.description.contains(#""\#(attachment.preferredName)""#))
+    #expect(attachment.description.contains("'MyAttachable'"))
+  }
+
 #if !SWT_NO_FILE_IO
   func compare(_ attachableValue: borrowing MySendableAttachable, toContentsOfFileAtPath filePath: String) throws {
     let file = try FileHandle(forReadingAtPath: filePath)


### PR DESCRIPTION
This PR adds `CustomStringConvertible` conformance to `Attachment`. Note that if the attachable value is a move-only type, the conformance is not available in the stdlib, but we still provide a `description` property.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
