### PR TITLE
[Code style] Require explicitly specified types for public properties

### DIFF
--- a/Documentation/StyleGuide.md
+++ b/Documentation/StyleGuide.md
@@ -63,12 +63,13 @@ public var errorCount: Int {
 }
 ```
 
-Properties in Swift whose access level is `public` or greater must have an
-explicitly specified type even if they have an initialization expression and the
-compiler could infer their type. This is meant to protect against future changes
-to the code called by the initialization expression causing the inferred type of
-its property to change unknowingly, which could break clients. Properties with
-lower access levels may have an inferred type.
+Properties in Swift whose access level is `public` or greater, or which have
+`@usableFromInline`, must have an explicitly specified type even if they have an
+initialization expression and the compiler could infer their type. This is meant
+to protect against future changes to the code called by the initialization
+expression causing the inferred type of its property to change unknowingly,
+which could break clients. Properties with lower access levels may have an
+inferred type.
 
 Exported C and C++ symbols that are exported should be given the prefix `swt_`
 and should otherwise be named using the same lowerCamelCase naming rules as in

--- a/Documentation/StyleGuide.md
+++ b/Documentation/StyleGuide.md
@@ -63,13 +63,13 @@ public var errorCount: Int {
 }
 ```
 
-Properties in Swift whose access level is `public` or greater, or which have
-`@usableFromInline`, must have an explicitly specified type even if they have an
-initialization expression and the compiler could infer their type. This is meant
-to protect against future changes to the code called by the initialization
-expression causing the inferred type of its property to change unknowingly,
-which could break clients. Properties with lower access levels may have an
-inferred type.
+Properties, variables, and constants in Swift whose access level is `public` or
+greater, or which have the `@usableFromInline` attribute, must have an
+explicitly specified type even if they have an initialization expression and the
+compiler could infer their type. This is meant to protect against future changes
+to the code called by the initialization expression causing the inferred type of
+its property to change unknowingly, which could break clients. Properties with
+lower access levels may have an inferred type.
 
 Exported C and C++ symbols that are exported should be given the prefix `swt_`
 and should otherwise be named using the same lowerCamelCase naming rules as in

--- a/Documentation/StyleGuide.md
+++ b/Documentation/StyleGuide.md
@@ -63,6 +63,13 @@ public var errorCount: Int {
 }
 ```
 
+Properties in Swift whose access level is `public` or greater must have an
+explicitly specified type even if they have an initialization expression and the
+compiler could infer their type. This is meant to protect against future changes
+to the code called by the initialization expression causing the inferred type of
+its property to change unknowingly, which could break clients. Properties with
+lower access levels may have an inferred type.
+
 Exported C and C++ symbols that are exported should be given the prefix `swt_`
 and should otherwise be named using the same lowerCamelCase naming rules as in
 Swift. Use the `SWT_EXTERN` macro to ensure that symbols are consistently

--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -32,7 +32,7 @@ extension Event {
       /// On Windows, `GetFileType()` returns `FILE_TYPE_CHAR` for console file
       /// handles, and the [Console API](https://learn.microsoft.com/en-us/windows/console/)
       /// can be used to perform more complex console operations.
-      public var useANSIEscapeCodes = false
+      public var useANSIEscapeCodes: Bool = false
 
       /// The supported color bit depth when adding color to the output using
       /// [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code).
@@ -58,7 +58,7 @@ extension Event {
       /// If the SF&nbsp;Symbols app is not installed on the system where the
       /// output is being rendered, the effect of setting the value of this
       /// property to `true` is unspecified.
-      public var useSFSymbols = false
+      public var useSFSymbols: Bool = false
 #endif
 
       /// Storage for ``tagColors``.

--- a/Sources/Testing/ExitTests/ExitTestArtifacts.swift
+++ b/Sources/Testing/ExitTests/ExitTestArtifacts.swift
@@ -55,7 +55,7 @@ public struct ExitTestArtifacts: Sendable {
   ///
   /// If you did not request standard output content when running an exit test,
   /// the value of this property is the empty array.
-  public var standardOutputContent: [UInt] = []
+  public var standardOutputContent: [UInt8] = []
 
   /// All bytes written to the standard error stream of the exit test before
   /// it exited.

--- a/Sources/Testing/ExitTests/ExitTestArtifacts.swift
+++ b/Sources/Testing/ExitTests/ExitTestArtifacts.swift
@@ -55,7 +55,7 @@ public struct ExitTestArtifacts: Sendable {
   ///
   /// If you did not request standard output content when running an exit test,
   /// the value of this property is the empty array.
-  public var standardOutputContent = [UInt8]()
+  public var standardOutputContent: [UInt] = []
 
   /// All bytes written to the standard error stream of the exit test before
   /// it exited.
@@ -81,7 +81,7 @@ public struct ExitTestArtifacts: Sendable {
   ///
   /// If you did not request standard error content when running an exit test,
   /// the value of this property is the empty array.
-  public var standardErrorContent = [UInt8]()
+  public var standardErrorContent: [UInt8] = []
 
   @_spi(ForToolsIntegrationOnly)
   public init(exitCondition: ExitCondition) {

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -91,7 +91,7 @@ public struct Issue: Sendable {
 
   /// Whether or not this issue is known to occur.
   @_spi(ForToolsIntegrationOnly)
-  public var isKnown = false
+  public var isKnown: Bool = false
 
   /// Initialize an issue instance with the specified details.
   ///
@@ -254,7 +254,7 @@ extension Issue {
     public var sourceContext: SourceContext
 
     /// Whether or not this issue is known to occur.
-    public var isKnown = false
+    public var isKnown: Bool = false
 
     /// Initialize an issue instance with the specified details.
     ///

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -18,7 +18,7 @@ public struct Configuration: Sendable {
   // MARK: - Parallelization
 
   /// Whether or not to parallelize the execution of tests and test cases.
-  public var isParallelizationEnabled = true
+  public var isParallelizationEnabled: Bool = true
 
   /// How to symbolicate backtraces captured during a test run.
   ///
@@ -185,7 +185,7 @@ public struct Configuration: Sendable {
   /// By default, events of this kind are not delivered to event handlers
   /// because they occur frequently in a typical test run and can generate
   /// significant backpressure on the event handler.
-  public var deliverExpectationCheckedEvents = false
+  public var deliverExpectationCheckedEvents: Bool = false
 
   /// The event handler to which events should be passed when they occur.
   public var eventHandler: Event.Handler = { _, _ in }
@@ -237,7 +237,7 @@ public struct Configuration: Sendable {
   /// is provided. When the value of this property is less than `0`, some
   /// output is suppressed. The exact effects of this property are determined by
   /// the instance's event handler.
-  public var verbosity = 0
+  public var verbosity: Int = 0
 
   // MARK: - Test selection
 
@@ -286,7 +286,7 @@ public struct Configuration: Sendable {
     /// this maximum count. After this maximum is reached, all subsequent
     /// elements are omitted and a single placeholder child is added indicating
     /// the number of elements which have been truncated.
-    public var maximumCollectionCount = 10
+    public var maximumCollectionCount: Int = 10
 
     /// The maximum depth of children that can be included in the reflection of
     /// a checked expectation value.
@@ -303,7 +303,7 @@ public struct Configuration: Sendable {
     ///   Since optionals are common, the default value of this property is
     ///   somewhat larger than it otherwise would be in an attempt to make the
     ///   defaults useful for real-world tests.
-    public var maximumChildDepth = 10
+    public var maximumChildDepth: Int = 10
   }
 }
 

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -199,7 +199,7 @@ public struct Test: Sendable {
   /// being added to the plan. For such suites, the value of this property is
   /// `true`.
   @_spi(ForToolsIntegrationOnly)
-  public var isSynthesized = false
+  public var isSynthesized: Bool = false
 
   /// Initialize an instance of this type representing a test suite type.
   init(


### PR DESCRIPTION
This amends the code style guidelines for the project to require an explicit type for all properties whose access level is `public` or greater, and adjusts the code accordingly.

### Motivation:

See the explanation in the code style document for rationale. This topic recently [came up](https://github.com/swiftlang/swift-testing/pull/915#discussion_r1919360835) in a PR discussion.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
