### PR TITLE
Remove some remnants of the C++ section discovery code that we no longer need.

### DIFF
--- a/Sources/Testing/Test+Discovery+Legacy.swift
+++ b/Sources/Testing/Test+Discovery+Legacy.swift
@@ -57,15 +57,13 @@ let exitTestContainerTypeNameMagic = "__🟠$exit_test_body__"
 ///
 /// - Returns: A sequence of Swift types whose names contain `nameSubstring`.
 func types(withNamesContaining nameSubstring: String) -> some Sequence<Any.Type> {
-  SectionBounds.all(.typeMetadata).lazy
-    .map { sb in
-      var count = 0
-      let start = swt_copyTypes(in: sb.buffer.baseAddress!, sb.buffer.count, withNamesContaining: nameSubstring, count: &count)
-      defer {
-        free(start)
-      }
-      return start.withMemoryRebound(to: Any.Type.self, capacity: count) { start in
-        Array(UnsafeBufferPointer(start: start, count: count))
-      }
-    }.joined()
+  SectionBounds.all(.typeMetadata).lazy.flatMap { sb in
+    var count = 0
+    let start = swt_copyTypes(in: sb.buffer.baseAddress!, sb.buffer.count, withNamesContaining: nameSubstring, count: &count)
+    defer {
+      free(start)
+    }
+    return UnsafeBufferPointer(start: start, count: count)
+      .withMemoryRebound(to: Any.Type.self) { Array($0) }
+  }
 }

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -48,86 +48,20 @@ const void *_Nonnull const SWTTypeMetadataSectionBounds[2] = {
 
 #pragma mark - Legacy test discovery
 
-#include <algorithm>
-#include <array>
-#include <atomic>
-#include <cstring>
-#include <iterator>
+#include <cstdlib>
+#include <cstdint>
 #include <memory>
-#include <tuple>
 #include <type_traits>
 #include <vector>
-#include <optional>
-
-/// Enumerate over all Swift type metadata sections in the current process.
-///
-/// - Parameters:
-///   - body: A function to call once for every section in the current process.
-///     A pointer to the first type metadata record and the number of records
-///     are passed to this function.
-template <typename SectionEnumerator>
-static void enumerateTypeMetadataSections(const SectionEnumerator& body);
-
-/// A type that acts as a C++ [Allocator](https://en.cppreference.com/w/cpp/named_req/Allocator)
-/// without using global `operator new` or `operator delete`.
-///
-/// This type is necessary because global `operator new` and `operator delete`
-/// can be overridden in developer-supplied code and cause deadlocks or crashes
-/// when subsequently used while holding a dyld- or libobjc-owned lock. Using
-/// `std::malloc()` and `std::free()` allows the use of C++ container types
-/// without this risk.
-template<typename T>
-struct SWTHeapAllocator {
-  using value_type = T;
-
-  T *allocate(size_t count) {
-    return reinterpret_cast<T *>(std::calloc(count, sizeof(T)));
-  }
-
-  void deallocate(T *ptr, size_t count) {
-    std::free(ptr);
-  }
-};
-
-/// A structure describing the bounds of a Swift metadata section.
-///
-/// The template argument `T` is the element type of the metadata section.
-/// Instances of this type can be used with a range-based `for`-loop to iterate
-/// the contents of the section.
-template <typename T>
-struct SWTSectionBounds {
-  /// The base address of the image containing the section, if known.
-  const void *imageAddress;
-
-  /// The base address of the section.
-  const void *start;
-
-  /// The size of the section in bytes.
-  size_t size;
-
-  const struct SWTTypeMetadataRecord *begin(void) const {
-    return reinterpret_cast<const T *>(start);
-  }
-
-  const struct SWTTypeMetadataRecord *end(void) const {
-    return reinterpret_cast<const T *>(reinterpret_cast<uintptr_t>(start) + size);
-  }
-};
-
-/// A type that acts as a C++ [Container](https://en.cppreference.com/w/cpp/named_req/Container)
-/// and which contains a sequence of instances of `SWTSectionBounds<T>`.
-template <typename T>
-using SWTSectionBoundsList = std::vector<SWTSectionBounds<T>, SWTHeapAllocator<SWTSectionBounds<T>>>;
 
 #pragma mark - Swift ABI
 
 #if defined(__PTRAUTH_INTRINSICS__)
 #include <ptrauth.h>
-#define SWT_PTRAUTH __ptrauth
+#define SWT_PTRAUTH_SWIFT_TYPE_DESCRIPTOR __ptrauth(ptrauth_key_process_independent_data, 1, 0xae86)
 #else
-#define SWT_PTRAUTH(...)
+#define SWT_PTRAUTH_SWIFT_TYPE_DESCRIPTOR
 #endif
-#define SWT_PTRAUTH_SWIFT_TYPE_DESCRIPTOR SWT_PTRAUTH(ptrauth_key_process_independent_data, 1, 0xae86)
 
 /// A type representing a pointer relative to itself.
 ///
@@ -273,10 +207,16 @@ public:
 #pragma mark -
 
 void **swt_copyTypesWithNamesContaining(const void *sectionBegin, size_t sectionSize, const char *nameSubstring, size_t *outCount) {
-  SWTSectionBounds<SWTTypeMetadataRecord> sb = { nullptr, sectionBegin, sectionSize };
-  std::vector<void *, SWTHeapAllocator<void *>> result;
+  auto records = reinterpret_cast<const SWTTypeMetadataRecord *>(sectionBegin);
+  size_t recordCount = sectionSize / sizeof(SWTTypeMetadataRecord);
 
-  for (const auto& record : sb) {
+  // The buffer we'll return and how many types we've placed in it. (We only
+  // allocate the buffer if at least one type in the section matches.)
+  void **result = nullptr;
+  auto resultCount = 0;
+
+  for (size_t i = 0; i < recordCount; i++) {
+    const auto& record = records[i];
     auto contextDescriptor = record.getContextDescriptor();
     if (!contextDescriptor) {
       // This type metadata record is invalid (or we don't understand how to
@@ -297,14 +237,19 @@ void **swt_copyTypesWithNamesContaining(const void *sectionBegin, size_t section
     }
 
     if (void *typeMetadata = contextDescriptor->getMetadata()) {
-      result.push_back(typeMetadata);
+      if (!result) {
+        // This is the first matching type we've found. That presumably means
+        // we'll find more, so allocate enough space for all remaining types in
+        // the section. Is this necessarily space-efficient? No, but this
+        // allocation is short-lived and is immediately copied and freed in the
+        // Swift caller.
+        result = reinterpret_cast<void **>(std::calloc(recordCount - i, sizeof(void *)));
+      }
+      result[resultCount] = typeMetadata;
+      resultCount += 1;
     }
   }
 
-  auto resultCopy = reinterpret_cast<void **>(std::calloc(sizeof(void *), result.size()));
-  if (resultCopy) {
-    std::uninitialized_move(result.begin(), result.end(), resultCopy);
-    *outCount = result.size();
-  }
-  return resultCopy;
+  *outCount = resultCount;
+  return result;
 }

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -37,25 +37,18 @@ static const char typeMetadataSectionBegin = 0;
 static const char& typeMetadataSectionEnd = typeMetadataSectionBegin;
 #endif
 
-/// The bounds of the test content section statically linked into the image
-/// containing Swift Testing.
 const void *_Nonnull const SWTTestContentSectionBounds[2] = {
-  &testContentSectionBegin,
-  &testContentSectionEnd
+  &testContentSectionBegin, &testContentSectionEnd
 };
 
-/// The bounds of the type metadata section statically linked into the image
-/// containing Swift Testing.
 const void *_Nonnull const SWTTypeMetadataSectionBounds[2] = {
-  &typeMetadataSectionBegin,
-  &typeMetadataSectionEnd
+  &typeMetadataSectionBegin, &typeMetadataSectionEnd
 };
 #endif
 
 #pragma mark - Swift ABI
 
 #if defined(__PTRAUTH_INTRINSICS__)
-#include <ptrauth.h>
 #define SWT_PTRAUTH_SWIFT_TYPE_DESCRIPTOR __ptrauth(ptrauth_key_process_independent_data, 1, 0xae86)
 #else
 #define SWT_PTRAUTH_SWIFT_TYPE_DESCRIPTOR
@@ -197,17 +190,13 @@ public:
 #pragma mark - Legacy test discovery
 
 void **swt_copyTypesWithNamesContaining(const void *sectionBegin, size_t sectionSize, const char *nameSubstring, size_t *outCount) {
-  auto records = reinterpret_cast<const SWTTypeMetadataRecord *>(sectionBegin);
-  size_t recordCount = sectionSize / sizeof(SWTTypeMetadataRecord);
-
-  // The buffer we'll return and how many types we've placed in it. (We only
-  // allocate the buffer if at least one type in the section matches.)
   void **result = nullptr;
   size_t resultCount = 0;
 
+  auto records = reinterpret_cast<const SWTTypeMetadataRecord *>(sectionBegin);
+  size_t recordCount = sectionSize / sizeof(SWTTypeMetadataRecord);
   for (size_t i = 0; i < recordCount; i++) {
-    const auto& record = records[i];
-    auto contextDescriptor = record.getContextDescriptor();
+    auto contextDescriptor = records[i].getContextDescriptor();
     if (!contextDescriptor) {
       // This type metadata record is invalid (or we don't understand how to
       // get its context descriptor), so skip it.

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -50,6 +50,7 @@ const void *_Nonnull const SWTTypeMetadataSectionBounds[2] = {
 
 #include <cstdlib>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <type_traits>
 #include <vector>

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -10,6 +10,12 @@
 
 #include "Discovery.h"
 
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+#include <vector>
+
 #if defined(SWT_NO_DYNAMIC_LINKING)
 #pragma mark - Statically-linked section bounds
 
@@ -45,15 +51,6 @@ const void *_Nonnull const SWTTypeMetadataSectionBounds[2] = {
   &typeMetadataSectionEnd
 };
 #endif
-
-#pragma mark - Legacy test discovery
-
-#include <cstdlib>
-#include <cstdint>
-#include <cstring>
-#include <memory>
-#include <type_traits>
-#include <vector>
 
 #pragma mark - Swift ABI
 
@@ -197,7 +194,7 @@ public:
   }
 };
 
-#pragma mark -
+#pragma mark - Legacy test discovery
 
 void **swt_copyTypesWithNamesContaining(const void *sectionBegin, size_t sectionSize, const char *nameSubstring, size_t *outCount) {
   auto records = reinterpret_cast<const SWTTypeMetadataRecord *>(sectionBegin);
@@ -206,7 +203,7 @@ void **swt_copyTypesWithNamesContaining(const void *sectionBegin, size_t section
   // The buffer we'll return and how many types we've placed in it. (We only
   // allocate the buffer if at least one type in the section matches.)
   void **result = nullptr;
-  auto resultCount = 0;
+  size_t resultCount = 0;
 
   for (size_t i = 0; i < recordCount; i++) {
     const auto& record = records[i];

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -98,10 +98,6 @@ public:
 #endif
     return reinterpret_cast<const T *>(result);
   }
-
-  const T *_Nullable operator ->(void) const& {
-    return get();
-  }
 };
 
 /// A type representing a 32-bit absolute function pointer, usually used on platforms
@@ -117,10 +113,6 @@ private:
 public:
   const T *_Nullable get(void) const & {
     return _pointer;
-  }
-
-  const T *_Nullable operator ->(void) const & {
-    return get();
   }
 };
 

--- a/Sources/_TestingInternals/Versions.cpp
+++ b/Sources/_TestingInternals/Versions.cpp
@@ -10,12 +10,6 @@
 
 #include "Versions.h"
 
-#if defined(_SWT_TESTING_LIBRARY_VERSION) && !defined(SWT_TESTING_LIBRARY_VERSION)
-#warning _SWT_TESTING_LIBRARY_VERSION is deprecated
-#warning Define SWT_TESTING_LIBRARY_VERSION and optionally SWT_TARGET_TRIPLE instead
-#define SWT_TESTING_LIBRARY_VERSION _SWT_TESTING_LIBRARY_VERSION
-#endif
-
 const char *swt_getTestingLibraryVersion(void) {
 #if defined(SWT_TESTING_LIBRARY_VERSION)
   return SWT_TESTING_LIBRARY_VERSION;

--- a/Sources/_TestingInternals/include/Discovery.h
+++ b/Sources/_TestingInternals/include/Discovery.h
@@ -94,8 +94,9 @@ SWT_EXTERN const void *_Nonnull const SWTTypeMetadataSectionBounds[2];
 ///   - nameSubstring: A string which the names of matching classes all contain.
 ///   - outCount: On return, the number of type metadata pointers returned.
 ///
-/// - Returns: A pointer to an array of type metadata pointers. The caller is
-///   responsible for freeing this memory with `free()` when done.
+/// - Returns: A pointer to an array of type metadata pointers, or `nil` if no
+///   matching types were found. The caller is responsible for freeing this
+///   memory with `free()` when done.
 SWT_EXTERN void *_Nonnull *_Nullable swt_copyTypesWithNamesContaining(
   const void *sectionBegin,
   size_t sectionSize,

--- a/Sources/_TestingInternals/include/Discovery.h
+++ b/Sources/_TestingInternals/include/Discovery.h
@@ -96,7 +96,7 @@ SWT_EXTERN const void *_Nonnull const SWTTypeMetadataSectionBounds[2];
 ///
 /// - Returns: A pointer to an array of type metadata pointers. The caller is
 ///   responsible for freeing this memory with `free()` when done.
-SWT_EXTERN void *_Nonnull *_Nonnull swt_copyTypesWithNamesContaining(
+SWT_EXTERN void *_Nonnull *_Nullable swt_copyTypesWithNamesContaining(
   const void *sectionBegin,
   size_t sectionSize,
   const char *nameSubstring,


### PR DESCRIPTION
This PR removes additional C++ section discovery code that is no longer needed.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
