### PR TITLE
Add example for how to test any error is thrown in the error testing documentation article

### DIFF
--- a/Sources/Testing/Testing.docc/testing-for-errors-in-swift-code.md
+++ b/Sources/Testing/Testing.docc/testing-for-errors-in-swift-code.md
@@ -46,10 +46,10 @@ running your test if the code doesn't throw the expected error.
 
 ### Validate that your code throws any error
 
-To check that the code under test throws any error, or to continue a
-longer test function after the code throws an error, pass that `(any Error).self` as the
-first argument of ``expect(throws:_:sourceLocation:performing:)-1xr34``, and
-pass a closure that calls the code under test:
+To check that the code under test throws an error of any type, pass
+`(any Error).self` as the first argument to either
+``expect(throws:_:sourceLocation:performing:)-1xr34`` or
+``require(_:_:sourceLocation:)-5l63q``:
 
 ```swift
 @Test func cannotAddToppingToPizzaBeforeStartOfList() {

--- a/Sources/Testing/Testing.docc/testing-for-errors-in-swift-code.md
+++ b/Sources/Testing/Testing.docc/testing-for-errors-in-swift-code.md
@@ -44,6 +44,22 @@ test that the code throws an error of a given type, or matches an arbitrary
 Boolean test. Similar overloads of ``require(_:_:sourceLocation:)-5l63q`` stop
 running your test if the code doesn't throw the expected error.
 
+### Validate that your code throws any error
+
+To check that the code under test throws any error, or to continue a
+longer test function after the code throws an error, pass that `(any Error).self` as the
+first argument of ``expect(throws:_:sourceLocation:performing:)-1xr34``, and
+pass a closure that calls the code under test:
+
+```swift
+@Test func cannotAddToppingToPizzaBeforeStartOfList() {
+  var order = PizzaToppings(bases: [.calzone, .deepCrust])
+  #expect(throws: (any Error).self) {
+    try order.add(topping: .mozarella, toPizzasIn: -1..<0)
+  }
+}
+```
+
 ### Validate that your code doesn't throw an error
 
 A test function that throws an error fails, which is usually sufficient for


### PR DESCRIPTION
I was stumped earlier when trying to find the details for how to test that any error is thrown. This detail _is_ in the migrating from XCTest content, but I landed on this page, and it seemed an odd miss, especially given the history of ignoring the kind of error in many cases.  (I found my solution in [a post by Jonathan the forums](https://forums.swift.org/t/swift-testing-whats-the-recommend-approach-to-test-throwing-function/70806/2).)

While it is duplicated content, this would have helped me - so I'm proposing it for a documentation update. Happy to edit as y'all see fit.