### PR TITLE
[DON'T MERGE] Temporarily set CMake policy CMP0157 to OLD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 cmake_minimum_required(VERSION 3.19.6...3.29)
 
 if(POLICY CMP0157)
-  cmake_policy(SET CMP0157 NEW)
+  cmake_policy(SET CMP0157 OLD)
 endif()
 
 project(SwiftTesting


### PR DESCRIPTION
We need the old setting as long as we use Swift's legacy driver on Windows. This is a workaround for cross-compiling the Swift Runtime to Android in https://github.com/swiftlang/swift/pull/79185. It's not supposed to land.