### PR TITLE
Require sendable userInfo values in JSON.withEncoding(of:userInfo:_:)

### DIFF
--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -29,7 +29,7 @@ enum JSON {
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body` or by the encoding process.
-  static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: Any] = [:], _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+  static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: any Sendable] = [:], _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
 #if canImport(Foundation)
     let encoder = JSONEncoder()
 


### PR DESCRIPTION
swift-foundation recently landed a change (in https://github.com/swiftlang/swift-foundation/pull/764) which requires `any Sendable` values in `JSONEncoder.userInfo`. This causes a build failure in swift-testing:

```
JSON.swift:44:28: error: type 'Any' does not conform to the 'Sendable' protocol 
42 | 
43 |     // Set user info keys that clients want to use during encoding.
44 |     encoder.userInfo.merge(userInfo, uniquingKeysWith: { _, rhs in rhs})
   |                            `- error: type 'Any' does not conform to the 'Sendable' protocol
```

This PR adjusts our `userInfo:` parameter require `any Sendable` values. The values we were passing to this utility were already sendable, luckily.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
