### PR TITLE
Add `@_spi` annotations to reexport decls in cross-import overlays.

### DIFF
--- a/Sources/Overlays/_Testing_CoreGraphics/ReexportTesting.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/ReexportTesting.swift
@@ -8,4 +8,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_exported public import Testing
+@_exported @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import Testing

--- a/Sources/Overlays/_Testing_Foundation/ReexportTesting.swift
+++ b/Sources/Overlays/_Testing_Foundation/ReexportTesting.swift
@@ -8,4 +8,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_exported public import Testing
+@_exported @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import Testing


### PR DESCRIPTION
This PR attempts to make sure that SPI is reexported from our cross-import overlays. This change is speculative and I'm not actually sure if it'll do what I want.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
