### PR TITLE
Remove an import of UniformTypeIdentifiers from the Foundation overlay.

### DIFF
--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
@@ -12,10 +12,6 @@
 @_spi(Experimental) @_spi(ForSwiftTestingOnly) public import Testing
 public import Foundation
 
-#if SWT_TARGET_OS_APPLE && canImport(UniformTypeIdentifiers)
-private import UniformTypeIdentifiers
-#endif
-
 #if !SWT_NO_PROCESS_SPAWNING && os(Windows)
 private import WinSDK
 #endif


### PR DESCRIPTION
An earlier iteration of this code needed to talk to the UniformTypeIdentifiers framework on Apple platforms. This is no longer the case.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
