### PR TITLE
[6.1] Adopt prerelease tags of swift-syntax-601.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.0-latest"),
   ],
 
   targets: [

--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -31,7 +31,7 @@ if(SwiftTesting_BuildMacrosAsExecutables)
   set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/_d)
   FetchContent_Declare(SwiftSyntax
     GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
-    GIT_TAG cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25) # 600.0.0
+    GIT_TAG 1cd35348b089ff8966588742c69727205d99f8ed) # 601.0.0-prerelease-2024-11-18
   FetchContent_MakeAvailable(SwiftSyntax)
 endif()
 

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -19,6 +19,7 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     guard _diagnoseIssues(with: declaration, suiteAttribute: node, in: context) else {


### PR DESCRIPTION
  - **Explanation**: Update our swift-syntax package dependency.
  - **Scope**: 6.1 release when building as a package
  - **Issues**: N/A
  - **Original PRs**: #847
  - **Risk**: Low (no obvious issues)
  - **Testing**: All tests continue to pass. No additional testing needed.
  - **Reviewers**: @briancroom @stmontgomery