### PR TITLE
Remove ForSwiftTestingOnly SPI

### DIFF
--- a/Documentation/SPI.md
+++ b/Documentation/SPI.md
@@ -39,14 +39,6 @@ external tools, _both_ groups are specified. Such SPI is not generally meant to
 be promoted to public API, but is still experimental until tools authors have a
 chance to evaluate it.
 
-For interfaces internal to Swift Testing that must be available across targets,
-the SPI group `@_spi(ForSwiftTestingOnly)` is used. They _should_ be marked
-`package` and may be in the future, but are currently exported due to technical
-constraints when Swift Testing is built using CMake.
-
-> [!WARNING]
-> Never use symbols marked `@_spi(ForSwiftTestingOnly)`.
-
 ## SPI stability
 
 The testing library does **not** guarantee SPI stability for either group of
@@ -58,12 +50,6 @@ to newer interfaces.
 
 SPI marked `@_spi(Experimental)` should be assumed to be unstable. It may be
 modified or removed at any time.
-
-SPI marked `@_spi(ForSwiftTestingOnly)` is unstable and subject to change at any
-time.
-
-> [!WARNING]
-> Never use symbols marked `@_spi(ForSwiftTestingOnly)`.
 
 ## API and ABI stability
 

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/Attachment+AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/Attachment+AttachableAsCGImage.swift
@@ -9,7 +9,7 @@
 //
 
 #if SWT_TARGET_OS_APPLE && canImport(CoreGraphics)
-@_spi(ForSwiftTestingOnly) @_spi(Experimental) public import Testing
+@_spi(Experimental) public import Testing
 
 public import UniformTypeIdentifiers
 

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/ImageAttachmentError.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/ImageAttachmentError.swift
@@ -10,8 +10,7 @@
 
 #if SWT_TARGET_OS_APPLE && canImport(CoreGraphics)
 /// A type representing an error that can occur when attaching an image.
-@_spi(ForSwiftTestingOnly)
-public enum ImageAttachmentError: Error, CustomStringConvertible {
+package enum ImageAttachmentError: Error, CustomStringConvertible {
   /// The image could not be converted to an instance of `CGImage`.
   case couldNotCreateCGImage
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
@@ -9,7 +9,7 @@
 //
 
 #if canImport(Foundation)
-@_spi(Experimental) @_spi(ForSwiftTestingOnly) public import Testing
+@_spi(Experimental) public import Testing
 public import Foundation
 
 #if SWT_TARGET_OS_APPLE && canImport(UniformTypeIdentifiers)

--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -37,8 +37,7 @@ public struct Attachment<AttachableValue>: ~Copyable where AttachableValue: Atta
   public var fileSystemPath: String?
 
   /// The default preferred name to use if the developer does not supply one.
-  @_spi(ForSwiftTestingOnly)
-  public static var defaultPreferredName: String {
+  package static var defaultPreferredName: String {
     "untitled"
   }
 

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -16,7 +16,7 @@ import Foundation
 #endif
 #if canImport(CoreGraphics)
 import CoreGraphics
-@_spi(Experimental) @_spi(ForSwiftTestingOnly) import _Testing_CoreGraphics
+@_spi(Experimental) import _Testing_CoreGraphics
 #endif
 #if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers

--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -16,6 +16,8 @@ add_compile_options(
 add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend ExistentialAny>"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InternalImportsByDefault>")
+add_compile_options(
+  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -package-name -Xfrontend swift-testing>")
 
 # Platform-specific definitions.
 if(APPLE)


### PR DESCRIPTION
Align with SwiftPM package name and remove ForSwiftTestingOnly SPI

### Motivation:

Remove unnecessary ForSwiftTestingOnly SPI

### Modifications:

- Remove ForSwiftTestingOnly SPI
- Change `@_spi(ForSwiftTestingOnly) public` to `package`
- Add `-package-name swift-testing` in CMake build to align with SwiftPM build

### Result:

No long need `@_spi(ForSwiftTestingOnly)`

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

### Testing

I have verified it locally by building it via cmake.

```shell
gh repo clone swiftlang/swift-testing & cd swift-testing
gh pr checkout 859
cmake -G Ninja -B build
cmake --build build
```

There is also a CI toolchain build to verify it.

https://github.com/swiftlang/swift/pull/78185

