### PR TITLE
[6.1] Declare Swift 6.1 availability for TestScoping-related APIs

### DIFF
--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/SuiteTrait-scopeProvider-default-implementation-Self.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/SuiteTrait-scopeProvider-default-implementation-Self.md
@@ -1,0 +1,15 @@
+# ``Trait/scopeProvider(for:testCase:)-1z8kh``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScopeProvider.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScopeProvider.md
@@ -1,0 +1,15 @@
+# ``Trait/TestScopeProvider``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScoping-provideScope.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScoping-provideScope.md
@@ -1,0 +1,15 @@
+# ``TestScoping/provideScope(for:testCase:performing:)``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScoping.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/TestScoping.md
@@ -1,0 +1,15 @@
+# ``TestScoping``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-default-implementation-Never.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-default-implementation-Never.md
@@ -1,0 +1,15 @@
+# ``Trait/scopeProvider(for:testCase:)-9fxg4``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-default-implementation-Self.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-default-implementation-Self.md
@@ -1,0 +1,15 @@
+# ``Trait/scopeProvider(for:testCase:)-inmj``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}

--- a/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-protocol-requirement.md
+++ b/Sources/Testing/Testing.docc/AvailabilityStubs/Traits/Trait-scopeProvider-protocol-requirement.md
@@ -1,0 +1,15 @@
+# ``Trait/scopeProvider(for:testCase:)``
+
+<!--
+This source file is part of the Swift.org open source project
+
+Copyright (c) 2025 Apple Inc. and the Swift project authors
+Licensed under Apache License v2.0 with Runtime Library Exception
+
+See https://swift.org/LICENSE.txt for license information
+See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+-->
+
+@Metadata {
+  @Available(Swift, introduced: 6.1)
+}


### PR DESCRIPTION
  - **Explanation**: Declare Swift 6.1 availability for TestScoping-related APIs
  - **Scope**: Documentation
  - **Issues**: n/a
  - **Original PRs**: https://github.com/swiftlang/swift-testing/pull/927
  - **Risk**: Low
  - **Testing**: n/a, documentation only
  - **Reviewers**: @grynspan 
