### PR TITLE
Assign "Test Scoping Traits" proposal a number

### DIFF
--- a/Documentation/Proposals/0007-test-scoping-traits.md
+++ b/Documentation/Proposals/0007-test-scoping-traits.md
@@ -1,6 +1,6 @@
 # Test Scoping Traits
 
-* Proposal: [SWT-NNNN](NNNN-filename.md)
+* Proposal: [SWT-0007](0007-test-scoping-traits.md)
 * Authors: [Stuart Montgomery](https://github.com/stmontgomery)
 * Status: **Awaiting review**
 * Implementation: [swiftlang/swift-testing#733](https://github.com/swiftlang/swift-testing/pull/733), [swiftlang/swift-testing#86](https://github.com/swiftlang/swift-testing/pull/86)


### PR DESCRIPTION
Assign the "Test Scoping Traits" proposal, which was recently approved and merged in #733, a number

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
