### PR TITLE
Declare Swift 6.1 availability for TestScoping-related APIs

### DIFF
--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/SuiteTrait-scopeProvider-default-implementation-Self.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/SuiteTrait-scopeProvider-default-implementation-Self.md
@@ -1,0 +1,15 @@
+# ``Trait/scopeProvider(for:testCase:)-1z8kh``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScopeProvider.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScopeProvider.md
@@ -1,0 +1,15 @@
+# ``Trait/TestScopeProvider``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScoping-provideScope.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScoping-provideScope.md
@@ -1,0 +1,15 @@
+# ``TestScoping/provideScope(for:testCase:performing:)``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScoping.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScoping.md
@@ -1,0 +1,15 @@
+# ``TestScoping``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-default-implementation-Never.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-default-implementation-Never.md
@@ -1,0 +1,15 @@
+# ``Trait/scopeProvider(for:testCase:)-9fxg4``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-default-implementation-Self.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-default-implementation-Self.md
@@ -1,0 +1,15 @@
+# ``Trait/scopeProvider(for:testCase:)-inmj``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-protocol-requirement.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-protocol-requirement.md
@@ -1,0 +1,15 @@
+# ``Trait/scopeProvider(for:testCase:)``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -48,6 +48,10 @@ public protocol Trait: Sendable {
   /// ``scopeProvider(for:testCase:)-cjmg`` method for any trait with this
   /// default type must return `nil`, meaning that trait will not provide a
   /// custom scope for the tests it's applied to.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.1)
+  /// }
   associatedtype TestScopeProvider: TestScoping = Never
 
   /// Get this trait's scope provider for the specified test and/or test case,
@@ -93,6 +97,10 @@ public protocol Trait: Sendable {
   /// associated ``Trait/TestScopeProvider`` type is the default `Never`, then
   /// this method returns `nil` by default. This means that instances of this
   /// trait will not provide a custom scope for tests to which they're applied.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.1)
+  /// }
   func scopeProvider(for test: Test, testCase: Test.Case?) -> TestScopeProvider?
 }
 
@@ -107,6 +115,10 @@ public protocol Trait: Sendable {
 /// logic for tests which have similar needs allows each test function to be
 /// more succinct with less repetitive boilerplate so it can focus on what makes
 /// it unique.
+///
+/// @Metadata {
+///   @Available(Swift, introduced: 6.1)
+/// }
 public protocol TestScoping: Sendable {
   /// Provide custom execution scope for a function call which is related to the
   /// specified test and/or test case.
@@ -140,6 +152,10 @@ public protocol TestScoping: Sendable {
   /// an error if it is unable to provide a custom scope.
   ///
   /// Issues recorded by this method are associated with `test`.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.1)
+  /// }
   func provideScope(for test: Test, testCase: Test.Case?, performing function: @Sendable () async throws -> Void) async throws
 }
 
@@ -156,6 +172,10 @@ extension Trait where Self: TestScoping {
   /// This default implementation is used when this trait type conforms to
   /// ``TestScoping`` and its return value is discussed in
   /// ``Trait/scopeProvider(for:testCase:)-cjmg``.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.1)
+  /// }
   public func scopeProvider(for test: Test, testCase: Test.Case?) -> Self? {
     testCase == nil ? nil : self
   }
@@ -174,6 +194,10 @@ extension SuiteTrait where Self: TestScoping {
   /// This default implementation is used when this trait type conforms to
   /// ``TestScoping`` and its return value is discussed in
   /// ``Trait/scopeProvider(for:testCase:)-cjmg``.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.1)
+  /// }
   public func scopeProvider(for test: Test, testCase: Test.Case?) -> Self? {
     if test.isSuite {
       isRecursive ? nil : self
@@ -229,6 +253,10 @@ extension Trait where TestScopeProvider == Never {
   /// This default implementation is used when this trait type's associated
   /// ``Trait/TestScopeProvider`` type is the default value of `Never`, and its
   /// return value is discussed in ``Trait/scopeProvider(for:testCase:)-cjmg``.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.1)
+  /// }
   public func scopeProvider(for test: Test, testCase: Test.Case?) -> Never? {
     nil
   }

--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -48,10 +48,6 @@ public protocol Trait: Sendable {
   /// ``scopeProvider(for:testCase:)-cjmg`` method for any trait with this
   /// default type must return `nil`, meaning that trait will not provide a
   /// custom scope for the tests it's applied to.
-  ///
-  /// @Metadata {
-  ///   @Available(Swift, introduced: 6.1)
-  /// }
   associatedtype TestScopeProvider: TestScoping = Never
 
   /// Get this trait's scope provider for the specified test and/or test case,
@@ -97,10 +93,6 @@ public protocol Trait: Sendable {
   /// associated ``Trait/TestScopeProvider`` type is the default `Never`, then
   /// this method returns `nil` by default. This means that instances of this
   /// trait will not provide a custom scope for tests to which they're applied.
-  ///
-  /// @Metadata {
-  ///   @Available(Swift, introduced: 6.1)
-  /// }
   func scopeProvider(for test: Test, testCase: Test.Case?) -> TestScopeProvider?
 }
 
@@ -115,10 +107,6 @@ public protocol Trait: Sendable {
 /// logic for tests which have similar needs allows each test function to be
 /// more succinct with less repetitive boilerplate so it can focus on what makes
 /// it unique.
-///
-/// @Metadata {
-///   @Available(Swift, introduced: 6.1)
-/// }
 public protocol TestScoping: Sendable {
   /// Provide custom execution scope for a function call which is related to the
   /// specified test and/or test case.
@@ -152,10 +140,6 @@ public protocol TestScoping: Sendable {
   /// an error if it is unable to provide a custom scope.
   ///
   /// Issues recorded by this method are associated with `test`.
-  ///
-  /// @Metadata {
-  ///   @Available(Swift, introduced: 6.1)
-  /// }
   func provideScope(for test: Test, testCase: Test.Case?, performing function: @Sendable () async throws -> Void) async throws
 }
 
@@ -172,10 +156,6 @@ extension Trait where Self: TestScoping {
   /// This default implementation is used when this trait type conforms to
   /// ``TestScoping`` and its return value is discussed in
   /// ``Trait/scopeProvider(for:testCase:)-cjmg``.
-  ///
-  /// @Metadata {
-  ///   @Available(Swift, introduced: 6.1)
-  /// }
   public func scopeProvider(for test: Test, testCase: Test.Case?) -> Self? {
     testCase == nil ? nil : self
   }
@@ -194,10 +174,6 @@ extension SuiteTrait where Self: TestScoping {
   /// This default implementation is used when this trait type conforms to
   /// ``TestScoping`` and its return value is discussed in
   /// ``Trait/scopeProvider(for:testCase:)-cjmg``.
-  ///
-  /// @Metadata {
-  ///   @Available(Swift, introduced: 6.1)
-  /// }
   public func scopeProvider(for test: Test, testCase: Test.Case?) -> Self? {
     if test.isSuite {
       isRecursive ? nil : self
@@ -253,10 +229,6 @@ extension Trait where TestScopeProvider == Never {
   /// This default implementation is used when this trait type's associated
   /// ``Trait/TestScopeProvider`` type is the default value of `Never`, and its
   /// return value is discussed in ``Trait/scopeProvider(for:testCase:)-cjmg``.
-  ///
-  /// @Metadata {
-  ///   @Available(Swift, introduced: 6.1)
-  /// }
   public func scopeProvider(for test: Test, testCase: Test.Case?) -> Never? {
     nil
   }


### PR DESCRIPTION
The `TestScoping` protocol and its related APIs have been introduced in Swift 6.1, so this annotates their availability accordingly.

Once this PR lands, I will cherry-pick it to the `release/6.1` branch as well.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
