### PR TITLE
[6.1] Suppress warning about `#require(nonOptional)` in some cases.

### DIFF
--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -352,6 +352,22 @@ struct ConditionMacroTests {
     #expect(diagnostic.message.contains("is redundant"))
   }
 
+#if !SWT_FIXED_137943258
+  @Test(
+    "#require(optional value mistyped as non-optional) diagnostic is suppressed",
+    .bug("https://github.com/swiftlang/swift/issues/79202"),
+    arguments: [
+      "#requireNonOptional(expression as? T)",
+      "#requireNonOptional(expression as Optional<T>)",
+      "#requireNonOptional(expression ?? nil)",
+    ]
+  )
+  func requireNonOptionalDiagnosticSuppressed(input: String) throws {
+    let (_, diagnostics) = try parse(input)
+    #expect(diagnostics.isEmpty)
+  }
+#endif
+
   @Test("#require(throws: Never.self) produces a diagnostic",
     arguments: [
       "#requireThrows(throws: Swift.Never.self)",


### PR DESCRIPTION
  - **Explanation**: Suppress some warnings that occur due to https://github.com/swiftlang/swift/issues/79202 when the compiler selects the wrong overload of `try #require()` for expansion.
  - **Scope**: Tests using `try #require()` with reference types.
  - **Issues**: works around https://github.com/swiftlang/swift/issues/79202
  - **Original PRs**: https://github.com/swiftlang/swift-testing/pull/947
  - **Risk**: Low, just suppresses some warnings we generate (lack of these warnings is not harmful)
  - **Testing**: Added a unit test
  - **Reviewers**: @briancroom