### PR TITLE
Remove arm64e ptrauth resigning from test content discovery.

### DIFF
--- a/Sources/Testing/Discovery.swift
+++ b/Sources/Testing/Discovery.swift
@@ -116,7 +116,7 @@ extension TestContentRecord where T: TestContent & ~Copyable {
   /// If this function is called more than once on the same instance, a new
   /// value is created on each call.
   func load(withHint hint: T.TestContentAccessorHint? = nil) -> T.TestContentAccessorResult? {
-    guard let accessor = _record.accessor.map(swt_resign) else {
+    guard let accessor = _record.accessor else {
       return nil
     }
 

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -47,6 +47,7 @@ const void *_Nonnull const SWTTypeMetadataSectionBounds[2] = {
 #pragma mark - Swift ABI
 
 #if defined(__PTRAUTH_INTRINSICS__)
+#include <ptrauth.h>
 #define SWT_PTRAUTH_SWIFT_TYPE_DESCRIPTOR __ptrauth(ptrauth_key_process_independent_data, 1, 0xae86)
 #else
 #define SWT_PTRAUTH_SWIFT_TYPE_DESCRIPTOR

--- a/Sources/_TestingInternals/include/Discovery.h
+++ b/Sources/_TestingInternals/include/Discovery.h
@@ -31,25 +31,6 @@ SWT_ASSUME_NONNULL_BEGIN
 ///   the memory at `outValue` when done.
 typedef bool (* SWTTestContentAccessor)(void *outValue, const void *_Null_unspecified hint);
 
-/// Resign an accessor function from a test content record.
-///
-/// - Parameters:
-///   - accessor: The accessor function to resign.
-///
-/// - Returns: A resigned copy of `accessor` on platforms that use pointer
-///   authentication, and an exact copy of `accessor` elsewhere.
-///
-/// - Bug: This C function is needed because Apple's pointer authentication
-///   intrinsics are not available in Swift. ([141465242](rdar://141465242))
-SWT_SWIFT_NAME(swt_resign(_:))
-static SWTTestContentAccessor swt_resignTestContentAccessor(SWTTestContentAccessor accessor) {
-#if defined(__APPLE__) && __has_include(<ptrauth.h>)
-  accessor = ptrauth_strip(accessor, ptrauth_key_function_pointer);
-  accessor = ptrauth_sign_unauthenticated(accessor, ptrauth_key_function_pointer, 0);
-#endif
-  return accessor;
-}
-
 #if defined(__ELF__) && defined(__swift__)
 /// A function exported by the Swift runtime that enumerates all metadata
 /// sections loaded into the current process.

--- a/Sources/_TestingInternals/include/Discovery.h
+++ b/Sources/_TestingInternals/include/Discovery.h
@@ -16,22 +16,9 @@
 
 SWT_ASSUME_NONNULL_BEGIN
 
-#pragma mark - Test content records
-
-/// The type of a test content accessor.
-///
-/// - Parameters:
-///   - outValue: On successful return, initialized to the value of the
-///     represented test content record.
-///   - hint: A hint value whose type and meaning depend on the type of test
-///     record being accessed.
-///
-/// - Returns: Whether or not the test record was initialized at `outValue`. If
-///   this function returns `true`, the caller is responsible for deinitializing
-///   the memory at `outValue` when done.
-typedef bool (* SWTTestContentAccessor)(void *outValue, const void *_Null_unspecified hint);
-
 #if defined(__ELF__) && defined(__swift__)
+#pragma mark - ELF image enumeration
+
 /// A function exported by the Swift runtime that enumerates all metadata
 /// sections loaded into the current process.
 ///

--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -127,10 +127,6 @@
 #if !SWT_NO_LIBDISPATCH
 #include <dispatch/dispatch.h>
 #endif
-
-#if __has_include(<ptrauth.h>)
-#include <ptrauth.h>
-#endif
 #endif
 
 #if defined(__FreeBSD__)


### PR DESCRIPTION
Finally got around to double-checking and we don't need to do ptrauth resigning on the `accessor` function pointers in the new test content section as dyld already does it for us at load time.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
