### PR TITLE
Add a `type` argument to the ABI accessor function signature.

### DIFF
--- a/Sources/Testing/Discovery.swift
+++ b/Sources/Testing/Discovery.swift
@@ -10,6 +10,26 @@
 
 private import _TestingInternals
 
+/// The type of the accessor function used to access a test content record.
+///
+/// - Parameters:
+///   - outValue: A pointer to uninitialized memory large enough to contain the
+///     corresponding test content record's value.
+///   - type: A pointer to the expected type of `outValue`. Use `load(as:)` to
+///     get the Swift type, not `unsafeBitCast(_:to:)`.
+///   - hint: An optional pointer to a hint value.
+///
+/// - Returns: Whether or not `outValue` was initialized. The caller is
+///   responsible for deinitializing `outValue` if it was initialized.
+///
+/// - Warning: This type is used to implement the `@Test` macro. Do not use it
+///   directly.
+public typealias __TestContentRecordAccessor = @convention(c) (
+  _ outValue: UnsafeMutableRawPointer,
+  _ type: UnsafeRawPointer,
+  _ hint: UnsafeRawPointer?
+) -> CBool
+
 /// The content of a test content record.
 ///
 /// - Parameters:
@@ -24,10 +44,26 @@ private import _TestingInternals
 public typealias __TestContentRecord = (
   kind: UInt32,
   reserved1: UInt32,
-  accessor: (@convention(c) (_ outValue: UnsafeMutableRawPointer, _ hint: UnsafeRawPointer?) -> CBool)?,
+  accessor: __TestContentRecordAccessor?,
   context: UInt,
   reserved2: UInt
 )
+
+/// Check that two Swift types are equivalent.
+///
+/// - Parameters:
+///   - lhsAddress: A pointer to (not a bitcast) a Swift type.
+///   - rhs: Another Swift type.
+///
+/// - Returns: Whether or not the type at `lhsAddress` and `rhs` are equivalent.
+///
+/// - Warning: This function is used to implement the `@Test` macro. Do not use
+///   it directly.
+public func __type(at lhsAddress: UnsafeRawPointer, is rhs: (some ~Copyable).Type) -> Bool {
+  let lhs = TypeInfo(describing: lhsAddress.load(as: (any ~Copyable.Type).self))
+  let rhs = TypeInfo(describing: rhs)
+  return lhs == rhs
+}
 
 // MARK: -
 
@@ -54,6 +90,20 @@ protocol TestContent: ~Copyable {
   /// By default, this type equals `Never`, indicating that this type of test
   /// content does not support hinting during discovery.
   associatedtype TestContentAccessorHint: Sendable = Never
+
+  /// The type to pass (by address) as the accessor function's `type` argument.
+  ///
+  /// The default value of this property is `Self.self`. A conforming type can
+  /// override the default implementation to substitute another type (e.g. if
+  /// the conforming type is not public but records are created during macro
+  /// expansion and can only reference public types.)
+  static var testContentAccessorTypeArgument: any ~Copyable.Type { get }
+}
+
+extension TestContent where Self: ~Copyable {
+  static var testContentAccessorTypeArgument: any ~Copyable.Type {
+    self
+  }
 }
 
 // MARK: - Individual test content records
@@ -108,18 +158,20 @@ struct TestContentRecord<T>: Sendable where T: TestContent & ~Copyable {
       return nil
     }
 
-    return withUnsafeTemporaryAllocation(of: T.self, capacity: 1) { buffer in
-      let initialized = if let hint {
-        withUnsafePointer(to: hint) { hint in
-          accessor(buffer.baseAddress!, hint)
+    return withUnsafePointer(to: T.testContentAccessorTypeArgument) { type in
+      withUnsafeTemporaryAllocation(of: T.self, capacity: 1) { buffer in
+        let initialized = if let hint {
+          withUnsafePointer(to: hint) { hint in
+            accessor(buffer.baseAddress!, type, hint)
+          }
+        } else {
+          accessor(buffer.baseAddress!, type, nil)
         }
-      } else {
-        accessor(buffer.baseAddress!, nil)
+        guard initialized else {
+          return nil
+        }
+        return buffer.baseAddress!.move()
       }
-      guard initialized else {
-        return nil
-      }
-      return buffer.baseAddress!.move()
     }
   }
 }

--- a/Sources/Testing/Discovery.swift
+++ b/Sources/Testing/Discovery.swift
@@ -49,22 +49,6 @@ public typealias __TestContentRecord = (
   reserved2: UInt
 )
 
-/// Check that two Swift types are equivalent.
-///
-/// - Parameters:
-///   - lhsAddress: A pointer to (not a bitcast) a Swift type.
-///   - rhs: Another Swift type.
-///
-/// - Returns: Whether or not the type at `lhsAddress` and `rhs` are equivalent.
-///
-/// - Warning: This function is used to implement the `@Test` macro. Do not use
-///   it directly.
-public func __type(at lhsAddress: UnsafeRawPointer, is rhs: (some ~Copyable).Type) -> Bool {
-  let lhs = TypeInfo(describing: lhsAddress.load(as: (any ~Copyable.Type).self))
-  let rhs = TypeInfo(describing: rhs)
-  return lhs == rhs
-}
-
 // MARK: -
 
 /// A protocol describing a type that can be stored as test content at compile

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -28,8 +28,15 @@ extension Test {
       0x74657374
     }
 
+    static var testContentAccessorTypeArgument: any ~Copyable.Type {
+      Generator.self
+    }
+
+    /// The type of the actual (asynchronous) generator function.
+    typealias Generator = @Sendable () async -> Test
+
     /// The actual (asynchronous) accessor function.
-    case generator(@Sendable () async -> Test)
+    case generator(Generator)
   }
 
   /// All available ``Test`` instances in the process, according to the runtime.

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -616,7 +616,7 @@ struct MiscellaneousTests {
       0xABCD1234,
       0,
       { outValue, type, hint in
-        guard __type(at: type, is: DiscoverableTestContent.self) else {
+        guard type.load(as: Any.Type.self) == DiscoverableTestContent.self else {
           return false
         }
         if let hint, hint.load(as: TestContentAccessorHint.self) != expectedHint {

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -615,7 +615,10 @@ struct MiscellaneousTests {
     private static let record: __TestContentRecord = (
       0xABCD1234,
       0,
-      { outValue, hint in
+      { outValue, type, hint in
+        guard __type(at: type, is: DiscoverableTestContent.self) else {
+          return false
+        }
         if let hint, hint.load(as: TestContentAccessorHint.self) != expectedHint {
           return false
         }


### PR DESCRIPTION
We access the test content record section directly instead of using some (non-existent) type-safe Swift API. On some platforms (Darwin in particular), it is possible for two copies of the testing library to be loaded at runtime, and for them to have incompatible definitions of types like `Test`. That means one library's `@Test` macro could produce a test content record that is then read by the other library's discovery logic, resulting in a stack smash or worse.

We can resolve this issue by adding a `type` argument to the accessor function we define for test content records; the body of the accessor can then compare the value of this argument against the expected Swift type of its result and, if they don't match, bail early.

The new argument is defined as a pointer _to_ a Swift type rather than as a Swift type directly because `@convention(c)` functions cannot directly reference Swift types. The value of the new argument can be safely ignored if the type of the test content record's value is and always has been `@frozen`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
