### PR TITLE
Fix the build for WASI

### DIFF
--- a/Sources/Testing/Discovery.swift
+++ b/Sources/Testing/Discovery.swift
@@ -86,8 +86,13 @@ struct TestContentRecord<T>: Sendable where T: ~Copyable {
   ///   with interfaces such as `dlsym()` that expect such a pointer.
 #if SWT_NO_DYNAMIC_LINKING
   @available(*, unavailable, message: "Image addresses are not available on this platform.")
-#endif
+  nonisolated(unsafe) var imageAddress: UnsafeRawPointer? {
+    get { fatalError() }
+    set { fatalError() }
+  }
+#else
   nonisolated(unsafe) var imageAddress: UnsafeRawPointer?
+#endif
 
   /// The underlying test content record loaded from a metadata section.
   private var _record: __TestContentRecord


### PR DESCRIPTION
Avoids a compiler error when `SWT_NO_DYNAMIC_LINKING` is true.

### Motivation:

Fixes the broken build, which is blocking Swift compiler PR testing.

### Modifications:

Makes `imageAddress` a computed property when `SWT_NO_DYNAMIC_LINKING` is true so that it can be marked `@available(*, unavailable)`.
