### PR TITLE
Remove the workaround for swift-package-manager-#8111.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
   products: [
     .library(
       name: "Testing",
+      type: .dynamic,
       targets: ["Testing"]
     ),
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
   products: [
     .library(
       name: "Testing",
-      type: .dynamic,
+      type: .dynamic, // needed so Windows exports ABI entry point symbols
       targets: ["Testing"]
     ),
   ],

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -129,7 +129,6 @@ struct ABIEntryPointTests {
     passing arguments: __CommandLineArguments_v0,
     recordHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void = { _ in }
   ) async throws -> Bool {
-#if !(!SWT_FIXED_SWIFTPM_8111 && os(Windows))
 #if !os(Linux) && !os(FreeBSD) && !os(Android) && !SWT_NO_DYNAMIC_LINKING
     // Get the ABI entry point by dynamically looking it up at runtime.
     //
@@ -143,7 +142,6 @@ struct ABIEntryPointTests {
         }
       )
     }
-#endif
 #endif
     let abiEntryPoint = unsafeBitCast(abiv0_getEntryPoint(), to: ABIv0.EntryPoint.self)
 


### PR DESCRIPTION
Remove the workaround for https://github.com/swiftlang/swift-package-manager/issues/8111. The issue has been resolved and Windows correctly exports symbols from dynamic library targets.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
