### PR TITLE
Change default behavior of exit tests to always succeed.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -158,11 +158,9 @@ extension ExitTest {
       _errorInMain(error)
     }
 
-    // Run some glue code that terminates the process with an exit condition
-    // that does not match the expected one. If the exit test's body doesn't
-    // terminate, we'll manually call exit() and cause the test to fail.
-    let expectingFailure = expectedExitCondition == .failure
-    exit(expectingFailure ? EXIT_SUCCESS : EXIT_FAILURE)
+    // If we get to this point without terminating, then we simulate main()'s
+    // behavior which is to exit with EXIT_SUCCESS.
+    exit(EXIT_SUCCESS)
   }
 }
 

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -22,6 +22,7 @@ private import _TestingInternals
         exit(EXIT_FAILURE + 1)
       }
     }
+    await #expect(exitsWith: .success) {}
     await #expect(exitsWith: .success) {
       exit(EXIT_SUCCESS)
     }
@@ -63,7 +64,7 @@ private import _TestingInternals
   }
 
   @Test("Exit tests (failing)") func failing() async {
-    await confirmation("Exit tests failed", expectedCount: 10) { failed in
+    await confirmation("Exit tests failed", expectedCount: 9) { failed in
       var configuration = Configuration()
       configuration.eventHandler = { event, _ in
         if case .issueRecorded = event.kind {
@@ -410,7 +411,6 @@ private import _TestingInternals
 
 @Suite(.hidden) struct FailingExitTests {
   @Test(.hidden) func failingExitTests() async {
-    await #expect(exitsWith: .success) {}
     await #expect(exitsWith: .failure) {}
     await #expect(exitsWith: .exitCode(123)) {}
     await #expect(exitsWith: .failure) {


### PR DESCRIPTION
Exit tests simulate calling `main()` (or some similar thing), but if you don't explicitly exit from them, they force a failure. After much mulling and some discussion with colleagues a while back, we should change the behavior so that, if a test doesn't otherwise terminate, it acts as if `main()` returned naturally—that is, by exiting with `EXIT_SUCCESS` rather than by forcing `EXIT_FAILURE`. This behavior is more consistent with the feature's theory of operation.

For example:

```swift
await #expect(exitsWith: .success) {
  assert(2 > 1) // this is true and doesn't assert, so this test should pass, right?
}
```

Exit tests remain an experimental feature.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
