### PR TITLE
Suppress warning about `#require(nonOptional)` in some cases.

### DIFF
--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -352,6 +352,22 @@ struct ConditionMacroTests {
     #expect(diagnostic.message.contains("is redundant"))
   }
 
+#if !SWT_FIXED_137943258
+  @Test(
+    "#require(optional value mistyped as non-optional) diagnostic is suppressed",
+    .bug("https://github.com/swiftlang/swift/issues/79202"),
+    arguments: [
+      "#requireNonOptional(expression as? T)",
+      "#requireNonOptional(expression as Optional<T>)",
+      "#requireNonOptional(expression ?? nil)",
+    ]
+  )
+  func requireNonOptionalDiagnosticSuppressed(input: String) throws {
+    let (_, diagnostics) = try parse(input)
+    #expect(diagnostics.isEmpty)
+  }
+#endif
+
   @Test("#require(throws: Never.self) produces a diagnostic",
     arguments: [
       "#requireThrows(throws: Swift.Never.self)",


### PR DESCRIPTION
When using `try #require()` to unwrap an optional value, we emit a compile-time warning if the value is not actually optional. However, there is a bug in the type checker (https://github.com/swiftlang/swift/issues/79202) that triggers a false positive when downcasting an object (of `class` type), e.g.:

```swift
class Animal {}
class Duck: Animal {}
let beast: Animal = Duck()
let definitelyADuck = try #require(beast as? Duck)
// ⚠️ '#require(_:_:)' is redundant because 'beast as? Duck' never equals 'nil'
```

This change suppresses the warning we emit if the expression contains certain syntax tokens (namely `?`, `nil`, or `Optional`) on the assumption that their presence means the test author is expecting an optional value and we've hit a false positive.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
