### PR TITLE
Fix statically-linked platforms building new test content discovery code.

### DIFF
--- a/Sources/Testing/Discovery+Platform.swift
+++ b/Sources/Testing/Discovery+Platform.swift
@@ -210,7 +210,7 @@ private func _testContentSectionBounds() -> [SectionBounds] {
 ///   contained in the same image as the testing library itself.
 private func _testContentSectionBounds() -> CollectionOfOne<SectionBounds> {
   let (sectionBegin, sectionEnd) = SWTTestContentSectionBounds
-  let buffer = UnsafeRawBufferPointer(start: n, count: max(0, sectionEnd - sectionBegin))
+  let buffer = UnsafeRawBufferPointer(start: sectionBegin, count: max(0, sectionEnd - sectionBegin))
   let sb = SectionBounds(imageAddress: nil, buffer: buffer)
   return CollectionOfOne(sb)
 }

--- a/Sources/_TestingInternals/include/Discovery.h
+++ b/Sources/_TestingInternals/include/Discovery.h
@@ -62,13 +62,16 @@ SWT_IMPORT_FROM_STDLIB void swift_enumerateAllMetadataSections(
 );
 #endif
 
-#if defined(SWT_NO_DYNAMIC_LINKING)
 #pragma mark - Statically-linked section bounds
 
 /// The bounds of the test content section statically linked into the image
 /// containing Swift Testing.
+///
+/// - Note: This symbol is _declared_, but not _defined_, on platforms with
+///   dynamic linking because the `SWT_NO_DYNAMIC_LINKING` C++ macro (not the
+///   Swift compiler conditional of the same name) is not consistently declared
+///   when Swift files import the `_TestingInternals` C++ module.
 SWT_EXTERN const void *_Nonnull const SWTTestContentSectionBounds[2];
-#endif
 
 #pragma mark - Legacy test discovery
 


### PR DESCRIPTION
This PR fixes an undefined symbol error for `SWTTestContentSectionBounds` when building for statically-linked platforms. This issue appears to only occur with CMake and is (I think) a quirk of that build system.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
