### PR TITLE
Fix multiline comments not rendering correctly at CLI.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -92,19 +92,7 @@ extension Event.HumanReadableOutputRecorder {
   /// - Returns: A formatted string representing `comments`, or `nil` if there
   ///   are none.
   private func _formattedComments(_ comments: [Comment]) -> [Message] {
-    // Insert an arrow character at the start of each comment, then indent any
-    // additional lines in the comment to align them with the arrow.
-    comments.lazy
-      .flatMap { comment in
-        let lines = comment.rawValue.split(whereSeparator: \.isNewline)
-        if let firstLine = lines.first {
-          let remainingLines = lines.dropFirst()
-          return CollectionOfOne(Message(symbol: .details, stringValue: String(firstLine))) + remainingLines.lazy
-            .map(String.init)
-            .map { Message(stringValue: $0) }
-        }
-        return []
-      }
+    comments.map { Message(symbol: .details, stringValue: $0.rawValue) }
   }
 
   /// Get a string representing the comments attached to a test, formatted for


### PR DESCRIPTION
This PR fixes a bug where a multi-line comment or message written to `stderr` would only have its first line in grey and would not write atomically, resulting in odd/incorrect output. All messages generated by a test event are now written to `stderr` atomically.

Resolves rdar://134519515.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
