### PR TITLE
Make all test content types directly conform to `TestContent`.

### DIFF
--- a/Documentation/ABI/TestContent.md
+++ b/Documentation/ABI/TestContent.md
@@ -63,6 +63,17 @@ struct SWTTestContentRecord {
 };
 ```
 
+Do not use the `__TestContentRecord` typealias defined in the testing library.
+This type exists to support the testing library's macros and may change in the
+future (e.g. to accomodate a generic argument or to make use of one of the
+reserved fields.)
+
+Instead, define your own copy of this type where needed&mdash;you can copy the
+definition above _verbatim_. If your test record type's `context` field (as
+described below) is a pointer type, make sure to change its type in your version
+of `TestContentRecord` accordingly so that, on systems with pointer
+authentication enabled, the pointer is correctly resigned at load time.
+
 ### Record content
 
 #### The kind field
@@ -78,6 +89,9 @@ record's kind is a 32-bit unsigned value. The following kinds are defined:
 
 <!-- When adding cases to this enumeration, be sure to also update the
 corresponding enumeration in TestContentGeneration.swift. -->
+
+If a test content record's `kind` field equals `0x00000000`, the values of all
+other fields in that record are undefined.
 
 #### The accessor field
 

--- a/Sources/Testing/Discovery+Platform.swift
+++ b/Sources/Testing/Discovery+Platform.swift
@@ -230,7 +230,7 @@ private func _findSection(named sectionName: String, in hModule: HMODULE) -> Sec
 ///
 /// - Returns: An array of structures describing the bounds of all known test
 ///   content sections in the current process.
-private func _sectionBounds(_ kind: SectionBounds.Kind) -> [SectionBounds] {
+private func _sectionBounds(_ kind: SectionBounds.Kind) -> some Sequence<SectionBounds> {
   let sectionName = switch kind {
   case .testContent:
     ".sw5test"

--- a/Sources/Testing/Discovery.swift
+++ b/Sources/Testing/Discovery.swift
@@ -48,7 +48,7 @@ protocol TestContent: ~Copyable {
   /// `ABI/TestContent.md` for a list of values and corresponding types.
   static var testContentKind: UInt32 { get }
 
-  /// A type of "hint" passed to ``discover(withHint:)`` to help the testing
+  /// A type of "hint" passed to ``allTestContentRecords()`` to help the testing
   /// library find the correct result.
   ///
   /// By default, this type equals `Never`, indicating that this type of test

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -228,7 +228,6 @@ extension ExitTest: TestContent {
     0x65786974
   }
 
-  typealias TestContentAccessorResult = Self
   typealias TestContentAccessorHint = ID
 }
 

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -10,28 +10,28 @@
 
 private import _TestingInternals
 
-/// A type that encapsulates test content records that produce instances of
-/// ``Test``.
-///
-/// This type is necessary because such test content records produce an indirect
-/// `async` accessor function rather than directly producing instances of
-/// ``Test``, but functions are non-nominal types and cannot directly conform to
-/// protocols.
-///
-/// - Note: This helper type must have the exact in-memory layout of the `async`
-///   accessor function. Do not add any additional stored properties. The layout
-///   of this type is _de facto_ [guaranteed](https://github.com/swiftlang/swift/blob/main/docs/ABI/TypeLayout.rst)
-///   by the Swift ABI.
-/* @frozen */ private struct _TestRecord: TestContent {
-  static var testContentKind: UInt32 {
-    0x74657374
+extension Test {
+  /// A type that encapsulates test content records that produce instances of
+  /// ``Test``.
+  ///
+  /// This type is necessary because such test content records produce an
+  /// indirect `async` accessor function rather than directly producing
+  /// instances of ``Test``, but functions are non-nominal types and cannot
+  /// directly conform to protocols.
+  ///
+  /// - Note: This helper type must have the exact in-memory layout of the
+  ///   `async` accessor function. Do not add any additional cases or associated
+  ///   values. The layout of this type is [guaranteed](https://github.com/swiftlang/swift/blob/main/docs/ABI/TypeLayout.rst#fragile-enum-layout)
+  ///   by the Swift ABI.
+  /* @frozen */ private enum _Record: TestContent {
+    static var testContentKind: UInt32 {
+      0x74657374
+    }
+
+    /// The actual (asynchronous) accessor function.
+    case generator(@Sendable () async -> Test)
   }
 
-  /// This instance's actual (asynchronous) accessor function.
-  var asyncAccessor: @Sendable () async -> Test
-}
-
-extension Test {
   /// All available ``Test`` instances in the process, according to the runtime.
   ///
   /// The order of values in this sequence is unspecified.
@@ -58,7 +58,12 @@ extension Test {
       // Walk all test content and gather generator functions, then call them in
       // a task group and collate their results.
       if useNewMode {
-        let generators = _TestRecord.allTestContentRecords().lazy.compactMap { $0.load()?.asyncAccessor }
+        let generators = _Record.allTestContentRecords().lazy.compactMap { record in
+          if case let .generator(generator) = record.load() {
+            return generator
+          }
+          return nil // currently unreachable, but not provably so
+        }
         await withTaskGroup(of: Self.self) { taskGroup in
           for generator in generators {
             taskGroup.addTask(operation: generator)

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -629,14 +629,15 @@ struct MiscellaneousTests {
 
   @Test func testDiscovery() async {
     // Check the type of the test record sequence (it should be lazy.)
-    let allRecords = DiscoverableTestContent.allTestContentRecords()
+    let allRecordsSeq = DiscoverableTestContent.allTestContentRecords()
 #if SWT_FIXED_143080508
-    #expect(allRecords is any LazySequenceProtocol)
-    #expect(!(allRecords is [TestContentRecord<DiscoverableTestContent>]))
+    #expect(allRecordsSeq is any LazySequenceProtocol)
+    #expect(!(allRecordsSeq is [TestContentRecord<DiscoverableTestContent>]))
 #endif
 
     // It should have exactly one matching record (because we only emitted one.)
-    #expect(Array(allRecords).count == 1)
+    let allRecords = Array(allRecordsSeq)
+    #expect(allRecords.count == 1)
 
     // Can find a single test record
     #expect(allRecords.contains { record in

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -583,7 +583,8 @@ struct MiscellaneousTests {
 #if !SWT_NO_DYNAMIC_LINKING && hasFeature(SymbolLinkageMarkers)
   struct DiscoverableTestContent: TestContent {
     typealias TestContentAccessorHint = UInt32
-    typealias TestContentAccessorResult = UInt32
+
+    var value: UInt32
 
     static var testContentKind: UInt32 {
       record.kind
@@ -593,7 +594,7 @@ struct MiscellaneousTests {
       0x01020304
     }
 
-    static var expectedResult: TestContentAccessorResult {
+    static var expectedValue: UInt32 {
       0xCAFEF00D
     }
 
@@ -618,7 +619,7 @@ struct MiscellaneousTests {
         if let hint, hint.load(as: TestContentAccessorHint.self) != expectedHint {
           return false
         }
-        _ = outValue.initializeMemory(as: TestContentAccessorResult.self, to: expectedResult)
+        _ = outValue.initializeMemory(as: Self.self, to: .init(value: expectedValue))
         return true
       },
       UInt(truncatingIfNeeded: UInt64(0x0204060801030507)),
@@ -639,21 +640,21 @@ struct MiscellaneousTests {
 
     // Can find a single test record
     #expect(allRecords.contains { record in
-      record.load() == DiscoverableTestContent.expectedResult
+      record.load()?.value == DiscoverableTestContent.expectedValue
         && record.context == DiscoverableTestContent.expectedContext
     })
 
     // Can find a test record with matching hint
     #expect(allRecords.contains { record in
       let hint = DiscoverableTestContent.expectedHint
-      return record.load(withHint: hint) == DiscoverableTestContent.expectedResult
+      return record.load(withHint: hint)?.value == DiscoverableTestContent.expectedValue
         && record.context == DiscoverableTestContent.expectedContext
     })
 
     // Doesn't find a test record with a mismatched hint
     #expect(!allRecords.contains { record in
       let hint = ~DiscoverableTestContent.expectedHint
-      return record.load(withHint: hint) == DiscoverableTestContent.expectedResult
+      return record.load(withHint: hint)?.value == DiscoverableTestContent.expectedValue
         && record.context == DiscoverableTestContent.expectedContext
     })
   }


### PR DESCRIPTION
This PR eliminates the `TestContentAccessorResult` associated type from the (currently internal, potentially eventually API) `TestContent` protocol. This associated type needed to be `~Copyable` so `ExitTest` could be used with it, but that appears to pose some _problems_ for the compiler (rdar://143049814&143080508).

Instead, we remove the associated type and just say "the test content record is the type that conforms to `TestContent`". `ExitTest` is happy with this, but `Test`'s produced type is a non-nominal function type, so we wrap that function in a small private type with identical layout and have that type conform.

The ultimate purpose of this PR is to get us a bit closer to turning `TestContent` into a public or tools-SPI protocol that other components can use for test discovery.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
