### PR TITLE
[WIP] Set C language settings as well as C++ language settings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -185,7 +185,7 @@ extension Array where Element: LanguageSetting {
       .define("SWT_NO_EXIT_TESTS", .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android])),
       .define("SWT_NO_PROCESS_SPAWNING", .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android])),
       .define("SWT_NO_SNAPSHOT_TYPES", .when(platforms: [.linux, .custom("freebsd"), .openbsd, .windows, .wasi])),
-      .define("SWT_NO_DYNAMIC_LINKING", nil),
+      .define("SWT_NO_DYNAMIC_LINKING", .when(platforms: [.wasi])),
       .define("SWT_NO_PIPES", .when(platforms: [.wasi])),
     ]
   }

--- a/Sources/_TestingInternals/include/Discovery.h
+++ b/Sources/_TestingInternals/include/Discovery.h
@@ -62,25 +62,19 @@ SWT_IMPORT_FROM_STDLIB void swift_enumerateAllMetadataSections(
 );
 #endif
 
+#if defined(SWT_NO_DYNAMIC_LINKING)
 #pragma mark - Statically-linked section bounds
 
 /// The bounds of the test content section statically linked into the image
 /// containing Swift Testing.
-///
-/// - Note: This symbol is _declared_, but not _defined_, on platforms with
-///   dynamic linking because the `SWT_NO_DYNAMIC_LINKING` C++ macro (not the
-///   Swift compiler conditional of the same name) is not consistently declared
-///   when Swift files import the `_TestingInternals` C++ module.
 SWT_EXTERN const void *_Nonnull const SWTTestContentSectionBounds[2];
 
+#if !defined(SWT_NO_LEGACY_TEST_DISCOVERY)
 /// The bounds of the type metadata section statically linked into the image
 /// containing Swift Testing.
-///
-/// - Note: This symbol is _declared_, but not _defined_, on platforms with
-///   dynamic linking because the `SWT_NO_DYNAMIC_LINKING` C++ macro (not the
-///   Swift compiler conditional of the same name) is not consistently declared
-///   when Swift files import the `_TestingInternals` C++ module.
 SWT_EXTERN const void *_Nonnull const SWTTypeMetadataSectionBounds[2];
+#endif
+#endif
 
 #pragma mark - Legacy test discovery
 


### PR DESCRIPTION
In theory, this lets us correctly see those settings in C++ headers (need to see if CMake is happy.)

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
