### PR TITLE
Additional FreeBSD fixes

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -114,7 +114,7 @@ extension ExitTest {
     // As with Linux, disable the generation core files. FreeBSD does not, as
     // far as I can tell, special-case RLIMIT_CORE=1.
     var rl = rlimit(rlim_cur: 0, rlim_max: 0)
-    _ = setrlimit(CInt(RLIMIT_CORE.rawValue), &rl)
+    _ = setrlimit(RLIMIT_CORE, &rl)
 #elseif os(Windows)
     // On Windows, similarly disable Windows Error Reporting and the Windows
     // Error Reporting UI. Note we expect to be the first component to call

--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -143,12 +143,19 @@ func spawnExecutable(
 #if SWT_TARGET_OS_APPLE
       // Close all other file descriptors open in the parent.
       flags |= CShort(POSIX_SPAWN_CLOEXEC_DEFAULT)
-#elseif os(Linux) || os(FreeBSD)
+#elseif os(Linux)
       // This platform doesn't have POSIX_SPAWN_CLOEXEC_DEFAULT, but we can at
       // least close all file descriptors higher than the highest inherited one.
       // We are assuming here that the caller didn't set FD_CLOEXEC on any of
       // these file descriptors.
       _ = swt_posix_spawn_file_actions_addclosefrom_np(fileActions, highestFD + 1)
+#elseif os(FreeBSD)
+      // Like Linux, this platfrom doesn't have POSIX_SPAWN_CLOEXEC_DEFAULT;
+      // However; unlike Linux, all non-EOL FreeBSD (>= 13.1) supports
+      // `posix_spawn_file_actions_addclosefrom_np` and therefore we don't need
+      // need `swt_posix_spawn_file_actions_addclosefrom_np` to guard the availability
+      // of this api.
+      _ = posix_spawn_file_actions_addclosefrom_np(fileActions, highestFD + 1)
 #else
 #warning("Platform-specific implementation missing: cannot close unused file descriptors")
 #endif

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -36,8 +36,10 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   /// To keep the implementation of this type as simple as possible,
   /// `pthread_mutex_t` is used on Apple platforms instead of `os_unfair_lock`
   /// or `OSAllocatedUnfairLock`.
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
   private typealias _Lock = pthread_mutex_t
+#elseif os(FreeBSD)
+  private typealias _Lock = pthread_mutex_t?
 #elseif os(Windows)
   private typealias _Lock = SRWLOCK
 #elseif os(WASI)
@@ -121,7 +123,7 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
     }
   }
 
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
   /// Acquire the lock and invoke a function while it is held, yielding both the
   /// protected value and a reference to the lock itself.
   ///
@@ -143,6 +145,34 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   ///   closure returns. If the lock is not acquired when `body` returns, the
   ///   effect is undefined.
   nonmutating func withUnsafeUnderlyingLock<R>(_ body: (UnsafeMutablePointer<pthread_mutex_t>, T) throws -> R) rethrows -> R {
+    try withLock { value in
+      try _storage.withUnsafeMutablePointerToElements { lock in
+        try body(lock, value)
+      }
+    }
+  }
+#elseif os(FreeBSD)
+  /// Acquire the lock and invoke a function while it is held, yielding both the
+  /// protected value and a reference to the lock itself.
+  ///
+  /// - Parameters:
+  ///   - body: A closure to invoke while the lock is held.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  ///
+  /// This function is equivalent to ``withLock(_:)`` except that the closure
+  /// passed to it also takes a reference to the underlying platform lock. This
+  /// function can be used when platform-specific functionality such as a
+  /// `pthread_cond_t` is needed. Because the caller has direct access to the
+  /// lock and is able to unlock and re-lock it, it is unsafe to modify the
+  /// protected value.
+  ///
+  /// - Warning: Callers that unlock the lock _must_ lock it again before the
+  ///   closure returns. If the lock is not acquired when `body` returns, the
+  ///   effect is undefined.
+  nonmutating func withUnsafeUnderlyingLock<R>(_ body: (UnsafeMutablePointer<pthread_mutex_t?>, T) throws -> R) rethrows -> R {
     try withLock { value in
       try _storage.withUnsafeMutablePointerToElements { lock in
         try body(lock, value)

--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -129,6 +129,10 @@
 #endif
 #endif
 
+#if defined(__FreeBSD__)
+#include <libutil.h>
+#endif
+
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX

--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -80,6 +80,10 @@
 #include <pthread.h>
 #endif
 
+#if __has_include(<pthread_np.h>)
+#include <pthread_np.h>
+#endif
+
 #if __has_include(<pty.h>)
 #include <pty.h>
 #endif


### PR DESCRIPTION
Add FreeBSD support for swift-testing.

### Result:
With this PR, swift-testing can be built on FreeBSD (tested on x86_64 FreeBSD 14.1-RELEASE-p6)

### Known issue:
There are some issue running `swift test` on this repo, but most likely due to bugs in my host toolchain.
- Tests failed to link due to duplicated main symbols:
```
error: link command failed with exit code 1 (use -v to see invocation)
ld: error: duplicate symbol: main
>>> defined at TestingMacrosMain.swift:0 (/zdata/swift-main/swift-project/swift-testing/Sources/TestingMacros/TestingMacrosMain.swift:0)
>>>            /zdata/swift-main/swift-project/swift-testing/.build/x86_64-unknown-freebsd14.1/debug/TestingMacros-tool.build/TestingMacrosMain.swift.o:(main)
>>> defined at runner.swift:0 (/zdata/swift-main/swift-project/swift-testing/.build/x86_64-unknown-freebsd14.1/debug/swift-testingPackageTests.derived/runner.swift:0)
>>>            /zdata/swift-main/swift-project/swift-testing/.build/x86_64-unknown-freebsd14.1/debug/swift_testingPackageTests-tool.build/runner.swift.o:(.text.main+0x0)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[25/26] Linking swift-testingPackageTests.xctest
```

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
