### PR TITLE
Add support for raw identifiers.

### DIFF
--- a/Sources/Testing/SourceAttribution/SourceLocation.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation.swift
@@ -46,7 +46,7 @@ public struct SourceLocation: Sendable {
   /// - ``moduleName``
   public var fileName: String {
     let lastSlash = fileID.lastIndex(of: "/")!
-    return String(fileID[fileID.index(after: lastSlash)...])
+    return String(fileID[lastSlash...].dropFirst())
   }
 
   /// The name of the module containing the source file.
@@ -67,8 +67,18 @@ public struct SourceLocation: Sendable {
   /// - ``fileName``
   /// - [`#fileID`](https://developer.apple.com/documentation/swift/fileID())
   public var moduleName: String {
-    let firstSlash = fileID.firstIndex(of: "/")!
-    return String(fileID[..<firstSlash])
+    var inRawIdentifier = false
+    for i in fileID.indices {
+      let c = fileID[i]
+      if c == "`" {
+        inRawIdentifier.toggle()
+      } else if c == "/" && !inRawIdentifier {
+        return String(fileID[..<i])
+      }
+    }
+
+    // Normally unreachable.
+    fatalError("Could not find the end of the module name of Swift file ID '\(fileID)'.")
   }
 
   /// The path to the source file.

--- a/Sources/Testing/SourceAttribution/SourceLocation.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation.swift
@@ -67,18 +67,7 @@ public struct SourceLocation: Sendable {
   /// - ``fileName``
   /// - [`#fileID`](https://developer.apple.com/documentation/swift/fileID())
   public var moduleName: String {
-    var inRawIdentifier = false
-    for i in fileID.indices {
-      let c = fileID[i]
-      if c == "`" {
-        inRawIdentifier.toggle()
-      } else if c == "/" && !inRawIdentifier {
-        return String(fileID[..<i])
-      }
-    }
-
-    // Normally unreachable.
-    fatalError("Could not find the end of the module name of Swift file ID '\(fileID)'.")
+    rawIdentifierAwareSplit(fileID, separator: "/", maxSplits: 1).first.map(String.init)!
   }
 
   /// The path to the source file.

--- a/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
@@ -34,7 +34,7 @@ extension TokenSyntax {
   /// token, or `nil` if it does not represent one.
   var rawIdentifier: String? {
     let (textWithoutBackticks, backticksRemoved) = _textWithoutBackticks
-    if backticksRemoved, textWithoutBackticks.contains(where: \.isWhitespace) {
+    if backticksRemoved, !textWithoutBackticks.isValidSwiftIdentifier(for: .memberAccess) {
       return textWithoutBackticks
     }
 

--- a/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
@@ -11,11 +11,39 @@
 import SwiftSyntax
 
 extension TokenSyntax {
+  /// A tuple containing the text of this instance with enclosing backticks
+  /// removed and whether or not they were removed.
+  private var _textWithoutBackticks: (String, backticksRemoved: Bool) {
+    let text = text
+    if case .identifier = tokenKind, text.first == "`" && text.last == "`" && text.count >= 2 {
+      return (String(text.dropFirst().dropLast()), true)
+    }
+
+    return (text, false)
+  }
+
   /// The text of this instance with all backticks removed.
   ///
   /// - Bug: This property works around the presence of backticks in `text.`
   ///   ([swift-syntax-#1936](https://github.com/swiftlang/swift-syntax/issues/1936))
   var textWithoutBackticks: String {
-    text.filter { $0 != "`" }
+    _textWithoutBackticks.0
+  }
+
+  /// The raw identifier, not including enclosing backticks, represented by this
+  /// token, or `nil` if it does not represent one.
+  var rawIdentifier: String? {
+    let (textWithoutBackticks, backticksRemoved) = _textWithoutBackticks
+    if backticksRemoved, textWithoutBackticks.contains(where: \.isWhitespace) {
+      return textWithoutBackticks
+    }
+
+    // TODO: remove this mock path once the toolchain fully supports raw IDs.
+    let mockPrefix = "__raw__$"
+    if backticksRemoved, textWithoutBackticks.starts(with: mockPrefix) {
+      return String(textWithoutBackticks.dropFirst(mockPrefix.count))
+    }
+
+    return nil
   }
 }

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -648,6 +648,14 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   /// Create a diagnostic message stating that a declaration has two display
   /// names.
   ///
+  /// - Parameters:
+  ///   - decl: The declaration that has two display names.
+  ///   - displayNameFromAttribute: The display name provided by the `@Test` or
+  ///     `@Suite` attribute.
+  ///   - argumentContainingDisplayName: The argument node containing the node
+  ///     `displayNameFromAttribute`.
+  ///   - attribute: The `@Test` or `@Suite` attribute.
+  ///
   /// - Returns: A diagnostic message.
   static func declaration(
     _ decl: some NamedDeclSyntax,

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -655,7 +655,6 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     fromArgument argumentContainingDisplayName: LabeledExprListSyntax.Element,
     using attribute: AttributeSyntax
   ) -> Self {
-    // FIXME: implement fixits
     Self(
       syntax: Syntax(decl),
       message: "Attribute \(_macroName(attribute)) specifies display name '\(displayNameFromAttribute.representedLiteralValue!)' for \(_kindString(for: decl)) with implicit display name '\(decl.name.rawIdentifier!)'",

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -645,6 +645,34 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     )
   }
 
+  /// Create a diagnostic message stating that a declaration has two display
+  /// names.
+  ///
+  /// - Returns: A diagnostic message.
+  static func declaration(
+    _ decl: some NamedDeclSyntax,
+    hasExtraneousDisplayName displayNameFromAttribute: StringLiteralExprSyntax,
+    fromArgument argumentContainingDisplayName: LabeledExprListSyntax.Element,
+    using attribute: AttributeSyntax
+  ) -> Self {
+    // FIXME: implement fixits
+    Self(
+      syntax: Syntax(decl),
+      message: "Attribute \(_macroName(attribute)) specifies display name '\(displayNameFromAttribute.representedLiteralValue!)' for \(_kindString(for: decl)) with implicit display name '\(decl.name.rawIdentifier!)'",
+      severity: .error,
+      fixIts: [
+        FixIt(
+          message: MacroExpansionFixItMessage("Remove '\(displayNameFromAttribute.representedLiteralValue!)'"),
+          changes: [.replace(oldNode: Syntax(argumentContainingDisplayName), newNode: Syntax("" as ExprSyntax))]
+        ),
+        FixIt(
+          message: MacroExpansionFixItMessage("Rename '\(decl.name.textWithoutBackticks)'"),
+          changes: [.replace(oldNode: Syntax(decl.name), newNode: Syntax(EditorPlaceholderExprSyntax("name")))]
+        ),
+      ]
+    )
+  }
+
   /// Create a diagnostic messages stating that the expression passed to
   /// `#require()` is ambiguous.
   ///

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -407,7 +407,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     var testsBody: CodeBlockItemListSyntax = """
     return [
       .__function(
-        named: \(literal: functionDecl.completeName),
+        named: \(literal: functionDecl.completeName.trimmedDescription),
         in: \(typeNameExpr),
         xcTestCompatibleSelector: \(selectorExpr ?? "nil"),
         \(raw: attributeInfo.functionArgumentList(in: context)),
@@ -433,7 +433,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
         private \(_staticKeyword(for: typeName)) nonisolated func \(unavailableTestName)() async -> [Testing.Test] {
           [
             .__function(
-              named: \(literal: functionDecl.completeName),
+              named: \(literal: functionDecl.completeName.trimmedDescription),
               in: \(typeNameExpr),
               xcTestCompatibleSelector: \(selectorExpr ?? "nil"),
               \(raw: attributeInfo.functionArgumentList(in: context)),

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -256,6 +256,21 @@ struct TestDeclarationMacroTests {
     }
   }
 
+  @Test("Raw identifier is detected")
+  func rawIdentifier() {
+    #expect(TokenSyntax.identifier("`hello`").rawIdentifier == nil)
+    #expect(TokenSyntax.identifier("`helloworld`").rawIdentifier == nil)
+    #expect(TokenSyntax.identifier("`hélloworld`").rawIdentifier == nil)
+    #expect(TokenSyntax.identifier("`hello_world`").rawIdentifier == nil)
+    #expect(TokenSyntax.identifier("`hello world`").rawIdentifier != nil)
+    #expect(TokenSyntax.identifier("`hello/world`").rawIdentifier != nil)
+    #expect(TokenSyntax.identifier("`hello\tworld`").rawIdentifier != nil)
+
+    #expect(TokenSyntax.identifier("`class`").rawIdentifier == nil)
+    #expect(TokenSyntax.identifier("`struct`").rawIdentifier == nil)
+    #expect(TokenSyntax.identifier("`class struct`").rawIdentifier != nil)
+  }
+
   @Test("Warning diagnostics emitted on API misuse",
     arguments: [
       // return types

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -271,6 +271,15 @@ struct TestDeclarationMacroTests {
     #expect(TokenSyntax.identifier("`class struct`").rawIdentifier != nil)
   }
 
+  @Test("Raw function name components")
+  func rawFunctionNameComponents() throws {
+    let decl = """
+    func `__raw__$hello`(`__raw__$world`: T, etc: U, `blah`: V) {}
+    """ as DeclSyntax
+    let functionDecl = try #require(decl.as(FunctionDeclSyntax.self))
+    #expect(functionDecl.completeName.trimmedDescription == "`hello`(`world`:etc:blah:)")
+  }
+
   @Test("Warning diagnostics emitted on API misuse",
     arguments: [
       // return types

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -209,6 +209,21 @@ struct TestDeclarationMacroTests {
             ),
           ]
         ),
+
+      #"@Test("Goodbye world") func `__raw__$helloWorld`()"#:
+        (
+          message: "Attribute 'Test' specifies display name 'Goodbye world' for function with implicit display name 'helloWorld'",
+          fixIts: [
+            ExpectedFixIt(
+              message: "Remove 'Goodbye world'",
+              changes: [.replace(oldSourceCode: #""Goodbye world""#, newSourceCode: "")]
+            ),
+            ExpectedFixIt(
+              message: "Rename '__raw__$helloWorld'",
+              changes: [.replace(oldSourceCode: "`__raw__$helloWorld`", newSourceCode: "\(EditorPlaceholderExprSyntax("name"))")]
+            ),
+          ]
+        ),
     ]
   }
 

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -290,6 +290,10 @@ struct MiscellaneousTests {
   @Test func `__raw__$raw_identifier_provides_a_display_name`() throws {
     let test = try #require(Test.current)
     #expect(test.displayName == "raw_identifier_provides_a_display_name")
+    #expect(test.name == "`raw_identifier_provides_a_display_name`()")
+    let id = test.id
+    #expect(id.moduleName == "TestingTests")
+    #expect(id.nameComponents == ["MiscellaneousTests", "`raw_identifier_provides_a_display_name`()"])
   }
 
   @Test("Free functions are runnable")

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -287,6 +287,11 @@ struct MiscellaneousTests {
     #expect(testType.displayName == "Named Sendable test type")
   }
 
+  @Test func `__raw__$raw_identifier_provides_a_display_name`() throws {
+    let test = try #require(Test.current)
+    #expect(test.displayName == "raw_identifier_provides_a_display_name")
+  }
+
   @Test("Free functions are runnable")
   func freeFunction() async throws {
     await Test(testFunction: freeSyncFunction).run()

--- a/Tests/TestingTests/SourceLocationTests.swift
+++ b/Tests/TestingTests/SourceLocationTests.swift
@@ -44,6 +44,20 @@ struct SourceLocationTests {
     #expect(sourceLocation.moduleName == "FakeModule")
   }
 
+  @Test("SourceLocation.moduleName property with raw identifier",
+    arguments: [
+      ("Foo/Bar.swift", "Foo", "Bar.swift"),
+      ("`Foo`/Bar.swift", "`Foo`", "Bar.swift"),
+      ("`Foo.Bar`/Quux.swift", "`Foo.Bar`", "Quux.swift"),
+      ("`Foo./.Bar`/Quux.swift", "`Foo./.Bar`", "Quux.swift"),
+    ]
+  )
+  func sourceLocationModuleNameWithRawIdentifier(fileID: String, expectedModuleName: String, expectedFileName: String) throws {
+    let sourceLocation = SourceLocation(fileID: fileID, filePath: "", line: 1, column: 1)
+    #expect(sourceLocation.moduleName == expectedModuleName)
+    #expect(sourceLocation.fileName == expectedFileName)
+  }
+
   @Test("SourceLocation.fileID property ignores middle components")
   func sourceLocationFileIDMiddleIgnored() {
     let sourceLocation = SourceLocation(fileID: "A/B/C/D.swift", filePath: "", line: 1, column: 1)

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -66,6 +66,8 @@ struct TypeInfoTests {
       ("(extension in `Module`):`Foo`.`B.ar`.(unknown context at $0).Quux", ["`Foo`", "`B.ar`", "Quux"]),
       ("(extension in `Mo:dule`):`Foo`.`B.ar`.(unknown context at $0).Quux", ["`Foo`", "`B.ar`", "Quux"]),
       ("(extension in `Module`):`F:oo`.`B.ar`.(unknown context at $0).Quux", ["`F:oo`", "`B.ar`", "Quux"]),
+      ("`(extension in Foo):Bar`.Baz", ["`(extension in Foo):Bar`", "Baz"]),
+      ("(extension in `(extension in Foo2):Bar2`):`(extension in Foo):Bar`.Baz", ["`(extension in Foo):Bar`", "Baz"]),
 
       // These aren't syntactically valid, but we should at least not crash.
       ("Foo.`B.ar`.Quux.`Alpha`..Beta", ["Foo", "`B.ar`", "Quux", "`Alpha`", "", "Beta"]),

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -64,6 +64,8 @@ struct TypeInfoTests {
       ("(extension in Module):Foo.`B.ar`.(unknown context at $0).Quux", ["Foo", "`B.ar`", "Quux"]),
       ("(extension in `Module`):Foo.`B.ar`.(unknown context at $0).Quux", ["Foo", "`B.ar`", "Quux"]),
       ("(extension in `Module`):`Foo`.`B.ar`.(unknown context at $0).Quux", ["`Foo`", "`B.ar`", "Quux"]),
+      ("(extension in `Mo:dule`):`Foo`.`B.ar`.(unknown context at $0).Quux", ["`Foo`", "`B.ar`", "Quux"]),
+      ("(extension in `Module`):`F:oo`.`B.ar`.(unknown context at $0).Quux", ["`F:oo`", "`B.ar`", "Quux"]),
 
       // These aren't syntactically valid, but we should at least not crash.
       ("Foo.`B.ar`.Quux.`Alpha`..Beta", ["Foo", "`B.ar`", "Quux", "`Alpha`", "", "Beta"]),


### PR DESCRIPTION
This PR adds support for the raw identifiers feature introduced with [SE-0451](https://forums.swift.org/t/accepted-with-revision-se-0451-raw-identifiers/76387).

Resolves #842.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
