### PR TITLE
Enable Library Evolution in package builds for public library targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -128,6 +128,9 @@ let package = Package(
       path: "Sources/Overlays/_Testing_Foundation",
       exclude: ["CMakeLists.txt"],
       swiftSettings: .packageSettings + [
+        // The Foundation module only has Library Evolution enabled on Apple
+        // platforms, and since this target's module publicly imports Foundation,
+        // it can only enable Library Evolution itself on those platforms.
         .enableLibraryEvolution(applePlatformsOnly: true),
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
       ],
       exclude: ["CMakeLists.txt", "Testing.swiftcrossimport"],
       cxxSettings: .packageSettings,
-      swiftSettings: .packageSettings,
+      swiftSettings: .publicLibraryTargetSettings,
       linkerSettings: [
         .linkedLibrary("execinfo", .when(platforms: [.custom("freebsd"), .openbsd]))
       ]
@@ -114,7 +114,7 @@ let package = Package(
         "Testing",
       ],
       path: "Sources/Overlays/_Testing_CoreGraphics",
-      swiftSettings: .packageSettings
+      swiftSettings: .publicLibraryTargetSettings
     ),
     .target(
       name: "_Testing_Foundation",
@@ -123,7 +123,7 @@ let package = Package(
       ],
       path: "Sources/Overlays/_Testing_Foundation",
       exclude: ["CMakeLists.txt"],
-      swiftSettings: .packageSettings
+      swiftSettings: .publicLibraryTargetSettings
     ),
   ],
 
@@ -163,6 +163,16 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .define("SWT_NO_SNAPSHOT_TYPES", .when(platforms: [.linux, .custom("freebsd"), .openbsd, .windows, .wasi])),
       .define("SWT_NO_DYNAMIC_LINKING", .when(platforms: [.wasi])),
       .define("SWT_NO_PIPES", .when(platforms: [.wasi])),
+    ]
+  }
+
+  /// Settings intended to be applied to every public Swift library target in
+  /// this package.
+  static var publicLibraryTargetSettings: Self {
+    packageSettings + [
+      // Enable Library Evolution to match the way this library is built for
+      // distribution.
+      .unsafeFlags(["-enable-library-evolution"]),
     ]
   }
 

--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,9 @@ let package = Package(
       ],
       exclude: ["CMakeLists.txt", "Testing.swiftcrossimport"],
       cxxSettings: .packageSettings,
-      swiftSettings: .publicLibraryTargetSettings,
+      swiftSettings: .packageSettings + [
+        .enableLibraryEvolution(),
+      ],
       linkerSettings: [
         .linkedLibrary("execinfo", .when(platforms: [.custom("freebsd"), .openbsd]))
       ]
@@ -114,7 +116,9 @@ let package = Package(
         "Testing",
       ],
       path: "Sources/Overlays/_Testing_CoreGraphics",
-      swiftSettings: .publicLibraryTargetSettings
+      swiftSettings: .packageSettings + [
+        .enableLibraryEvolution(),
+      ]
     ),
     .target(
       name: "_Testing_Foundation",
@@ -123,7 +127,9 @@ let package = Package(
       ],
       path: "Sources/Overlays/_Testing_Foundation",
       exclude: ["CMakeLists.txt"],
-      swiftSettings: .publicLibraryTargetSettings
+      swiftSettings: .packageSettings + [
+        .enableLibraryEvolution(applePlatformsOnly: true),
+      ]
     ),
   ],
 
@@ -166,16 +172,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
     ]
   }
 
-  /// Settings intended to be applied to every public Swift library target in
-  /// this package.
-  static var publicLibraryTargetSettings: Self {
-    packageSettings + [
-      // Enable Library Evolution to match the way this library is built for
-      // distribution.
-      .unsafeFlags(["-enable-library-evolution"]),
-    ]
-  }
-
   /// Settings which define commonly-used OS availability macros.
   ///
   /// These leverage a pseudo-experimental feature in the Swift compiler for
@@ -193,6 +189,18 @@ extension Array where Element == PackageDescription.SwiftSetting {
 
       .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0"),
     ]
+  }
+}
+
+extension PackageDescription.SwiftSetting {
+  /// Create a Swift setting which enables Library Evolution, optionally
+  /// constraining it to only Apple platforms.
+  ///
+  /// - Parameters:
+  ///   - applePlatformsOnly: Whether to constrain this setting to only Apple
+  ///     platforms.
+  static func enableLibraryEvolution(applePlatformsOnly: Bool = false) -> Self {
+    unsafeFlags(["-enable-library-evolution"], .when(platforms: applePlatformsOnly ? [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS] : []))
   }
 }
 

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -199,7 +199,7 @@ public struct Configuration: Sendable {
   /// property is pre-configured. Otherwise, the default value of this property
   /// records an issue indicating that it has not been configured.
   @_spi(Experimental)
-  public var exitTestHandler: ExitTest.Handler = { _ in
+  public var exitTestHandler: ExitTest.Handler = { exitTest in
     throw SystemError(description: "Exit test support has not been implemented by the current testing infrastructure.")
   }
 #endif


### PR DESCRIPTION
This modifies `Package.swift` to enable Library Evolution for builds of the package.

### Motivation:

I recently landed a change (#931) which passed our project-level CI but later failed in Swift CI. The difference ended up being due to the latter building with Library Evolution (LE) enabled, whereas our project-level CI builds via SwiftPM and does not enable LE. The change was reverted (#950) but this revealed a gap in our testing strategy. We should always build these targets with LE enabled.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Fixes rdar://144655439
