### PR TITLE
Use `swift_getErrorValue()` unless Objective-C is available.

### DIFF
--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -133,7 +133,7 @@ extension Backtrace {
     ///   - errorAddress: The address of the error existential box.
     init(_ errorAddress: UnsafeMutableRawPointer) {
       _rawValue = errorAddress
-#if SWT_TARGET_OS_APPLE
+#if _runtime(_ObjC)
       let error = Unmanaged<AnyObject>.fromOpaque(errorAddress).takeUnretainedValue() as! any Error
       if type(of: error) is AnyObject.Type {
         _rawValue = Unmanaged.passUnretained(error as AnyObject).toOpaque()
@@ -336,7 +336,7 @@ extension Backtrace {
   /// - Note: The underlying Foundation function is called (if present) the
   ///   first time the value of this property is read.
   static let isFoundationCaptureEnabled = {
-#if SWT_TARGET_OS_APPLE && !SWT_NO_DYNAMIC_LINKING
+#if _runtime(_ObjC) && !SWT_NO_DYNAMIC_LINKING
     if Environment.flag(named: "SWT_FOUNDATION_ERROR_BACKTRACING_ENABLED") == true {
       let _CFErrorSetCallStackCaptureEnabled = symbol(named: "_CFErrorSetCallStackCaptureEnabled").map {
         unsafeBitCast($0, to: (@convention(c) (DarwinBoolean) -> DarwinBoolean).self)

--- a/Sources/_TestingInternals/include/WillThrow.h
+++ b/Sources/_TestingInternals/include/WillThrow.h
@@ -71,8 +71,8 @@ typedef void (* SWT_SENDABLE SWTWillThrowTypedHandler)(void *error, const void *
 /// ``SWTWillThrowTypedHandler``
 SWT_EXTERN SWTWillThrowTypedHandler SWT_SENDABLE _Nullable swt_setWillThrowTypedHandler(SWTWillThrowTypedHandler SWT_SENDABLE _Nullable handler);
 
-#if !defined(__APPLE__)
-/// The result of `swift__getErrorValue()`.
+#if defined(__swift__) && !defined(__OBJC__)
+/// The result of `swift_getErrorValue()`.
 ///
 /// For more information, see this type's declaration
 /// [in the Swift repository](https://github.com/swiftlang/swift/blob/main/include/swift/Runtime/Error.h).


### PR DESCRIPTION
Tweak the logic for when we use the runtime-internal `swift_getErrorValue()` function in our `_swift_willThrow` handler so that we use it if the runtime does not support Objective-C interop. Currently, we toggle based on whether we're on an Apple platform, but this isn't quite right.

Resolves rdar://143328537.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
