### PR TITLE
Fix several compile-time warnings that have snuck in.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         "_TestingInternals",
         "TestingMacros",
       ],
-      exclude: ["CMakeLists.txt"],
+      exclude: ["CMakeLists.txt", "Testing.swiftcrossimport"],
       cxxSettings: .packageSettings,
       swiftSettings: .packageSettings,
       linkerSettings: [
@@ -122,6 +122,7 @@ let package = Package(
         "Testing",
       ],
       path: "Sources/Overlays/_Testing_Foundation",
+      exclude: ["CMakeLists.txt"],
       swiftSettings: .packageSettings
     ),
   ],

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -243,8 +243,8 @@ private import _TestingInternals
   func exitConditionMatching() {
     #expect(Optional<ExitCondition>.none == Optional<ExitCondition>.none)
     #expect(Optional<ExitCondition>.none === Optional<ExitCondition>.none)
-    #expect(Optional<ExitCondition>.none !== .success)
-    #expect(Optional<ExitCondition>.none !== .failure)
+    #expect(Optional<ExitCondition>.none !== .some(.success))
+    #expect(Optional<ExitCondition>.none !== .some(.failure))
 
     #expect(ExitCondition.success == .success)
     #expect(ExitCondition.success === .success)

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -203,13 +203,12 @@ struct TimeLimitTraitTests {
         guard case let .issueRecorded(issue) = event.kind,
               case .timeLimitExceeded = issue.kind,
               let test = context.test,
-              let testCase = context.testCase
+              context.testCase != nil
         else {
           return
         }
         issueRecorded()
         #expect(test.timeLimit == .milliseconds(10))
-        #expect(testCase != nil)
       }
 
       await Test(.timeLimit(.milliseconds(10))) {


### PR DESCRIPTION
This PR resolves some compile-time warnings that occur when building the package from source. None of these warnings are critical issues.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
