### PR TITLE
[docs] Correct the link of Proposal SWT-0006

### DIFF
--- a/Documentation/Proposals/0006-return-errors-from-expect-throws.md
+++ b/Documentation/Proposals/0006-return-errors-from-expect-throws.md
@@ -1,6 +1,6 @@
 # Return errors from `#expect(throws:)`
 
-* Proposal: [SWT-0006](0006-filename.md)
+* Proposal: [SWT-0006](0006-return-errors-from-expect-throws.md)
 * Authors: [Jonathan Grynspan](https://github.com/grynspan)
 * Status: **Awaiting review**
 * Bug: rdar://138235250


### PR DESCRIPTION
### Motivation:

Currently, we the link of `SWT-0006` at `0006-return-errors-from-expect-throws.md` that will display `404 Not Found` . Correct the link of Proposal SWT-0006.

### Modifications:

+ Documentation/Proposals/0006-return-errors-from-expect-throws.md

### Result:

Correct the link of Proposal SWT-0006

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
