### PR TITLE
Revert #916 and apply a slightly different change.

### DIFF
--- a/Sources/Testing/Discovery.swift
+++ b/Sources/Testing/Discovery.swift
@@ -78,24 +78,19 @@ protocol TestContent: ~Copyable {
 struct TestContentRecord<T>: Sendable where T: ~Copyable {
   /// The base address of the image containing this instance, if known.
   ///
-  /// This property is not available on platforms such as WASI that statically
-  /// link to the testing library.
+  /// On platforms such as WASI that statically link to the testing library, the
+  /// value of this property is always `nil`.
   ///
   /// - Note: The value of this property is distinct from the pointer returned
   ///   by `dlopen()` (on platforms that have that function) and cannot be used
   ///   with interfaces such as `dlsym()` that expect such a pointer.
-#if SWT_NO_DYNAMIC_LINKING
-  @available(*, unavailable, message: "Image addresses are not available on this platform.")
-#endif
   nonisolated(unsafe) var imageAddress: UnsafeRawPointer?
 
   /// The underlying test content record loaded from a metadata section.
   private var _record: __TestContentRecord
 
   fileprivate init(imageAddress: UnsafeRawPointer?, record: __TestContentRecord) {
-#if !SWT_NO_DYNAMIC_LINKING
     self.imageAddress = imageAddress
-#endif
     self._record = record
   }
 }

--- a/Sources/Testing/Discovery.swift
+++ b/Sources/Testing/Discovery.swift
@@ -86,13 +86,8 @@ struct TestContentRecord<T>: Sendable where T: ~Copyable {
   ///   with interfaces such as `dlsym()` that expect such a pointer.
 #if SWT_NO_DYNAMIC_LINKING
   @available(*, unavailable, message: "Image addresses are not available on this platform.")
-  nonisolated(unsafe) var imageAddress: UnsafeRawPointer? {
-    get { fatalError() }
-    set { fatalError() }
-  }
-#else
-  nonisolated(unsafe) var imageAddress: UnsafeRawPointer?
 #endif
+  nonisolated(unsafe) var imageAddress: UnsafeRawPointer?
 
   /// The underlying test content record loaded from a metadata section.
   private var _record: __TestContentRecord


### PR DESCRIPTION
Thank you to @tshortli for the patch! We don't actually _need_ this property to be unavailable on WASI—it was just meant as a convenience. But since we're not using the property for anything at this time (a future PR might try to productize `TestContentRecord`), it's overkill.

So instead I'll just leave the property available, and document it's always `nil` on statically-linked platforms.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
