### PR TITLE
Refactor test content discovery to produce a sequence.

### DIFF
--- a/Sources/Testing/Discovery+Platform.swift
+++ b/Sources/Testing/Discovery+Platform.swift
@@ -35,7 +35,7 @@ struct SectionBounds: Sendable {
   ///
   /// - Returns: A sequence of structures describing the bounds of metadata
   ///   sections of the given kind found in the current process.
-  static func all(_ kind: Kind) -> some RandomAccessCollection<SectionBounds> {
+  static func all(_ kind: Kind) -> some Sequence<SectionBounds> {
     _sectionBounds(kind)
   }
 }
@@ -237,7 +237,7 @@ private func _sectionBounds(_ kind: SectionBounds.Kind) -> [SectionBounds] {
   case .typeMetadata:
     ".sw5tymd"
   }
-  return HMODULE.all.compactMap { _findSection(named: sectionName, in: $0) }
+  return HMODULE.all.lazy.compactMap { _findSection(named: sectionName, in: $0) }
 }
 #else
 /// The fallback implementation of ``SectionBounds/all(_:)`` for platforms that

--- a/Sources/Testing/Discovery.swift
+++ b/Sources/Testing/Discovery.swift
@@ -120,7 +120,7 @@ extension TestContentRecord where T: TestContent & ~Copyable {
   ///
   /// If this function is called more than once on the same instance, a new
   /// value is created on each call.
-  func load<R>(withHint hint: T.TestContentAccessorHint? = nil) -> R? where R == T.TestContentAccessorResult, R: ~Copyable {
+  func load(withHint hint: T.TestContentAccessorHint? = nil) -> T.TestContentAccessorResult? {
     guard let accessor = _record.accessor.map(swt_resign) else {
       return nil
     }
@@ -150,7 +150,7 @@ extension TestContent where Self: ~Copyable {
   /// - Returns: A sequence of instances of ``TestContentRecord``. Only test
   ///   content records matching this ``TestContent`` type's requirements are
   ///   included in the sequence.
-  static func allTestContentRecords() -> some Sequence<TestContentRecord<Self>> {
+  static func allTestContentRecords() -> LazySequence<some Sequence<TestContentRecord<Self>>> {
     SectionBounds.all(.testContent).lazy.flatMap { sb in
       sb.buffer.withMemoryRebound(to: __TestContentRecord.self) { records in
         records.lazy

--- a/Sources/Testing/Discovery.swift
+++ b/Sources/Testing/Discovery.swift
@@ -68,8 +68,9 @@ protocol TestContent: ~Copyable {
 
 /// A type describing a test content record of a particular (known) type.
 ///
-/// Instances of this type can be created by calling ``TestContent/discover()``
-/// on a type that conforms to ``TestContent``.
+/// Instances of this type can be created by calling
+/// ``TestContent/allTestContentRecords()`` on a type that conforms to
+/// ``TestContent``.
 ///
 /// This type is not part of the public interface of the testing library. In the
 /// future, we could make it public if we want to support runtime discovery of
@@ -119,7 +120,7 @@ extension TestContentRecord where T: TestContent & ~Copyable {
   ///
   /// If this function is called more than once on the same instance, a new
   /// value is created on each call.
-  func load(withHint hint: T.TestContentAccessorHint? = nil) -> T.TestContentAccessorResult? {
+  func load<R>(withHint hint: T.TestContentAccessorHint? = nil) -> R? where R == T.TestContentAccessorResult, R: ~Copyable {
     guard let accessor = _record.accessor.map(swt_resign) else {
       return nil
     }
@@ -149,7 +150,7 @@ extension TestContent where Self: ~Copyable {
   /// - Returns: A sequence of instances of ``TestContentRecord``. Only test
   ///   content records matching this ``TestContent`` type's requirements are
   ///   included in the sequence.
-  static func discover() -> some Sequence<TestContentRecord<Self>> {
+  static func allTestContentRecords() -> some Sequence<TestContentRecord<Self>> {
     SectionBounds.all(.testContent).lazy.flatMap { sb in
       sb.buffer.withMemoryRebound(to: __TestContentRecord.self) { records in
         records.lazy

--- a/Sources/Testing/Discovery.swift
+++ b/Sources/Testing/Discovery.swift
@@ -150,13 +150,17 @@ extension TestContent where Self: ~Copyable {
   /// - Returns: A sequence of instances of ``TestContentRecord``. Only test
   ///   content records matching this ``TestContent`` type's requirements are
   ///   included in the sequence.
-  static func allTestContentRecords() -> LazySequence<some Sequence<TestContentRecord<Self>>> {
-    SectionBounds.all(.testContent).lazy.flatMap { sb in
+  ///
+  /// - Bug: This function returns an instance of `AnySequence` instead of an
+  ///   opaque type due to a compiler crash. ([143080508](rdar://143080508))
+  static func allTestContentRecords() -> AnySequence<TestContentRecord<Self>> {
+    let result = SectionBounds.all(.testContent).lazy.flatMap { sb in
       sb.buffer.withMemoryRebound(to: __TestContentRecord.self) { records in
         records.lazy
           .filter { $0.kind == testContentKind }
           .map { TestContentRecord<Self>(imageAddress: sb.imageAddress, record: $0) }
       }
     }
+    return AnySequence(result)
   }
 }

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -242,7 +242,7 @@ extension ExitTest {
   /// - Returns: The specified exit test function, or `nil` if no such exit test
   ///   could be found.
   public static func find(identifiedBy id: ExitTest.ID) -> Self? {
-    for record in Self.discover() {
+    for record in Self.allTestContentRecords() {
       if let exitTest = record.load(withHint: id) {
         return exitTest
       }

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -51,7 +51,7 @@ public typealias ExitTest = __ExitTest
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
-public struct __ExitTest: Sendable {
+public struct __ExitTest: Sendable, ~Copyable {
   /// A type whose instances uniquely identify instances of `__ExitTest`.
   public struct ID: Sendable, Equatable, Codable {
     /// An underlying UUID (stored as two `UInt64` values to avoid relying on

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -22,59 +22,51 @@ extension Test: TestContent {
   /// The order of values in this sequence is unspecified.
   static var all: some Sequence<Self> {
     get async {
-      var generators = [@Sendable () async -> [Self]]()
+      // The result is a set rather than an array to deduplicate tests that were
+      // generated multiple times (e.g. from multiple discovery modes or from
+      // defective test records.)
+      var result = Set<Self>()
 
       // Figure out which discovery mechanism to use. By default, we'll use both
       // the legacy and new mechanisms, but we can set an environment variable
       // to explicitly select one or the other. When we remove legacy support,
       // we can also remove this enumeration and environment variable check.
-      enum DiscoveryMode {
-        case tryBoth
-        case newOnly
-        case legacyOnly
-      }
-      let discoveryMode: DiscoveryMode = switch Environment.flag(named: "SWT_USE_LEGACY_TEST_DISCOVERY") {
+      let (useNewMode, useLegacyMode) = switch Environment.flag(named: "SWT_USE_LEGACY_TEST_DISCOVERY") {
       case .none:
-        .tryBoth
+        (true, true)
       case .some(true):
-        .legacyOnly
+        (false, true)
       case .some(false):
-        .newOnly
+        (true, false)
       }
 
-      // Walk all test content and gather generator functions. Note we don't
-      // actually call the generators yet because enumerating test content may
-      // involve holding some internal lock such as the ones in libobjc or
-      // dl_iterate_phdr(), and we don't want to accidentally deadlock if the
-      // user code we call ends up loading another image.
-      if discoveryMode != .legacyOnly {
-        enumerateTestContent { imageAddress, generator, _, _ in
-          generators.append { @Sendable in
-            await [generator()]
+      // Walk all test content and gather generator functions, then call them in
+      // a task group and collate their results.
+      if useNewMode {
+        let generators = Self.discover().lazy.compactMap { $0.load() }
+        await withTaskGroup(of: Self.self) { taskGroup in
+          for generator in generators {
+            taskGroup.addTask(operation: generator)
           }
+          result = await taskGroup.reduce(into: result) { $0.insert($1) }
         }
       }
 
-      if discoveryMode != .newOnly && generators.isEmpty {
-        generators += types(withNamesContaining: testContainerTypeNameMagic).lazy
+      // Perform legacy test discovery if needed.
+      if useLegacyMode && result.isEmpty {
+        let types = types(withNamesContaining: testContainerTypeNameMagic).lazy
           .compactMap { $0 as? any __TestContainer.Type }
-          .map { type in
-            { @Sendable in await type.__tests }
+        await withTaskGroup(of: [Self].self) { taskGroup in
+          for type in types {
+            taskGroup.addTask {
+              await type.__tests
+            }
           }
+          result = await taskGroup.reduce(into: result) { $0.formUnion($1) }
+        }
       }
 
-      // *Now* we call all the generators and return their results.
-      // Reduce into a set rather than an array to deduplicate tests that were
-      // generated multiple times (e.g. from multiple discovery modes or from
-      // defective test records.)
-      return await withTaskGroup(of: [Self].self) { taskGroup in
-        for generator in generators {
-          taskGroup.addTask {
-            await generator()
-          }
-        }
-        return await taskGroup.reduce(into: Set()) { $0.formUnion($1) }
-      }
+      return result
     }
   }
 }

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -43,7 +43,7 @@ extension Test: TestContent {
       // Walk all test content and gather generator functions, then call them in
       // a task group and collate their results.
       if useNewMode {
-        let generators = Self.discover().lazy.compactMap { $0.load() }
+        let generators = Self.allTestContentRecords().lazy.compactMap { $0.load() }
         await withTaskGroup(of: Self.self) { taskGroup in
           for generator in generators {
             taskGroup.addTask(operation: generator)

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -628,9 +628,11 @@ struct MiscellaneousTests {
 
   @Test func testDiscovery() async {
     // Check the type of the test record sequence (it should be lazy.)
-    let allRecords: some Sequence<TestContentRecord<DiscoverableTestContent>> = DiscoverableTestContent.allTestContentRecords()
+    let allRecords = DiscoverableTestContent.allTestContentRecords()
+#if SWT_FIXED_143080508
     #expect(allRecords is any LazySequenceProtocol)
     #expect(!(allRecords is [TestContentRecord<DiscoverableTestContent>]))
+#endif
 
     // It should have exactly one matching record (because we only emitted one.)
     #expect(Array(allRecords).count == 1)

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -628,7 +628,7 @@ struct MiscellaneousTests {
 
   @Test func testDiscovery() async {
     // Check the type of the test record sequence (it should be lazy.)
-    let allRecords = DiscoverableTestContent.discover()
+    let allRecords = DiscoverableTestContent.allTestContentRecords()
     #expect(allRecords is any LazySequenceProtocol)
     #expect(!(allRecords is [TestContentRecord<DiscoverableTestContent>]))
 

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -628,7 +628,7 @@ struct MiscellaneousTests {
 
   @Test func testDiscovery() async {
     // Check the type of the test record sequence (it should be lazy.)
-    let allRecords = DiscoverableTestContent.allTestContentRecords()
+    let allRecords: some Sequence<TestContentRecord<DiscoverableTestContent>> = DiscoverableTestContent.allTestContentRecords()
     #expect(allRecords is any LazySequenceProtocol)
     #expect(!(allRecords is [TestContentRecord<DiscoverableTestContent>]))
 


### PR DESCRIPTION
This PR does away with `enumerateTestContent {}` and replaces it with `discover()`, a function that returns a sequence of `TestContentRecord` instances that the caller can then inspect. This simplifies the logic in callers by letting them use sequence operations/monads like `map()`, and simplifies the logic in the implementation by doing away with intermediate tuples and allowing it to just map section bounds to sequences of `TestContentRecord` values.

Evaluation of the accessor functions for test content records is now lazier, allowing us to potentially leverage the `context` field of a test content record to avoid calling accessors for records we know won't match due to the content of that field. (This functionality isn't currently needed, but could be useful for future test content types.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
