### PR TITLE
Simplify statically-linked section discovery.

### DIFF
--- a/Sources/Testing/Discovery+Platform.swift
+++ b/Sources/Testing/Discovery+Platform.swift
@@ -23,7 +23,7 @@ struct SectionBounds: Sendable {
 
   /// An enumeration describing the different sections discoverable by the
   /// testing library.
-  enum Kind: Equatable, Hashable, CaseIterable {
+  enum Kind: Int, Equatable, Hashable, CaseIterable {
     /// The test content metadata section.
     case testContent
 
@@ -285,13 +285,9 @@ private func _sectionBounds(_ kind: SectionBounds.Kind) -> [SectionBounds] {
 /// - Returns: A structure describing the bounds of the type metadata section
 ///   contained in the same image as the testing library itself.
 private func _sectionBounds(_ kind: SectionBounds.Kind) -> CollectionOfOne<SectionBounds> {
-  let (sectionBegin, sectionEnd) = switch kind {
-  case .testContent:
-    SWTTestContentSectionBounds
-  case .typeMetadata:
-    SWTTypeMetadataSectionBounds
-  }
-  let buffer = UnsafeRawBufferPointer(start: sectionBegin, count: max(0, sectionEnd - sectionBegin))
+  var (baseAddress, count): (UnsafeRawPointer?, Int) = (nil, 0)
+  swt_getStaticallyLinkedSectionBounds(kind.rawValue, &baseAddress, &count)
+  let buffer = UnsafeRawBufferPointer(start: baseAddress, count: count)
   let sb = SectionBounds(imageAddress: nil, buffer: buffer)
   return CollectionOfOne(sb)
 }

--- a/Sources/_TestingInternals/Discovery.cpp
+++ b/Sources/_TestingInternals/Discovery.cpp
@@ -10,6 +10,7 @@
 
 #include "Discovery.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <type_traits>
@@ -35,13 +36,16 @@ static const char typeMetadataSectionBegin = 0;
 static const char& typeMetadataSectionEnd = typeMetadataSectionBegin;
 #endif
 
-const void *_Nonnull const SWTTestContentSectionBounds[2] = {
-  &testContentSectionBegin, &testContentSectionEnd
+static constexpr const char *const staticallyLinkedSectionBounds[][2] = {
+  { &testContentSectionBegin, &testContentSectionEnd },
+  { &typeMetadataSectionBegin, &typeMetadataSectionEnd },
 };
 
-const void *_Nonnull const SWTTypeMetadataSectionBounds[2] = {
-  &typeMetadataSectionBegin, &typeMetadataSectionEnd
-};
+void swt_getStaticallyLinkedSectionBounds(size_t kind, const void **outSectionBegin, size_t *outByteCount) {
+  auto [sectionBegin, sectionEnd] = staticallyLinkedSectionBounds[kind];
+  *outSectionBegin = sectionBegin;
+  *outByteCount = std::distance(sectionBegin, sectionEnd);
+}
 #endif
 
 #pragma mark - Swift ABI

--- a/Sources/_TestingInternals/include/Discovery.h
+++ b/Sources/_TestingInternals/include/Discovery.h
@@ -32,23 +32,18 @@ SWT_IMPORT_FROM_STDLIB void swift_enumerateAllMetadataSections(
 
 #pragma mark - Statically-linked section bounds
 
-/// The bounds of the test content section statically linked into the image
-/// containing Swift Testing.
+/// Get the bounds of a statically linked section in this image.
+///
+/// - Parameters:
+///   - kind: The value of `SectionBounds.Kind.rawValue` for the given section.
+///   - outSectionBegin: On return, a pointer to the first byte of the section.
+///   - outByteCount: On return, the number of bytes in the section.
 ///
 /// - Note: This symbol is _declared_, but not _defined_, on platforms with
 ///   dynamic linking because the `SWT_NO_DYNAMIC_LINKING` C++ macro (not the
 ///   Swift compiler conditional of the same name) is not consistently declared
 ///   when Swift files import the `_TestingInternals` C++ module.
-SWT_EXTERN const void *_Nonnull const SWTTestContentSectionBounds[2];
-
-/// The bounds of the type metadata section statically linked into the image
-/// containing Swift Testing.
-///
-/// - Note: This symbol is _declared_, but not _defined_, on platforms with
-///   dynamic linking because the `SWT_NO_DYNAMIC_LINKING` C++ macro (not the
-///   Swift compiler conditional of the same name) is not consistently declared
-///   when Swift files import the `_TestingInternals` C++ module.
-SWT_EXTERN const void *_Nonnull const SWTTypeMetadataSectionBounds[2];
+SWT_EXTERN void swt_getStaticallyLinkedSectionBounds(size_t kind, const void *_Nullable *_Nonnull outSectionBegin, size_t *outByteCount);
 
 #pragma mark - Legacy test discovery
 


### PR DESCRIPTION
This PR simplifies the code used to discover metadata sections when the testing library is statically linked into a test target.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
