### PR TITLE
[6.1] [SWT-0006] Return the thrown error from `#expect(throws:)` and `#require(throws:)`.

### DIFF
--- a/Documentation/Proposals/0006-return-errors-from-expect-throws.md
+++ b/Documentation/Proposals/0006-return-errors-from-expect-throws.md
@@ -1,0 +1,267 @@
+# Return errors from `#expect(throws:)`
+
+* Proposal: [SWT-0006](0006-filename.md)
+* Authors: [Jonathan Grynspan](https://github.com/grynspan)
+* Status: **Awaiting review**
+* Bug: rdar://138235250
+* Implementation: [swiftlang/swift-testing#780](https://github.com/swiftlang/swift-testing/pull/780)
+* Review: ([pitch](https://forums.swift.org/t/pitch-returning-errors-from-expect-throws/75567))
+
+## Introduction
+
+Swift Testing includes overloads of `#expect()` and `#require()` that can be
+used to assert that some code throws an error. They are useful when validating
+that your code's failure cases are correctly detected and handled. However, for
+more complex validation cases, they aren't particularly ergonomic. This proposal
+seeks to resolve that issue by having these overloads return thrown errors for
+further inspection.
+
+## Motivation
+
+We offer three variants of `#expect(throws:)`:
+
+- One that takes an error type, and matches any error of the same type;
+- One that takes an error _instance_ (conforming to `Equatable`) and matches any
+  error that compares equal to it; and
+- One that takes a trailing closure and allows test authors to write arbitrary
+  validation logic.
+
+The third overload has proven to be somewhat problematic. First, it yields the
+error to its closure as an instance of `any Error`, which typically forces the
+developer to cast it before doing any useful comparisons. Second, the test
+author must return `true` to indicate the error matched and `false` to indicate
+it didn't, which can be both logically confusing and difficult to express
+concisely:
+
+```swift
+try #require {
+  let potato = try Sack.randomPotato()
+  try potato.turnIntoFrenchFries()
+} throws: { error in
+  guard let error = error as PotatoError else {
+    return false
+  }
+  guard case .potatoNotPeeled = error else {
+    return false
+  }
+  return error.variety != .russet
+}
+```
+
+The first impulse many test authors have here is to use `#expect()` in the
+second closure, but it doesn't return the necessary boolean value _and_ it can
+result in multiple issues being recorded in a test when there's really only one.
+
+## Proposed solution
+
+I propose deprecating [`#expect(_:sourceLocation:performing:throws:)`](https://developer.apple.com/documentation/testing/expect(_:sourcelocation:performing:throws:))
+and [`#require(_:sourceLocation:performing:throws:)`](https://developer.apple.com/documentation/testing/require(_:sourcelocation:performing:throws:))
+and modifying the other overloads so that, on success, they return the errors
+that were thrown.
+
+## Detailed design
+
+All overloads of `#expect(throws:)` and `#require(throws:)` will be updated to
+return an instance of the error type specified by their arguments, with the
+problematic overloads returning `any Error` since more precise type information
+is not statically available. The problematic overloads will also be deprecated:
+
+```diff
+--- a/Sources/Testing/Expectations/Expectation+Macro.swift
++++ b/Sources/Testing/Expectations/Expectation+Macro.swift
++@discardableResult
+ @freestanding(expression) public macro expect<E, R>(
+   throws errorType: E.Type,
+   _ comment: @autoclosure () -> Comment? = nil,
+   sourceLocation: SourceLocation = #_sourceLocation,
+   performing expression: () async throws -> R
+-)
++) -> E? where E: Error
+
++@discardableResult
+ @freestanding(expression) public macro require<E, R>(
+   throws errorType: E.Type,
+   _ comment: @autoclosure () -> Comment? = nil,
+   sourceLocation: SourceLocation = #_sourceLocation,
+   performing expression: () async throws -> R
+-) where E: Error
++) -> E where E: Error
+
++@discardableResult
+ @freestanding(expression) public macro expect<E, R>(
+   throws error: E,
+   _ comment: @autoclosure () -> Comment? = nil,
+   sourceLocation: SourceLocation = #_sourceLocation,
+   performing expression: () async throws -> R
+-) where E: Error & Equatable
++) -> E? where E: Error & Equatable
+
++@discardableResult
+ @freestanding(expression) public macro require<E, R>(
+   throws error: E,
+   _ comment: @autoclosure () -> Comment? = nil,
+   sourceLocation: SourceLocation = #_sourceLocation,
+   performing expression: () async throws -> R
+-) where E: Error & Equatable
++) -> E where E: Error & Equatable
+
++@available(*, deprecated, message: "Examine the result of '#expect(throws:)' instead.")
++@discardableResult
+ @freestanding(expression) public macro expect<R>(
+   _ comment: @autoclosure () -> Comment? = nil,
+   sourceLocation: SourceLocation = #_sourceLocation,
+   performing expression: () async throws -> R,
+   throws errorMatcher: (any Error) async throws -> Bool
+-)
++) -> (any Error)?
+
++@available(*, deprecated, message: "Examine the result of '#require(throws:)' instead.")
++@discardableResult
+ @freestanding(expression) public macro require<R>(
+   _ comment: @autoclosure () -> Comment? = nil,
+   sourceLocation: SourceLocation = #_sourceLocation,
+   performing expression: () async throws -> R,
+   throws errorMatcher: (any Error) async throws -> Bool
+-)
++) -> any Error
+```
+
+(More detailed information about the deprecations will be provided via DocC.)
+
+The `#expect(throws:)` overloads return an optional value that is `nil` if the
+expectation failed, while the `#require(throws:)` overloads return non-optional
+values and throw instances of `ExpectationFailedError` on failure (as before.)
+
+> [!NOTE]
+> Instances of `ExpectationFailedError` thrown by `#require(throws:)` on failure
+> are not returned as that would defeat the purpose of using `#require(throws:)`
+> instead of `#expect(throws:)`.
+
+Test authors will be able to use the result of the above functions to verify
+that the thrown error is correct:
+
+```swift
+let error = try #require(throws: PotatoError.self) {
+  let potato = try Sack.randomPotato()
+  try potato.turnIntoFrenchFries()
+}
+#expect(error == .potatoNotPeeled)
+#expect(error.variety != .russet)
+```
+
+The new code is more concise than the old code and avoids boilerplate casting
+from `any Error`.
+
+## Source compatibility
+
+In most cases, this change does not affect source compatibility. Swift does not
+allow forming references to macros at runtime, so we don't need to worry about
+type mismatches assigning one to some local variable.
+
+We have identified two scenarios where a new warning will be emitted.
+
+### Inferred return type from macro invocation
+
+The return type of the macro may be used by the compiler to infer the return
+type of an enclosing closure. If the return value is then discarded, the
+compiler may emit a warning:
+
+```swift
+func pokePotato(_ pPotato: UnsafePointer<Potato>) throws { ... }
+
+let potato = Potato()
+try await Task.sleep(for: .months(3))
+withUnsafePointer(to: potato) { pPotato in
+  // ^ ^ ^ ⚠️ Result of call to 'withUnsafePointer(to:_:)' is unused
+  #expect(throws: PotatoError.rotten) {
+    try pokePotato(pPotato)
+  }
+}
+```
+
+This warning can be suppressed by assigning the result of the macro invocation
+or the result of the function call to `_`:
+
+```swift
+withUnsafePointer(to: potato) { pPotato in
+  _ = #expect(throws: PotatoError.rotten) {
+    try pokePotato(pPotato)
+  }
+}
+```
+
+### Use of `#require(throws:)` in a generic context with `Never.self`
+
+If `#require(throws:)` (but not `#expect(throws:)`) is used in a generic context
+where the type of thrown error is a generic parameter, and the type is resolved
+to `Never`, there is no valid value for the invocation to return:
+
+```swift
+func wrapper<E>(throws type: E.Type, _ body: () throws -> Void) throws -> E {
+  return try #require(throws: type) {
+    try body()
+  }
+}
+let error = try #require(throws: Never.self) { ... }
+```
+
+We don't think this particular pattern is common (and outside of our own test
+target, I'd be surprised if anybody's attempted it yet.) However, we do need to
+handle it gracefully. If this pattern is encountered, Swift Testing will record
+an "API Misused" issue for the current test and advise the test author to switch
+to `#expect(throws:)` or to not pass `Never.self` here.
+
+## Integration with supporting tools
+
+N/A
+
+## Future directions
+
+- Adopting [typed throws](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md)
+  to statically require that the error thrown from test code is of the correct
+  type.
+
+  If we adopted typed throws in the signatures of these macros, it would force
+  adoption of typed throws in the code under test even when it may not be
+  appropriate. For example, if we adopted typed throws, the following code would
+  not compile:
+
+  ```swift
+  func cook(_ food: consuming some Food) throws { ... }
+
+  let error: PotatoError? = #expect(throws: PotatoError.self) {
+    var potato = Potato()
+    potato.fossilize()
+    try cook(potato) // 🛑 ERROR: Invalid conversion of thrown error type
+                     // 'any Error' to 'PotatoError'
+  }
+  ```
+
+  We believe it may be possible to overload these macros or their expansions so
+  that the code sample above _does_ compile and behave as intended. We intend to
+  experiment further with this idea and potentially revisit typed throws support
+  in a future proposal.
+
+## Alternatives considered
+
+- Leaving the existing implementation and signatures in place. We've had
+  sufficient feedback about the ergonomics of this API that we want to address
+  the problem.
+
+- Having the return type of the macros be `any Error` and returning _any_ error
+  that was thrown even on mismatch. This would make the ergonomics of the
+  subsequent test code less optimal because the test author would need to cast
+  the error to the appropriate type before inspecting it.
+
+  There's a philosophical argument to be made here that if a mismatched error is
+  thrown, then the test has already failed and is in an inconsistent state, so
+  we should allow the test to fail rather than return what amounts to "bad
+  output".
+
+  If the test author wants to inspect any arbitrary thrown error, they can
+  specify `(any Error).self` instead of a concrete error type.
+
+## Acknowledgments
+
+Thanks to the team and to [@jakepetroules](https://github.com/jakepetroules) for
+starting the discussion that ultimately led to this proposal.

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -142,6 +142,9 @@ public macro require<T>(
 ///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///
+/// - Returns: If the expectation passes, the instance of `errorType` that was
+///   thrown by `expression`. If the expectation fails, the result is `nil`.
+///
 /// Use this overload of `#expect()` when the expression `expression` _should_
 /// throw an error of a given type:
 ///
@@ -158,7 +161,7 @@ public macro require<T>(
 /// discarded.
 ///
 /// If the thrown error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
-/// use ``expect(throws:_:sourceLocation:performing:)-1xr34`` instead.
+/// use ``expect(throws:_:sourceLocation:performing:)-7du1h`` instead.
 ///
 /// ## Expressions that should never throw
 ///
@@ -181,12 +184,13 @@ public macro require<T>(
 /// fail when an error is thrown by `expression`, rather than to explicitly
 /// check that an error is _not_ thrown by it, do not use this macro. Instead,
 /// simply call the code in question and allow it to throw an error naturally.
+@discardableResult
 @freestanding(expression) public macro expect<E, R>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: () async throws -> R
-) = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error
+) -> E? = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error
 
 /// Check that an expression always throws an error of a given type, and throw
 /// an error if it does not.
@@ -199,6 +203,8 @@ public macro require<T>(
 ///   - sourceLocation: The source location to which recorded expectations and
 ///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
+///
+/// - Returns: The instance of `errorType` that was thrown by `expression`.
 ///
 /// - Throws: An instance of ``ExpectationFailedError`` if `expression` does not
 ///   throw a matching error. The error thrown by `expression` is not rethrown.
@@ -219,16 +225,17 @@ public macro require<T>(
 /// is thrown. Any value returned by `expression` is discarded.
 ///
 /// If the thrown error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
-/// use ``require(throws:_:sourceLocation:performing:)-7v83e`` instead.
+/// use ``require(throws:_:sourceLocation:performing:)-4djuw`` instead.
 ///
 /// If `expression` should _never_ throw, simply invoke the code without using
 /// this macro. The test will then fail if an error is thrown.
+@discardableResult
 @freestanding(expression) public macro require<E, R>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: () async throws -> R
-) = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error
+) -> E = #externalMacro(module: "TestingMacros", type: "RequireThrowsMacro") where E: Error
 
 /// Check that an expression never throws an error, and throw an error if it
 /// does.
@@ -261,6 +268,10 @@ public macro require<R>(
 ///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///
+/// - Returns: If the expectation passes, the instance of `E` that was thrown by
+///   `expression` and is equal to `error`. If the expectation fails, the result
+///   is `nil`.
+///
 /// Use this overload of `#expect()` when the expression `expression` _should_
 /// throw a specific error:
 ///
@@ -276,13 +287,14 @@ public macro require<R>(
 /// in the current task. Any value returned by `expression` is discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
-/// ``expect(throws:_:sourceLocation:performing:)-79piu`` instead.
+/// ``expect(throws:_:sourceLocation:performing:)-1hfms`` instead.
+@discardableResult
 @freestanding(expression) public macro expect<E, R>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: () async throws -> R
-) = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error & Equatable
+) -> E? = #externalMacro(module: "TestingMacros", type: "ExpectMacro") where E: Error & Equatable
 
 /// Check that an expression always throws a specific error, and throw an error
 /// if it does not.
@@ -293,6 +305,9 @@ public macro require<R>(
 ///   - sourceLocation: The source location to which recorded expectations and
 ///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
+
+/// - Returns: The instance of `E` that was thrown by `expression` and is equal
+///   to `error`.
 ///
 /// - Throws: An instance of ``ExpectationFailedError`` if `expression` does not
 ///   throw a matching error. The error thrown by `expression` is not rethrown.
@@ -313,13 +328,14 @@ public macro require<R>(
 /// Any value returned by `expression` is discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
-/// ``require(throws:_:sourceLocation:performing:)-76bjn`` instead.
+/// ``require(throws:_:sourceLocation:performing:)-7n34r`` instead.
+@discardableResult
 @freestanding(expression) public macro require<E, R>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: () async throws -> R
-) = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error & Equatable
+) -> E = #externalMacro(module: "TestingMacros", type: "RequireMacro") where E: Error & Equatable
 
 // MARK: - Arbitrary error matching
 
@@ -332,6 +348,9 @@ public macro require<R>(
 ///   - expression: The expression to be evaluated.
 ///   - errorMatcher: A closure to invoke when `expression` throws an error that
 ///     indicates if it matched or not.
+///
+/// - Returns: If the expectation passes, the error that was thrown by
+///   `expression`. If the expectation fails, the result is `nil`.
 ///
 /// Use this overload of `#expect()` when the expression `expression` _should_
 /// throw an error, but the logic to determine if the error matches is complex:
@@ -353,15 +372,17 @@ public macro require<R>(
 /// discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
-/// ``expect(throws:_:sourceLocation:performing:)-79piu`` instead. If the thrown
+/// ``expect(throws:_:sourceLocation:performing:)-1hfms`` instead. If the thrown
 /// error need only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
-/// use ``expect(throws:_:sourceLocation:performing:)-1xr34`` instead.
+/// use ``expect(throws:_:sourceLocation:performing:)-7du1h`` instead.
+@available(*, deprecated, message: "Examine the result of '#expect(throws:)' instead.")
+@discardableResult
 @freestanding(expression) public macro expect<R>(
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: () async throws -> R,
   throws errorMatcher: (any Error) async throws -> Bool
-) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
+) -> (any Error)? = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
 
 /// Check that an expression always throws an error matching some condition, and
 /// throw an error if it does not.
@@ -373,6 +394,8 @@ public macro require<R>(
 ///   - expression: The expression to be evaluated.
 ///   - errorMatcher: A closure to invoke when `expression` throws an error that
 ///     indicates if it matched or not.
+///
+/// - Returns: The error that was thrown by `expression`.
 ///
 /// - Throws: An instance of ``ExpectationFailedError`` if `expression` does not
 ///   throw a matching error. The error thrown by `expression` is not rethrown.
@@ -398,18 +421,20 @@ public macro require<R>(
 /// discarded.
 ///
 /// If the thrown error need only be an instance of a particular type, use
-/// ``require(throws:_:sourceLocation:performing:)-76bjn`` instead. If the thrown error need
+/// ``require(throws:_:sourceLocation:performing:)-7n34r`` instead. If the thrown error need
 /// only equal another instance of [`Error`](https://developer.apple.com/documentation/swift/error),
-/// use ``require(throws:_:sourceLocation:performing:)-7v83e`` instead.
+/// use ``require(throws:_:sourceLocation:performing:)-4djuw`` instead.
 ///
 /// If `expression` should _never_ throw, simply invoke the code without using
 /// this macro. The test will then fail if an error is thrown.
+@available(*, deprecated, message: "Examine the result of '#require(throws:)' instead.")
+@discardableResult
 @freestanding(expression) public macro require<R>(
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: () async throws -> R,
   throws errorMatcher: (any Error) async throws -> Bool
-) = #externalMacro(module: "TestingMacros", type: "RequireMacro")
+) -> any Error = #externalMacro(module: "TestingMacros", type: "RequireMacro")
 
 // MARK: - Exit tests
 
@@ -425,7 +450,7 @@ public macro require<R>(
 ///     issues should be attributed.
 ///   - expression: The expression to be evaluated.
 ///
-/// - Returns: If the exit test passed, an instance of ``ExitTestArtifacts``
+/// - Returns: If the exit test passes, an instance of ``ExitTestArtifacts``
 ///   describing the state of the exit test when it exited. If the exit test
 ///   fails, the result is `nil`.
 ///

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -824,7 +824,8 @@ public func __checkCast<V, T>(
 /// Check that an expression always throws an error.
 ///
 /// This overload is used for `#expect(throws:) { }` invocations that take error
-/// types.
+/// types. It is disfavored so that `#expect(throws: Never.self)` preferentially
+/// returns `Void`.
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
@@ -835,7 +836,7 @@ public func __checkClosureCall<E>(
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
-) -> Result<Void, any Error> where E: Error {
+) -> Result<E?, any Error> where E: Error {
   if errorType == Never.self {
     __checkClosureCall(
       throws: Never.self,
@@ -844,7 +845,7 @@ public func __checkClosureCall<E>(
       comments: comments(),
       isRequired: isRequired,
       sourceLocation: sourceLocation
-    )
+    ).map { _ in nil }
   } else {
     __checkClosureCall(
       performing: body,
@@ -854,14 +855,15 @@ public func __checkClosureCall<E>(
       comments: comments(),
       isRequired: isRequired,
       sourceLocation: sourceLocation
-    )
+    ).map { $0 as? E }
   }
 }
 
 /// Check that an expression always throws an error.
 ///
 /// This overload is used for `await #expect(throws:) { }` invocations that take
-/// error types.
+/// error types. It is disfavored so that `#expect(throws: Never.self)`
+/// preferentially returns `Void`.
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
@@ -873,7 +875,7 @@ public func __checkClosureCall<E>(
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
   sourceLocation: SourceLocation
-) async -> Result<Void, any Error> where E: Error {
+) async -> Result<E?, any Error> where E: Error {
   if errorType == Never.self {
     await __checkClosureCall(
       throws: Never.self,
@@ -883,7 +885,7 @@ public func __checkClosureCall<E>(
       isRequired: isRequired,
       isolation: isolation,
       sourceLocation: sourceLocation
-    )
+    ).map { _ in nil }
   } else {
     await __checkClosureCall(
       performing: body,
@@ -894,7 +896,7 @@ public func __checkClosureCall<E>(
       isRequired: isRequired,
       isolation: isolation,
       sourceLocation: sourceLocation
-    )
+    ).map { $0 as? E }
   }
 }
 
@@ -932,7 +934,7 @@ public func __checkClosureCall(
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
-  )
+  ).map { _ in }
 }
 
 /// Check that an expression never throws an error.
@@ -969,7 +971,7 @@ public func __checkClosureCall(
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
-  )
+  ).map { _ in }
 }
 
 // MARK: - Matching instances of equatable errors
@@ -988,7 +990,7 @@ public func __checkClosureCall<E>(
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
-) -> Result<Void, any Error> where E: Error & Equatable {
+) -> Result<E?, any Error> where E: Error & Equatable {
   __checkClosureCall(
     performing: body,
     throws: { true == (($0 as? E) == error) },
@@ -997,7 +999,7 @@ public func __checkClosureCall<E>(
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
-  )
+  ).map { $0 as? E }
 }
 
 /// Check that an expression always throws an error.
@@ -1015,7 +1017,7 @@ public func __checkClosureCall<E>(
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
   sourceLocation: SourceLocation
-) async -> Result<Void, any Error> where E: Error & Equatable {
+) async -> Result<E?, any Error> where E: Error & Equatable {
   await __checkClosureCall(
     performing: body,
     throws: { true == (($0 as? E) == error) },
@@ -1025,7 +1027,7 @@ public func __checkClosureCall<E>(
     isRequired: isRequired,
     isolation: isolation,
     sourceLocation: sourceLocation
-  )
+  ).map { $0 as? E }
 }
 
 // MARK: - Arbitrary error matching
@@ -1044,10 +1046,11 @@ public func __checkClosureCall<R>(
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
-) -> Result<Void, any Error> {
+) -> Result<(any Error)?, any Error> {
   var errorMatches = false
   var mismatchExplanationValue: String? = nil
   var expression = expression
+  var caughtError: (any Error)?
   do {
     let result = try body()
 
@@ -1057,6 +1060,7 @@ public func __checkClosureCall<R>(
     }
     mismatchExplanationValue = explanation
   } catch {
+    caughtError = error
     expression = expression.capturingRuntimeValues(error)
     let secondError = Issue.withErrorRecording(at: sourceLocation) {
       errorMatches = try errorMatcher(error)
@@ -1075,7 +1079,7 @@ public func __checkClosureCall<R>(
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
-  )
+  ).map { caughtError }
 }
 
 /// Check that an expression always throws an error.
@@ -1093,10 +1097,11 @@ public func __checkClosureCall<R>(
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
   sourceLocation: SourceLocation
-) async -> Result<Void, any Error> {
+) async -> Result<(any Error)?, any Error> {
   var errorMatches = false
   var mismatchExplanationValue: String? = nil
   var expression = expression
+  var caughtError: (any Error)?
   do {
     let result = try await body()
 
@@ -1106,6 +1111,7 @@ public func __checkClosureCall<R>(
     }
     mismatchExplanationValue = explanation
   } catch {
+    caughtError = error
     expression = expression.capturingRuntimeValues(error)
     let secondError = await Issue.withErrorRecording(at: sourceLocation) {
       errorMatches = try await errorMatcher(error)
@@ -1124,7 +1130,7 @@ public func __checkClosureCall<R>(
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
-  )
+  ).map { caughtError }
 }
 
 // MARK: - Exit tests

--- a/Sources/Testing/Support/SystemError.swift
+++ b/Sources/Testing/Support/SystemError.swift
@@ -21,3 +21,16 @@
 struct SystemError: Error, CustomStringConvertible {
   var description: String
 }
+
+/// A type representing misuse of testing library API.
+///
+/// When an error of this type is thrown and caught by the testing library, it
+/// is recorded as an issue of kind ``Issue/Kind/apiMisused`` rather than
+/// ``Issue/Kind/errorCaught(_:)``.
+///
+/// This type is not part of the public interface of the testing library.
+/// External callers should generally record issues by throwing their own errors
+/// or by calling ``Issue/record(_:sourceLocation:)``.
+struct APIMisuseError: Error, CustomStringConvertible {
+  var description: String
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/ExpectComplexThrows.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/ExpectComplexThrows.md
@@ -1,0 +1,28 @@
+# ``expect(_:sourceLocation:performing:throws:)``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.0, deprecated: 999.0)
+  @Available(Xcode, introduced: 16.0, deprecated: 999.0)
+}
+
+@DeprecationSummary {
+  Examine the result of ``expect(throws:_:sourceLocation:performing:)-7du1h`` or
+  ``expect(throws:_:sourceLocation:performing:)-1hfms`` instead:
+  
+  ```swift
+  let error = #expect(throws: FoodTruckError.self) {
+    ...
+  }
+  #expect(error?.napkinCount == 0)
+  ```
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/RequireComplexThrows.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/RequireComplexThrows.md
@@ -1,0 +1,28 @@
+# ``require(_:sourceLocation:performing:throws:)``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2024 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.0, deprecated: 999.0)
+  @Available(Xcode, introduced: 16.0, deprecated: 999.0)
+}
+
+@DeprecationSummary {
+  Examine the result of ``require(throws:_:sourceLocation:performing:)-7n34r``
+  or ``require(throws:_:sourceLocation:performing:)-4djuw`` instead:
+  
+  ```swift
+  let error = try #require(throws: FoodTruckError.self) {
+    ...
+  }
+  #expect(error.napkinCount == 0)
+  ```
+}

--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -65,11 +65,11 @@ the test when the code doesn't satisfy a requirement, use
 ### Checking that errors are thrown
 
 - <doc:testing-for-errors-in-swift-code>
-- ``expect(throws:_:sourceLocation:performing:)-79piu``
-- ``expect(throws:_:sourceLocation:performing:)-1xr34``
+- ``expect(throws:_:sourceLocation:performing:)-1hfms``
+- ``expect(throws:_:sourceLocation:performing:)-7du1h``
 - ``expect(_:sourceLocation:performing:throws:)``
-- ``require(throws:_:sourceLocation:performing:)-76bjn``
-- ``require(throws:_:sourceLocation:performing:)-7v83e``
+- ``require(throws:_:sourceLocation:performing:)-7n34r``
+- ``require(throws:_:sourceLocation:performing:)-4djuw``
 - ``require(_:sourceLocation:performing:throws:)``
 
 ### Confirming that asynchronous events occur

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -326,7 +326,7 @@ their equivalents in the testing library:
 | `XCTAssertLessThanOrEqual(x, y)` | `#expect(x <= y)` |
 | `XCTAssertLessThan(x, y)` | `#expect(x < y)` |
 | `XCTAssertThrowsError(try f())` | `#expect(throws: (any Error).self) { try f() }` |
-| `XCTAssertThrowsError(try f()) { error in … }` | `#expect { try f() } throws: { error in return … }` |
+| `XCTAssertThrowsError(try f()) { error in … }` | `let error = #expect(throws: (any Error).self) { try f() }` |
 | `XCTAssertNoThrow(try f())` | `#expect(throws: Never.self) { try f() }` |
 | `try XCTUnwrap(x)` | `try #require(x)` |
 | `XCTFail("…")` | `Issue.record("…")` |

--- a/Sources/Testing/Testing.docc/testing-for-errors-in-swift-code.md
+++ b/Sources/Testing/Testing.docc/testing-for-errors-in-swift-code.md
@@ -26,7 +26,7 @@ If the code throws an error, then your test fails.
 
 To check that the code under test throws a specific error, or to continue a
 longer test function after the code throws an error, pass that error as the
-first argument of ``expect(throws:_:sourceLocation:performing:)-1xr34``, and
+first argument of ``expect(throws:_:sourceLocation:performing:)-7du1h``, and
 pass a closure that calls the code under test:
 
 ```swift
@@ -65,4 +65,23 @@ the error to `Never`:
 If the closure throws _any_ error, the testing library records an issue.
 If you need the test to stop when the code throws an error, include the
 code inline in the test function instead of wrapping it in a call to
-``expect(throws:_:sourceLocation:performing:)-1xr34``.
+``expect(throws:_:sourceLocation:performing:)-7du1h``.
+
+## Inspect an error thrown by your code
+
+When you use `#expect(throws:)` or `#require(throws:)` and the error matches the
+expectation, it is returned to the caller so that you can perform additional
+validation. If the expectation fails because no error was thrown or an error of
+a different type was thrown, `#expect(throws:)` returns `nil`:
+
+```swift
+@Test func cannotAddMarshmallowsToPizza() throws {
+  let error = #expect(throws: PizzaToppings.InvalidToppingError.self) {
+    try Pizza.current.add(topping: .marshmallows)
+  }
+  #expect(error?.topping == .marshmallows)
+  #expect(error?.reason == .dessertToppingOnly)
+}
+```
+
+If you aren't sure what type of error will be thrown, pass `(any Error).self`.

--- a/Sources/TestingMacros/Support/Additions/MacroExpansionContextAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/MacroExpansionContextAdditions.swift
@@ -80,6 +80,34 @@ extension MacroExpansionContext {
 // MARK: -
 
 extension MacroExpansionContext {
+  /// Whether or not our generated warnings are suppressed in the current
+  /// lexical context.
+  ///
+  /// The value of this property is `true` if the current lexical context
+  /// contains a node with the `@_semantics("testing.macros.nowarnings")`
+  /// attribute applied to it.
+  ///
+  /// - Warning: This functionality is not part of the public interface of the
+  ///   testing library. It may be modified or removed in a future update.
+  var areWarningsSuppressed: Bool {
+#if DEBUG
+    for lexicalContext in self.lexicalContext {
+      guard let lexicalContext = lexicalContext.asProtocol((any WithAttributesSyntax).self) else {
+        continue
+      }
+      for attribute in lexicalContext.attributes {
+        if case let .attribute(attribute) = attribute,
+           attribute.attributeNameText == "_semantics",
+           case let .string(argument) = attribute.arguments,
+           argument.representedLiteralValue == "testing.macros.nowarnings" {
+          return true
+        }
+      }
+    }
+#endif
+    return false
+  }
+
   /// Emit a diagnostic message.
   ///
   /// - Parameters:
@@ -87,23 +115,27 @@ extension MacroExpansionContext {
   ///     arguments to `Diagnostic.init()` are derived from the message's
   ///     `syntax` property.
   func diagnose(_ message: DiagnosticMessage) {
-    diagnose(
-      Diagnostic(
-        node: message.syntax,
-        position: message.syntax.positionAfterSkippingLeadingTrivia,
-        message: message,
-        fixIts: message.fixIts
-      )
-    )
+    diagnose(CollectionOfOne(message))
   }
 
   /// Emit a sequence of diagnostic messages.
   ///
   /// - Parameters:
   ///   - messages: The diagnostic messages to emit.
-  func diagnose(_ messages: some Sequence<DiagnosticMessage>) {
+  func diagnose(_ messages: some Collection<DiagnosticMessage>) {
+    lazy var areWarningsSuppressed = areWarningsSuppressed
     for message in messages {
-      diagnose(message)
+      if message.severity == .warning && areWarningsSuppressed {
+        continue
+      }
+      diagnose(
+        Diagnostic(
+          node: message.syntax,
+          position: message.syntax.positionAfterSkippingLeadingTrivia,
+          message: message,
+          fixIts: message.fixIts
+        )
+      )
     }
   }
 

--- a/Sources/TestingMacros/TestingMacrosMain.swift
+++ b/Sources/TestingMacros/TestingMacrosMain.swift
@@ -24,6 +24,7 @@ struct TestingMacrosMain: CompilerPlugin {
       RequireMacro.self,
       AmbiguousRequireMacro.self,
       NonOptionalRequireMacro.self,
+      RequireThrowsMacro.self,
       RequireThrowsNeverMacro.self,
       ExitTestExpectMacro.self,
       ExitTestRequireMacro.self,

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -354,6 +354,8 @@ struct ConditionMacroTests {
 
   @Test("#require(throws: Never.self) produces a diagnostic",
     arguments: [
+      "#requireThrows(throws: Swift.Never.self)",
+      "#requireThrows(throws: Never.self)",
       "#requireThrowsNever(throws: Never.self)",
     ]
   )

--- a/Tests/TestingMacrosTests/TestSupport/Parse.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Parse.swift
@@ -23,6 +23,7 @@ fileprivate let allMacros: [String: any Macro.Type] = [
   "require": RequireMacro.self,
   "requireAmbiguous": AmbiguousRequireMacro.self, // different name needed only for unit testing
   "requireNonOptional": NonOptionalRequireMacro.self, // different name needed only for unit testing
+  "requireThrows": RequireThrowsMacro.self, // different name needed only for unit testing
   "requireThrowsNever": RequireThrowsNeverMacro.self, // different name needed only for unit testing
   "expectExitTest": ExitTestRequireMacro.self, // different name needed only for unit testing
   "requireExitTest": ExitTestRequireMacro.self, // different name needed only for unit testing

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -171,7 +171,7 @@ struct TagListTests {
   func noTagColorsReadFromBadPath(tagColorJSON: String) throws {
     var tagColorJSON = tagColorJSON
     tagColorJSON.withUTF8 { tagColorJSON in
-      #expect(throws: (any Error).self) {
+      _ = #expect(throws: (any Error).self) {
         _ = try JSON.decode(Tag.Color.self, from: .init(tagColorJSON))
       }
     }


### PR DESCRIPTION
  - **Explanation**: Change `#expect(throws:)` and `#require(throws:)` to return the thrown error and deprecate the double-closure overloads.
  - **Scope**: 6.1 release, all tests that use these macros
  - **Issues**: rdar://138235250
  - **Original PRs**: #780
  - **Risk**: Low (some developers may get a new diagnostic about an unused return value, but this is a warning unless `-Werror`.
  - **Testing**: Unit test coverage.
  - **Reviewers**: @stmontgomery @briancroom