### PR TITLE
Remove @dennisweissmann from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 #
 
-* @stmontgomery @grynspan @dennisweissmann @briancroom @SeanROlszewski @suzannaratcliff
+* @stmontgomery @grynspan @briancroom @SeanROlszewski @suzannaratcliff


### PR DESCRIPTION
Remove @dennisweissmann from `CODEOWNERS` to reflect his current role 🫡

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
