### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -3,6 +3,5 @@ metadata:
   authors: Apple Inc.
 builder:
   configs:
-    - swift_version: 6.0
-      documentation_targets: [Testing]
+    - documentation_targets: [Testing]
       scheme: Testing


### PR DESCRIPTION
Swift 6 is now the default doc build version on SPI.