### PR TITLE
Implement `CommandLine.executablePath` on all Apple platforms.

### DIFF
--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -14,7 +14,7 @@ extension CommandLine {
   /// The path to the current process' executable.
   static var executablePath: String {
     get throws {
-#if os(macOS)
+#if SWT_TARGET_OS_APPLE
       var result: String?
 #if DEBUG
       var bufferCount = UInt32(1) // force looping


### PR DESCRIPTION
This change just makes sure `CommandLine.executablePath` is implemented consistently across Apple platforms and doesn't hit the unimplemented/warning path on e.g. iOS. (We're not using this property there, but the source file it lives in gets compiled regardless.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
