### PR TITLE
[TestingMacros] Remove reference to implicit backtracing import.

### DIFF
--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -108,8 +108,7 @@ target_sources(TestingMacros PRIVATE
   TestingMacrosMain.swift)
 
 target_compile_options(TestingMacros PRIVATE
-  "SHELL:-Xfrontend -disable-implicit-string-processing-module-import"
-  "SHELL:-Xfrontend -disable-implicit-backtracing-module-import")
+  "SHELL:-Xfrontend -disable-implicit-string-processing-module-import")
 
 target_link_libraries(TestingMacros PRIVATE
   SwiftSyntax::SwiftSyntax


### PR DESCRIPTION
The `_Backtracing` module was never implicitly imported by default, so this wasn't necessary anyway, but adding it is a blocker for SE-0419.

rdar://143310300
