### PR TITLE
Fix `posix_spawn()` error handling.

### DIFF
--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -175,8 +175,9 @@ func spawnExecutable(
       }
 
       var pid = pid_t()
-      guard 0 == posix_spawn(&pid, executablePath, fileActions, attrs, argv, environ) else {
-        throw CError(rawValue: swt_errno())
+      let processSpawned = posix_spawn(&pid, executablePath, fileActions, attrs, argv, environ)
+      guard 0 == processSpawned else {
+        throw CError(rawValue: processSpawned)
       }
       return pid
     }


### PR DESCRIPTION
`posix_spawn()` does not (portably) set `errno`. Instead, it returns its error code. Fix our call.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
