### PR TITLE
Revert "Work around a crash importing FoundationXML. (#786)"

### DIFF
--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -15,7 +15,7 @@ import RegexBuilder
 #if canImport(Foundation)
 import Foundation
 #endif
-#if SWT_FIXED_138761752 && canImport(FoundationXML)
+#if canImport(FoundationXML)
 import FoundationXML
 #endif
 
@@ -299,7 +299,7 @@ struct EventRecorderTests {
   }
 #endif
 
-#if (SWT_TARGET_OS_APPLE && canImport(Foundation)) || (SWT_FIXED_138761752 && canImport(FoundationXML))
+#if canImport(Foundation) || canImport(FoundationXML)
   @Test(
     "JUnitXMLRecorder outputs valid XML",
     .bug("https://github.com/swiftlang/swift-testing/issues/254")


### PR DESCRIPTION
This reverts commit 405d8c9d60730228527dbd74d9ba75bf3fde5069.

The issue should no longer be occurring. See #786.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
