### PR TITLE
Use `Never` instead of `Void` as the fallback lock/mutex type.

### DIFF
--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -44,10 +44,10 @@ struct Locked<T>: RawRepresentable, Sendable where T: Sendable {
   typealias PlatformLock = SRWLOCK
 #elseif os(WASI)
   // No locks on WASI without multithreaded runtime.
-  typealias PlatformLock = Void
+  typealias PlatformLock = Never
 #else
 #warning("Platform-specific implementation missing: locking unavailable")
-  typealias PlatformLock = Void
+  typealias PlatformLock = Never
 #endif
 
   /// A type providing heap-allocated storage for an instance of ``Locked``.


### PR DESCRIPTION
When using WASI without multithreading, or when using a platform to which Swift Testing has been incompletely ported, we don't know what type to use as a lock/mutex, so we use `Void`. However, turns out that produces a diagnostic:

> warning: UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer

So use `Never` instead. (Yes, this will produce a pointer to an uninitialized instance of `Never`. If this affects you, please read Porting.md!)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
