### PR TITLE
Don't capture arguments to `#expect(exitsWith:)` during macro expansion.

### DIFF
--- a/Documentation/ABI/TestContent.md
+++ b/Documentation/ABI/TestContent.md
@@ -118,9 +118,17 @@ to by `hint` depend on the kind of record:
 - For exit test declarations (kind `0x65786974`), the accessor produces a
   structure describing the exit test (of type `__ExitTest`.)
 
-  Test content records of this kind accept a `hint` of type `SourceLocation`.
-  They only produce a result if they represent an exit test declared at the same
-  source location (or if the hint is `nil`.)
+  Test content records of this kind accept a `hint` of type `__ExitTest.ID`.
+  They only produce a result if they represent an exit test declared with the
+  same ID (or if `hint` is `nil`.)
+
+> [!WARNING]
+> Calling code should use [`withUnsafeTemporaryAllocation(of:capacity:_:)`](https://developer.apple.com/documentation/swift/withunsafetemporaryallocation(of:capacity:_:))
+> and [`withUnsafePointer(to:_:)`](https://developer.apple.com/documentation/swift/withunsafepointer(to:_:)-35wrn),
+> respectively, to ensure the pointers passed to `accessor` are large enough and
+> are well-aligned. If they are not large enough to contain values of the
+> appropriate types (per above), or if `hint` points to uninitialized or
+> incorrectly-typed memory, the result is undefined.
 
 #### The context field
 

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -69,6 +69,7 @@ public struct __ExitTest: Sendable, ~Copyable {
     }
   }
 
+  /// A value that uniquely identifies this instance.
   public var id: ID
 
   /// The body closure of the exit test.

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -546,7 +546,7 @@ public macro require<R>(
   observing observedValues: [any PartialKeyPath<ExitTestArtifacts> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
-  performing expression: @convention(thin) () async throws -> Void
+  performing expression: @escaping @Sendable @convention(thin) () async throws -> Void
 ) -> ExitTestArtifacts? = #externalMacro(module: "TestingMacros", type: "ExitTestExpectMacro")
 
 /// Check that an expression causes the process to terminate in a given fashion
@@ -658,5 +658,5 @@ public macro require<R>(
   observing observedValues: [any PartialKeyPath<ExitTestArtifacts> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
-  performing expression: @convention(thin) () async throws -> Void
+  performing expression: @escaping @Sendable @convention(thin) () async throws -> Void
 ) -> ExitTestArtifacts = #externalMacro(module: "TestingMacros", type: "ExitTestRequireMacro")

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1147,6 +1147,7 @@ public func __checkClosureCall<R>(
 ///   `#require()` macros. Do not call it directly.
 @_spi(Experimental)
 public func __checkClosureCall(
+  identifiedBy exitTestID: __ExitTest.ID,
   exitsWith expectedExitCondition: ExitCondition,
   observing observedValues: [any PartialKeyPath<ExitTestArtifacts> & Sendable],
   performing body: @convention(thin) () -> Void,
@@ -1157,6 +1158,7 @@ public func __checkClosureCall(
   sourceLocation: SourceLocation
 ) async -> Result<ExitTestArtifacts?, any Error> {
   await callExitTest(
+    identifiedBy: exitTestID,
     exitsWith: expectedExitCondition,
     observing: observedValues,
     expression: expression,

--- a/Sources/Testing/Test+Discovery+Legacy.swift
+++ b/Sources/Testing/Test+Discovery+Legacy.swift
@@ -32,11 +32,8 @@ let testContainerTypeNameMagic = "__🟠$test_container__"
 @_alwaysEmitConformanceMetadata
 @_spi(Experimental)
 public protocol __ExitTestContainer {
-  /// The expected exit condition of the exit test.
-  static var __expectedExitCondition: ExitCondition { get }
-
-  /// The source location of the exit test.
-  static var __sourceLocation: SourceLocation { get }
+  /// The unique identifier of the exit test.
+  static var __id: __ExitTest.ID { get }
 
   /// The body function of the exit test.
   static var __body: @Sendable () async throws -> Void { get }

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -405,6 +405,17 @@ private import _TestingInternals
     #expect(result.standardOutputContent.isEmpty)
     #expect(result.standardErrorContent.contains("STANDARD ERROR".utf8.reversed()))
   }
+
+  @Test("Arguments to the macro are not captured during expansion (do not need to be literals/const)")
+  func argumentsAreNotCapturedDuringMacroExpansion() async throws {
+    let unrelatedSourceLocation = #_sourceLocation
+    func nonConstExitCondition() async throws -> ExitCondition {
+      .failure
+    }
+    await #expect(exitsWith: try await nonConstExitCondition(), sourceLocation: unrelatedSourceLocation) {
+      fatalError()
+    }
+  }
 }
 
 // MARK: - Fixtures


### PR DESCRIPTION
Other than the body closure, the arguments to `#expect(exitsWith:)` are not guaranteed to be literals or otherwise context-free, but we capture them during macro expansion. This can result in obscure errors if the developer writes an exit test with an argument that is computed:

```swift
let foo = ...
await #expect(exitsWith: self.exitCondition(for: foo)) {
  // 🛑 error: closure captures 'foo' before it is declared
  // 🛑 error: enum declaration cannot close over value 'self' defined in outer scope
  // (and other possible errors)
  ...
}
```

This PR removes the macro's compile-time dependency on its `exitCondition` and `sourceLocation` arguments and introduces an `ID` type to identify exit tests (instead of using their source locations as unique IDs.) The `ID` type is meant to be a UUID, but for the moment I've just strung together two 64-bit integers instead to avoid a dependency on Foundation or platform API.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
