### PR TITLE
Update `Comment` to use `CustomTestStringConvertible` during string interpolation.

### DIFF
--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -77,15 +77,50 @@ public struct Comment: RawRepresentable, Sendable {
   }
 }
 
-// MARK: - ExpressibleByStringLiteral, ExpressibleByStringInterpolation, CustomStringConvertible
+// MARK: - ExpressibleByStringLiteral, CustomStringConvertible
 
-extension Comment: ExpressibleByStringLiteral, ExpressibleByStringInterpolation, CustomStringConvertible {
+extension Comment: ExpressibleByStringLiteral, CustomStringConvertible {
   public init(stringLiteral: String) {
     self.init(rawValue: stringLiteral, kind: .stringLiteral)
   }
 
   public var description: String {
     rawValue
+  }
+}
+
+// MARK: - ExpressibleByStringInterpolation
+
+extension Comment: ExpressibleByStringInterpolation {
+  public init(stringInterpolation: StringInterpolation) {
+    self.init(rawValue: stringInterpolation.rawValue)
+  }
+
+  /// The string interpolation handler type for ``Comment``.
+  @_documentation(visibility: private)
+  public struct StringInterpolation: StringInterpolationProtocol, Sendable {
+    /// Storage for the string constructed by this instance.
+    ///
+    /// `DefaultStringInterpolation` in the Swift standard library also simply
+    /// accumulates its result in a string.
+    @usableFromInline var rawValue: String = ""
+
+    @inlinable public init(literalCapacity: Int, interpolationCount: Int) {}
+
+    @inlinable public mutating func appendLiteral(_ literal: String) {
+      rawValue += literal
+    }
+
+    @inlinable public mutating func appendInterpolation(_ value: some Any) {
+      rawValue += String(describingForTest: value)
+    }
+
+    @inlinable public mutating func appendInterpolation(_ value: (some Any)?) {
+      // This overload is provided so that the compiler does not emit warnings
+      // about optional values in string interpolations (which we are fine with
+      // when constructing Comment instances.)
+      rawValue += String(describingForTest: value)
+    }
   }
 }
 

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -105,7 +105,7 @@ extension Comment: ExpressibleByStringInterpolation {
     /// accumulates its result in a string.
     @usableFromInline var rawValue: String = ""
 
-    @inlinable public init(literalCapacity: Int, interpolationCount: Int) {}
+    public init(literalCapacity: Int, interpolationCount: Int) {}
 
     @inlinable public mutating func appendLiteral(_ literal: String) {
       rawValue += literal

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -111,15 +111,19 @@ extension Comment: ExpressibleByStringInterpolation {
       rawValue += literal
     }
 
-    @inlinable public mutating func appendInterpolation(_ value: some Any) {
+    @inlinable public mutating func appendInterpolation(_ value: (some Any)?) {
       rawValue += String(describingForTest: value)
     }
 
-    @inlinable public mutating func appendInterpolation(_ value: (some Any)?) {
-      // This overload is provided so that the compiler does not emit warnings
-      // about optional values in string interpolations (which we are fine with
-      // when constructing Comment instances.)
-      rawValue += String(describingForTest: value)
+    @inlinable public mutating func appendInterpolation(_ value: (some StringProtocol)?) {
+      // Special-case strings to not include the quotation marks added by
+      // CustomTestStringConvertible (which in the context of interpolation
+      // probably violate the Principle of Least Surprise).
+      if let value {
+        rawValue += value
+      } else {
+        rawValue += String(describingForTest: value)
+      }
     }
   }
 }

--- a/Tests/TestingTests/Traits/CommentTests.swift
+++ b/Tests/TestingTests/Traits/CommentTests.swift
@@ -57,6 +57,15 @@ struct CommentTests {
   func explicitlyNilComment() {
     #expect(true as Bool, nil as Comment?)
   }
+
+  @Test("String interpolation")
+  func stringInterpolation() {
+    let value1: Int? = 123
+    let value2: Int? = nil
+    let value3: Any.Type = Int.self
+    let comment: Comment = "abc\(value1)def\(value2)ghi\(value3)"
+    #expect(comment.rawValue == "abc123defnilghiInt")
+  }
 }
 
 // MARK: - Fixtures

--- a/Tests/TestingTests/Traits/CommentTests.swift
+++ b/Tests/TestingTests/Traits/CommentTests.swift
@@ -60,11 +60,27 @@ struct CommentTests {
 
   @Test("String interpolation")
   func stringInterpolation() {
-    let value1: Int? = 123
+    let value1: Int = 123
     let value2: Int? = nil
     let value3: Any.Type = Int.self
     let comment: Comment = "abc\(value1)def\(value2)ghi\(value3)"
     #expect(comment.rawValue == "abc123defnilghiInt")
+  }
+
+  @Test("String interpolation with a custom type")
+  func stringInterpolationWithCustomType() {
+    struct S: CustomStringConvertible, CustomTestStringConvertible {
+      var description: String {
+        "wrong!"
+      }
+
+      var testDescription: String {
+        "right!"
+      }
+    }
+
+    let comment: Comment = "abc\(S())def\(S() as S?)ghi\(S.self)jkl\("string")"
+    #expect(comment.rawValue == "abcright!defright!ghiSjklstring")
   }
 }
 


### PR DESCRIPTION
This PR ensures that `Comment`, when constructed from a string literal with interpolations, stringifies interpolated values using `String.init(descriptionForTest:)` rather than the default behaviour (i.e. `String.init(description:)`.)

For example:

```swift
enum E: CustomTestStringConvertible {
  case a
  case b
  case c

  var testDescription: String {
    switch self {
    case .a:
      "Once I was the King of Spain"
    case .b:
      "Now I eat humble pie"
    case .c:
      "Now I vacuum the turf at SkyDome™"
    }
  }
}

 #expect(1 == 2, "\(E.a) / \(E.b) / \(E.a) / \(E.c)")
```

Before:

> 🛑 Expectation failed: 1 == 2 - .a / .b / .a / .c

After:

> 🛑 Expectation failed: 1 == 2 - Once I was the King of Spain / Now I eat
> humble pie / Once I was the King of Spain / Now I vacuum the turf at SkyDome™

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
