### PR TITLE
Ensure the `ObjectiveC` module is visible to Discovery.swift

### DIFF
--- a/Sources/Testing/Discovery+Platform.swift
+++ b/Sources/Testing/Discovery+Platform.swift
@@ -9,6 +9,9 @@
 //
 
 internal import _TestingInternals
+#if _runtime(_ObjC)
+private import ObjectiveC
+#endif
 
 /// A structure describing the bounds of a Swift metadata section.
 struct SectionBounds: Sendable {


### PR DESCRIPTION
With recent work to rewrite our C++ code in Swift, we've wound up not including any Objective-C headers in `_TestingInternals`, but they are included transitively on some Apple platforms including macOS. Ensure the `ObjectiveC` module is included in Discovery.swift when available so that platforms that don't transitively include the libobjc headers can see (in particular) the `objc_addLoadImageFunc()` function.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
