### PR TITLE
Fix more things on FreeBSD

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,10 @@ let package = Package(
       ],
       exclude: ["CMakeLists.txt"],
       cxxSettings: .packageSettings,
-      swiftSettings: .packageSettings
+      swiftSettings: .packageSettings,
+      linkerSettings: [
+        .linkedLibrary("execinfo", .when(platforms: [.custom("freebsd")]))
+      ]
     ),
     .testTarget(
       name: "TestingTests",
@@ -114,7 +117,7 @@ let package = Package(
 )
 
 // BUG: swift-package-manager-#6367
-#if !os(Windows)
+#if !os(Windows) && !os(FreeBSD)
 package.targets.append(contentsOf: [
   .testTarget(
     name: "TestingMacrosTests",
@@ -143,7 +146,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
 
       .define("SWT_NO_EXIT_TESTS", .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android])),
       .define("SWT_NO_PROCESS_SPAWNING", .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android])),
-      .define("SWT_NO_SNAPSHOT_TYPES", .when(platforms: [.linux, .windows, .wasi])),
+      .define("SWT_NO_SNAPSHOT_TYPES", .when(platforms: [.linux, .custom("freebsd"), .windows, .wasi])),
       .define("SWT_NO_DYNAMIC_LINKING", .when(platforms: [.wasi])),
       .define("SWT_NO_PIPES", .when(platforms: [.wasi])),
     ]
@@ -178,7 +181,7 @@ extension Array where Element == PackageDescription.CXXSetting {
     result += [
       .define("SWT_NO_EXIT_TESTS", .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android])),
       .define("SWT_NO_PROCESS_SPAWNING", .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android])),
-      .define("SWT_NO_SNAPSHOT_TYPES", .when(platforms: [.linux, .windows, .wasi])),
+      .define("SWT_NO_SNAPSHOT_TYPES", .when(platforms: [.linux, .custom("freebsd"), .windows, .wasi])),
       .define("SWT_NO_DYNAMIC_LINKING", .when(platforms: [.wasi])),
       .define("SWT_NO_PIPES", .when(platforms: [.wasi])),
     ]

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -181,7 +181,7 @@ extension Backtrace {
     ///   crash. To avoid said crash, we'll keep a strong reference to the
     ///   object (abandoning memory until the process exits.)
     ///   ([swift-#62985](https://github.com/swiftlang/swift/issues/62985))
-#if os(Windows)
+#if os(Windows) || os(FreeBSD)
     nonisolated(unsafe) var errorObject: AnyObject?
 #else
     nonisolated(unsafe) weak var errorObject: AnyObject?

--- a/Sources/Testing/Support/CError.swift
+++ b/Sources/Testing/Support/CError.swift
@@ -47,6 +47,12 @@ func strerror(_ errorCode: CInt) -> String {
     _ = strerror_s(buffer.baseAddress!, buffer.count, errorCode)
     return strnlen(buffer.baseAddress!, buffer.count)
   }
+#elseif os(FreeBSD)
+  // FreeBSD's implementation of strerror() is not thread-safe.
+  String(unsafeUninitializedCapacity: 1024) { buffer in
+    _ = strerror_r(errorCode, buffer.baseAddress!, buffer.count)
+    return strnlen(buffer.baseAddress!, buffer.count)
+  }
 #else
   String(cString: _TestingInternals.strerror(errorCode))
 #endif


### PR DESCRIPTION
This PR contains a few more fixes for FreeBSD:

Use threadsafe `strerror_r` on FreeBSD
Define "SWT_NO_SNAPSHOT_TYPES" when host is FreeBSD
Work around issue https://github.com/swiftlang/swift/issues/62985


### Result:
Passed all the tests on FreeBSD

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
