### PR TITLE
Add a missing `#if !SWT_NO_EXIT_TESTS`.

### DIFF
--- a/Sources/Testing/Test+Discovery+Legacy.swift
+++ b/Sources/Testing/Test+Discovery+Legacy.swift
@@ -24,6 +24,7 @@ public protocol __TestContainer {
 /// `__TestContainer` protocol.
 let testContainerTypeNameMagic = "__🟠$test_container__"
 
+#if !SWT_NO_EXIT_TESTS
 /// A protocol describing a type that contains an exit test.
 ///
 /// - Warning: This protocol is used to implement the `#expect(exitsWith:)`
@@ -44,6 +45,7 @@ public protocol __ExitTestContainer {
 /// A string that appears within all auto-generated types conforming to the
 /// `__ExitTestContainer` protocol.
 let exitTestContainerTypeNameMagic = "__🟠$exit_test_body__"
+#endif
 
 // MARK: -
 


### PR DESCRIPTION
This PR adds a missing `#if !SWT_NO_EXIT_TESTS` statement in order to resolve a build failure on platforms that do not support exit tests (such as WASI.)

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
