### PR TITLE
Fix some typos in the new FreeBSD-specific code.

### DIFF
--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -150,11 +150,11 @@ func spawnExecutable(
       // these file descriptors.
       _ = swt_posix_spawn_file_actions_addclosefrom_np(fileActions, highestFD + 1)
 #elseif os(FreeBSD)
-      // Like Linux, this platfrom doesn't have POSIX_SPAWN_CLOEXEC_DEFAULT;
-      // However; unlike Linux, all non-EOL FreeBSD (>= 13.1) supports
-      // `posix_spawn_file_actions_addclosefrom_np` and therefore we don't need
-      // need `swt_posix_spawn_file_actions_addclosefrom_np` to guard the availability
-      // of this api.
+      // Like Linux, this platform doesn't have POSIX_SPAWN_CLOEXEC_DEFAULT.
+      // Unlike Linux, all non-EOL FreeBSD versions (≥13.1) support
+      // `posix_spawn_file_actions_addclosefrom_np`. Therefore, we don't need
+      // `swt_posix_spawn_file_actions_addclosefrom_np` to guard the
+      // availability of this function.
       _ = posix_spawn_file_actions_addclosefrom_np(fileActions, highestFD + 1)
 #else
 #warning("Platform-specific implementation missing: cannot close unused file descriptors")

--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -85,11 +85,11 @@ private let _childProcessContinuations = Locked<[pid_t: CheckedContinuation<Exit
 /// A condition variable used to suspend the waiter thread created by
 /// `_createWaitThread()` when there are no child processes to await.
 private nonisolated(unsafe) let _waitThreadNoChildrenCondition = {
-  #if os(FreeBSD)
+#if os(FreeBSD)
   let result = UnsafeMutablePointer<pthread_cond_t?>.allocate(capacity: 1)
-  #else
+#else
   let result = UnsafeMutablePointer<pthread_cond_t>.allocate(capacity: 1)
-  #endif
+#endif
   _ = pthread_cond_init(result, nil)
   return result
 }()
@@ -126,7 +126,7 @@ private let _createWaitThread: Void = {
       // newly-scheduled waiter process. (If this condition is spuriously
       // woken, we'll just loop again, which is fine.) Note that we read errno
       // outside the lock in case acquiring the lock perturbs it.
-      _childProcessContinuations.withUnsafeUnderlyingLock { lock, childProcessContinuations in
+      _childProcessContinuations.withUnsafePlatformLock { lock, childProcessContinuations in
         if childProcessContinuations.isEmpty {
           _ = pthread_cond_wait(_waitThreadNoChildrenCondition, lock)
         }

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -123,7 +123,6 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
     }
   }
 
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(Android) || (os(WASI) && compiler(>=6.1) && _runtime(_multithreaded))
   /// Acquire the lock and invoke a function while it is held, yielding both the
   /// protected value and a reference to the lock itself.
   ///
@@ -144,14 +143,13 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   /// - Warning: Callers that unlock the lock _must_ lock it again before the
   ///   closure returns. If the lock is not acquired when `body` returns, the
   ///   effect is undefined.
-  nonmutating func withUnsafeUnderlyingLock<R>(_ body: (UnsafeMutablePointer<PlatformLock>, T) throws -> R) rethrows -> R {
+  nonmutating func withUnsafePlatformLock<R>(_ body: (UnsafeMutablePointer<PlatformLock>, T) throws -> R) rethrows -> R {
     try withLock { value in
       try _storage.withUnsafeMutablePointerToElements { lock in
         try body(lock, value)
       }
     }
   }
-#endif
 }
 
 extension Locked where T: AdditiveArithmetic {


### PR DESCRIPTION
Fixes some typos/code style bits and renames `withUnsafeUnderlyingLock()` to `withUnsafePlatformLock()` to make it more consistent with the newly-exposed `PlatformLock` typealias.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
