### PR TITLE
Plumb the schema version through the JSON ABI layers.

### DIFF
--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -9,7 +9,7 @@
 //
 
 #if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
-extension ABI.Record {
+extension ABI.Version {
   /// Post-process encoded JSON and write it to a file.
   ///
   /// - Parameters:
@@ -43,29 +43,8 @@ extension ABI.Record {
     }
   }
 
-  /// Create an event handler that encodes events as JSON and forwards them to
-  /// an ABI-friendly event handler.
-  ///
-  /// - Parameters:
-  ///   - encodeAsJSONLines: Whether or not to ensure JSON passed to
-  ///     `eventHandler` is encoded as JSON Lines (i.e. that it does not contain
-  ///     extra newlines.)
-  ///   - version: The JSON schema version to use.
-  ///   - eventHandler: The event handler to forward events to. See
-  ///     ``ABIv0/EntryPoint-swift.typealias`` for more information.
-  ///
-  /// - Returns: An event handler.
-  ///
-  /// The resulting event handler outputs data as JSON. For each event handled
-  /// by the resulting event handler, a JSON object representing it and its
-  /// associated context is created and is passed to `eventHandler`.
-  ///
-  /// Note that ``configurationForEntryPoint(from:)`` calls this function and
-  /// performs additional postprocessing before writing JSON data to ensure it
-  /// does not contain any newline characters.
   static func eventHandler(
     encodeAsJSONLines: Bool,
-    version: Int,
     forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
   ) -> Event.Handler {
     // Encode as JSON Lines if requested.
@@ -77,12 +56,12 @@ extension ABI.Record {
     let humanReadableOutputRecorder = Event.HumanReadableOutputRecorder()
     return { [eventHandler = eventHandlerCopy] event, context in
       if case .testDiscovered = event.kind, let test = context.test {
-        try? JSON.withEncoding(of: Self(encoding: test, version: version)) { testJSON in
+        try? JSON.withEncoding(of: ABI.Record<Self>(encoding: test)) { testJSON in
           eventHandler(testJSON)
         }
       } else {
         let messages = humanReadableOutputRecorder.record(event, in: context, verbosity: 0)
-        if let eventRecord = Self(encoding: event, in: context, messages: messages, version: version) {
+        if let eventRecord = ABI.Record<Self>(encoding: event, in: context, messages: messages) {
           try? JSON.withEncoding(of: eventRecord, eventHandler)
         }
       }
@@ -91,63 +70,33 @@ extension ABI.Record {
 }
 
 #if !SWT_NO_SNAPSHOT_TYPES
-// MARK: - Experimental event streaming
+// MARK: - Xcode 16 Beta 1 compatibility
 
-/// A type containing an event snapshot and snapshots of the contents of an
-/// event context suitable for streaming over JSON.
-///
-/// This type is not part of the public interface of the testing library.
-/// External adopters are not necessarily written in Swift and are expected to
-/// decode the JSON produced for this type in implementation-specific ways.
-///
-/// - Warning: This type supports early Xcode 16 betas and will be removed in a
-///   future update.
-struct EventAndContextSnapshot {
-  /// A snapshot of the event.
-  var event: Event.Snapshot
+extension ABI.Xcode16Beta1 {
+  static func eventHandler(
+    encodeAsJSONLines: Bool,
+    forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
+  ) -> Event.Handler {
+    return { event, context in
+      if case .testDiscovered = event.kind {
+        // Discard events of this kind rather than forwarding them to avoid a
+        // crash in Xcode 16 Beta 1 (which does not expect any events to occur
+        // before .runStarted.)
+        return
+      }
 
-  /// A snapshot of the event context.
-  var eventContext: Event.Context.Snapshot
-}
-
-extension EventAndContextSnapshot: Codable {}
-
-/// Create an event handler that encodes events as JSON and forwards them to an
-/// ABI-friendly event handler.
-///
-/// - Parameters:
-///   - eventHandler: The event handler to forward events to. See
-///     ``ABIv0/EntryPoint-swift.typealias`` for more information.
-///
-/// - Returns: An event handler.
-///
-/// The resulting event handler outputs data as JSON. For each event handled by
-/// the resulting event handler, a JSON object representing it and its
-/// associated context is created and is passed to `eventHandler`.
-///
-/// Note that ``configurationForEntryPoint(from:)`` calls this function and
-/// performs additional postprocessing before writing JSON data to ensure it
-/// does not contain any newline characters.
-///
-/// - Warning: This function supports early Xcode 16 betas and will be removed
-///   in a future update.
-func eventHandlerForStreamingEventSnapshots(
-  to eventHandler: @escaping @Sendable (_ eventAndContextJSON: UnsafeRawBufferPointer) -> Void
-) -> Event.Handler {
-  return { event, context in
-    if case .testDiscovered = event.kind {
-      // Discard events of this kind rather than forwarding them to avoid a
-      // crash in Xcode 16 Beta 1 (which does not expect any events to occur
-      // before .runStarted.)
-      return
-    }
-    let snapshot = EventAndContextSnapshot(
-      event: Event.Snapshot(snapshotting: event),
-      eventContext: Event.Context.Snapshot(snapshotting: context)
-    )
-    try? JSON.withEncoding(of: snapshot) { eventAndContextJSON in
-      eventAndContextJSON.withUnsafeBytes { eventAndContextJSON in
-        eventHandler(eventAndContextJSON)
+      struct EventAndContextSnapshot: Codable {
+        var event: Event.Snapshot
+        var eventContext: Event.Context.Snapshot
+      }
+      let snapshot = EventAndContextSnapshot(
+        event: Event.Snapshot(snapshotting: event),
+        eventContext: Event.Context.Snapshot(snapshotting: context)
+      )
+      try? JSON.withEncoding(of: snapshot) { eventAndContextJSON in
+        eventAndContextJSON.withUnsafeBytes { eventAndContextJSON in
+          eventHandler(eventAndContextJSON)
+        }
       }
     }
   }

--- a/Sources/Testing/ABI/ABI.Record.swift
+++ b/Sources/Testing/ABI/ABI.Record.swift
@@ -18,8 +18,9 @@ extension ABI {
   struct Record: Sendable {
     /// The version of this record.
     ///
-    /// The value of this property corresponds to the ABI version i.e. `0`.
-    var version = 0
+    /// The value of this property corresponds to the JSON schema version this
+    /// record is compatible with.
+    var version: Int
 
     /// An enumeration describing the various kinds of record.
     enum Kind: Sendable {
@@ -33,14 +34,16 @@ extension ABI {
     /// The kind of record.
     var kind: Kind
 
-    init(encoding test: borrowing Test) {
-      kind = .test(EncodedTest(encoding: test))
+    init(encoding test: borrowing Test, version: Int) {
+      self.version = version
+      kind = .test(EncodedTest(encoding: test, version: version))
     }
 
-    init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message]) {
-      guard let event = EncodedEvent(encoding: event, in: eventContext, messages: messages) else {
+    init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message], version: Int) {
+      guard let event = EncodedEvent(encoding: event, in: eventContext, messages: messages, version: version) else {
         return nil
       }
+      self.version = version
       kind = .event(event)
     }
   }

--- a/Sources/Testing/ABI/ABI.Record.swift
+++ b/Sources/Testing/ABI/ABI.Record.swift
@@ -16,14 +16,6 @@ extension ABI {
   /// assists in converting values to JSON; clients that consume this JSON are
   /// expected to write their own decoders.
   struct Record<V>: Sendable where V: ABI.Version {
-    /// The version of this record.
-    ///
-    /// The value of this property corresponds to the JSON schema version this
-    /// record is compatible with.
-    var version: V.Type {
-      V.self
-    }
-
     /// An enumeration describing the various kinds of record.
     enum Kind: Sendable {
       /// A test record.

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -50,7 +50,7 @@ extension ABI {
 #if !SWT_NO_SNAPSHOT_TYPES
   /// A namespace and version type for Xcode 16 Beta 1 compatibility.
   ///
-  /// This type will be removed in a future update.
+  /// - Warning: This type will be removed in a future update.
   enum Xcode16Beta1: Sendable, Version {
     static var versionNumber: Int {
       -1
@@ -66,6 +66,10 @@ extension ABI {
   }
 
   /// A namespace and type for ABI version 1 symbols.
+  ///
+  /// @Metadata {
+  ///   @Available("Swift Testing ABI", introduced: 1)
+  /// }
   @_spi(Experimental)
   public enum v1: Sendable, Version {
     static var versionNumber: Int {

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -41,9 +41,7 @@ extension ABI {
   }
 
   /// The current supported ABI version (ignoring any experimental versions.)
-  static var currentVersion: (some Version).Type {
-    v0.self
-  }
+  typealias CurrentVersion = v0
 }
 
 // MARK: - Concrete ABI versions

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -21,7 +21,7 @@ extension ABI {
     /// The path where the attachment was written.
     var path: String?
 
-    init(encoding attachment: borrowing Attachment<AnyAttachable>, in eventContext: borrowing Event.Context) {
+    init(encoding attachment: borrowing Attachment<AnyAttachable>, in eventContext: borrowing Event.Context, version: Int) {
       path = attachment.fileSystemPath
     }
   }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -17,11 +17,11 @@ extension ABI {
   /// expected to write their own decoders.
   ///
   /// - Warning: Attachments are not yet part of the JSON schema.
-  struct EncodedAttachment: Sendable {
+  struct EncodedAttachment<V>: Sendable where V: ABI.Version {
     /// The path where the attachment was written.
     var path: String?
 
-    init(encoding attachment: borrowing Attachment<AnyAttachable>, in eventContext: borrowing Event.Context, version: Int) {
+    init(encoding attachment: borrowing Attachment<AnyAttachable>, in eventContext: borrowing Event.Context) {
       path = attachment.fileSystemPath
     }
   }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
@@ -21,7 +21,7 @@ extension ABI {
     /// The frames in the backtrace.
     var symbolicatedAddresses: [Backtrace.SymbolicatedAddress]
 
-    init(encoding backtrace: borrowing Backtrace, in eventContext: borrowing Event.Context) {
+    init(encoding backtrace: borrowing Backtrace, in eventContext: borrowing Event.Context, version: Int) {
       if let symbolicationMode = eventContext.configuration?.backtraceSymbolicationMode {
         symbolicatedAddresses = backtrace.symbolicate(symbolicationMode)
       } else {

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
@@ -17,11 +17,11 @@ extension ABI {
   /// expected to write their own decoders.
   ///
   /// - Warning: Backtraces are not yet part of the JSON schema.
-  struct EncodedBacktrace: Sendable {
+  struct EncodedBacktrace<V>: Sendable where V: ABI.Version {
     /// The frames in the backtrace.
     var symbolicatedAddresses: [Backtrace.SymbolicatedAddress]
 
-    init(encoding backtrace: borrowing Backtrace, in eventContext: borrowing Event.Context, version: Int) {
+    init(encoding backtrace: borrowing Backtrace, in eventContext: borrowing Event.Context) {
       if let symbolicationMode = eventContext.configuration?.backtraceSymbolicationMode {
         symbolicatedAddresses = backtrace.symbolicate(symbolicationMode)
       } else {

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
@@ -17,7 +17,7 @@ extension ABI {
   /// expected to write their own decoders.
   ///
   /// - Warning: Errors are not yet part of the JSON schema.
-  struct EncodedError: Sendable {
+  struct EncodedError<V>: Sendable where V: ABI.Version {
     /// The error's description
     var description: String
 
@@ -29,7 +29,7 @@ extension ABI {
 
     // TODO: userInfo (partial) encoding
 
-    init(encoding error: some Error, in eventContext: borrowing Event.Context, version: Int) {
+    init(encoding error: some Error, in eventContext: borrowing Event.Context) {
       description = String(describingForTest: error)
       domain = error._domain
       code = error._code

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
@@ -29,7 +29,7 @@ extension ABI {
 
     // TODO: userInfo (partial) encoding
 
-    init(encoding error: some Error, in eventContext: borrowing Event.Context) {
+    init(encoding error: some Error, in eventContext: borrowing Event.Context, version: Int) {
       description = String(describingForTest: error)
       domain = error._domain
       code = error._code

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -66,7 +66,7 @@ extension ABI {
     /// - Warning: Test cases are not yet part of the JSON schema.
     var _testCase: EncodedTestCase?
 
-    init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message]) {
+    init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message], version: Int) {
       switch event.kind {
       case .runStarted:
         kind = .runStarted
@@ -79,10 +79,10 @@ extension ABI {
         kind = .testCaseStarted
       case let .issueRecorded(recordedIssue):
         kind = .issueRecorded
-        issue = EncodedIssue(encoding: recordedIssue, in: eventContext)
+        issue = EncodedIssue(encoding: recordedIssue, in: eventContext, version: version)
       case let .valueAttached(attachment):
         kind = .valueAttached
-        _attachment = EncodedAttachment(encoding: attachment, in: eventContext)
+        _attachment = EncodedAttachment(encoding: attachment, in: eventContext, version: version)
       case .testCaseEnded:
         if eventContext.test?.isParameterized == false {
           return nil
@@ -97,11 +97,11 @@ extension ABI {
       default:
         return nil
       }
-      instant = EncodedInstant(encoding: event.instant)
-      self.messages = messages.map(EncodedMessage.init)
-      testID = event.testID.map(EncodedTest.ID.init)
+      instant = EncodedInstant(encoding: event.instant, version: version)
+      self.messages = messages.map { EncodedMessage(encoding: $0, version: version) }
+      testID = event.testID.map { EncodedTest.ID(encoding: $0, version: version) }
       if eventContext.test?.isParameterized == true {
-        _testCase = eventContext.testCase.map(EncodedTestCase.init)
+        _testCase = eventContext.testCase.map { EncodedTestCase(encoding: $0, version: version) }
       }
     }
   }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
@@ -15,7 +15,7 @@ extension ABI {
   /// This type is not part of the public interface of the testing library. It
   /// assists in converting values to JSON; clients that consume this JSON are
   /// expected to write their own decoders.
-  struct EncodedInstant: Sendable {
+  struct EncodedInstant<V>: Sendable where V: ABI.Version {
     /// The number of seconds since the system-defined suspending epoch.
     ///
     /// For more information, see [`SuspendingClock`](https://developer.apple.com/documentation/swift/suspendingclock).
@@ -24,7 +24,7 @@ extension ABI {
     /// The number of seconds since the UNIX epoch (1970-01-01 00:00:00 UT).
     var since1970: Double
 
-    init(encoding instant: borrowing Test.Clock.Instant, version: Int) {
+    init(encoding instant: borrowing Test.Clock.Instant) {
       absolute = Double(instant.suspending)
 #if !SWT_NO_UTC_CLOCK
       since1970 = Double(instant.wall)

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
@@ -24,7 +24,7 @@ extension ABI {
     /// The number of seconds since the UNIX epoch (1970-01-01 00:00:00 UT).
     var since1970: Double
 
-    init(encoding instant: borrowing Test.Clock.Instant) {
+    init(encoding instant: borrowing Test.Clock.Instant, version: Int) {
       absolute = Double(instant.suspending)
 #if !SWT_NO_UTC_CLOCK
       since1970 = Double(instant.wall)

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -15,7 +15,7 @@ extension ABI {
   /// This type is not part of the public interface of the testing library. It
   /// assists in converting values to JSON; clients that consume this JSON are
   /// expected to write their own decoders.
-  struct EncodedIssue: Sendable {
+  struct EncodedIssue<V>: Sendable where V: ABI.Version {
     /// An enumeration representing the level of severity of a recorded issue.
     ///
     /// For descriptions of individual cases, see ``Issue/Severity-swift.enum``.
@@ -38,14 +38,14 @@ extension ABI {
     /// The backtrace where this issue occurred, if available.
     ///
     /// - Warning: Backtraces are not yet part of the JSON schema.
-    var _backtrace: EncodedBacktrace?
+    var _backtrace: EncodedBacktrace<V>?
 
     /// The error associated with this issue, if applicable.
     ///
     /// - Warning: Errors are not yet part of the JSON schema.
-    var _error: EncodedError?
+    var _error: EncodedError<V>?
 
-    init(encoding issue: borrowing Issue, in eventContext: borrowing Event.Context, version: Int) {
+    init(encoding issue: borrowing Issue, in eventContext: borrowing Event.Context) {
       _severity = switch issue.severity {
       case .warning: .warning
       case .error: .error
@@ -53,10 +53,10 @@ extension ABI {
       isKnown = issue.isKnown
       sourceLocation = issue.sourceLocation
       if let backtrace = issue.sourceContext.backtrace {
-        _backtrace = EncodedBacktrace(encoding: backtrace, in: eventContext, version: version)
+        _backtrace = EncodedBacktrace(encoding: backtrace, in: eventContext)
       }
       if let error = issue.error {
-        _error = EncodedError(encoding: error, in: eventContext, version: version)
+        _error = EncodedError(encoding: error, in: eventContext)
       }
     }
   }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -45,19 +45,18 @@ extension ABI {
     /// - Warning: Errors are not yet part of the JSON schema.
     var _error: EncodedError?
 
-    init(encoding issue: borrowing Issue, in eventContext: borrowing Event.Context) {
+    init(encoding issue: borrowing Issue, in eventContext: borrowing Event.Context, version: Int) {
       _severity = switch issue.severity {
       case .warning: .warning
       case .error: .error
       }
-
       isKnown = issue.isKnown
       sourceLocation = issue.sourceLocation
       if let backtrace = issue.sourceContext.backtrace {
-        _backtrace = EncodedBacktrace(encoding: backtrace, in: eventContext)
+        _backtrace = EncodedBacktrace(encoding: backtrace, in: eventContext, version: version)
       }
       if let error = issue.error {
-        _error = EncodedError(encoding: error, in: eventContext)
+        _error = EncodedError(encoding: error, in: eventContext, version: version)
       }
     }
   }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
@@ -33,7 +33,7 @@ extension ABI {
       case details
       case attachment = "_attachment"
 
-      init(encoding symbol: Event.Symbol) {
+      init(encoding symbol: Event.Symbol, version: Int) {
         self = switch symbol {
         case .default:
           .default
@@ -67,8 +67,8 @@ extension ABI {
     /// The human-readable, unformatted text associated with this message.
     var text: String
 
-    init(encoding message: borrowing Event.HumanReadableOutputRecorder.Message) {
-      symbol = Symbol(encoding: message.symbol ?? .default)
+    init(encoding message: borrowing Event.HumanReadableOutputRecorder.Message, version: Int) {
+      symbol = Symbol(encoding: message.symbol ?? .default, version: version)
       text = message.conciseStringValue ?? message.stringValue
     }
   }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
@@ -16,7 +16,7 @@ extension ABI {
   /// This type is not part of the public interface of the testing library. It
   /// assists in converting values to JSON; clients that consume this JSON are
   /// expected to write their own decoders.
-  struct EncodedMessage: Sendable {
+  struct EncodedMessage<V>: Sendable where V: ABI.Version {
     /// A type implementing the JSON encoding of ``Event/Symbol`` for the ABI
     /// entry point and event stream output.
     ///
@@ -33,7 +33,7 @@ extension ABI {
       case details
       case attachment = "_attachment"
 
-      init(encoding symbol: Event.Symbol, version: Int) {
+      init(encoding symbol: Event.Symbol) {
         self = switch symbol {
         case .default:
           .default
@@ -67,8 +67,8 @@ extension ABI {
     /// The human-readable, unformatted text associated with this message.
     var text: String
 
-    init(encoding message: borrowing Event.HumanReadableOutputRecorder.Message, version: Int) {
-      symbol = Symbol(encoding: message.symbol ?? .default, version: version)
+    init(encoding message: borrowing Event.HumanReadableOutputRecorder.Message) {
+      symbol = Symbol(encoding: message.symbol ?? .default)
       text = message.conciseStringValue ?? message.stringValue
     }
   }

--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -68,15 +68,17 @@ extension ABI.v0 {
 #if !SWT_NO_SNAPSHOT_TYPES
 // MARK: - Xcode 16 Beta 1 compatibility
 
-/// An older signature for ``ABIv0/EntryPoint-swift.typealias`` used by Xcode 16
-/// Beta 1.
-///
-/// This type will be removed in a future update.
-@available(*, deprecated, message: "Use ABI.v0.EntryPoint instead.")
-typealias ABIEntryPoint_v0 = @Sendable (
-  _ argumentsJSON: UnsafeRawBufferPointer?,
-  _ recordHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
-) async throws -> CInt
+extension ABI.Xcode16Beta1 {
+  /// An older signature for ``ABIv0/EntryPoint-swift.typealias`` used by Xcode
+  /// 16 Beta 1.
+  ///
+  /// This type will be removed in a future update.
+  @available(*, deprecated, message: "Use ABI.v0.EntryPoint instead.")
+  typealias EntryPoint = @Sendable (
+    _ argumentsJSON: UnsafeRawBufferPointer?,
+    _ recordHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
+  ) async throws -> CInt
+}
 
 /// An older signature for ``ABIv0/entryPoint-swift.type.property`` used by
 /// Xcode 16 Beta 1.
@@ -85,7 +87,7 @@ typealias ABIEntryPoint_v0 = @Sendable (
 @available(*, deprecated, message: "Use ABI.v0.entryPoint (swt_abiv0_getEntryPoint()) instead.")
 @_cdecl("swt_copyABIEntryPoint_v0")
 @usableFromInline func copyABIEntryPoint_v0() -> UnsafeMutableRawPointer {
-  let result = UnsafeMutablePointer<ABIEntryPoint_v0>.allocate(capacity: 1)
+  let result = UnsafeMutablePointer<ABI.Xcode16Beta1.EntryPoint>.allocate(capacity: 1)
   result.initialize { configurationJSON, recordHandler in
     try await _entryPoint(
       configurationJSON: configurationJSON,

--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -56,9 +56,9 @@ extension ABI.v0 {
 }
 
 /// An exported C function that is the equivalent of
-/// ``ABIv0/entryPoint-swift.type.property``.
+/// ``ABI/v0/entryPoint-swift.type.property``.
 ///
-/// - Returns: The value of ``ABIv0/entryPoint-swift.type.property`` cast to an
+/// - Returns: The value of ``ABI/v0/entryPoint-swift.type.property`` cast to an
 ///   untyped pointer.
 @_cdecl("swt_abiv0_getEntryPoint")
 @usableFromInline func abiv0_getEntryPoint() -> UnsafeRawPointer {
@@ -69,10 +69,10 @@ extension ABI.v0 {
 // MARK: - Xcode 16 Beta 1 compatibility
 
 extension ABI.Xcode16Beta1 {
-  /// An older signature for ``ABIv0/EntryPoint-swift.typealias`` used by Xcode
+  /// An older signature for ``ABI/v0/EntryPoint-swift.typealias`` used by Xcode
   /// 16 Beta 1.
   ///
-  /// This type will be removed in a future update.
+  /// - Warning: This type will be removed in a future update.
   @available(*, deprecated, message: "Use ABI.v0.EntryPoint instead.")
   typealias EntryPoint = @Sendable (
     _ argumentsJSON: UnsafeRawBufferPointer?,
@@ -80,10 +80,10 @@ extension ABI.Xcode16Beta1 {
   ) async throws -> CInt
 }
 
-/// An older signature for ``ABIv0/entryPoint-swift.type.property`` used by
+/// An older signature for ``ABI/v0/entryPoint-swift.type.property`` used by
 /// Xcode 16 Beta 1.
 ///
-/// This function will be removed in a future update.
+/// - Warning: This function will be removed in a future update.
 @available(*, deprecated, message: "Use ABI.v0.entryPoint (swt_abiv0_getEntryPoint()) instead.")
 @_cdecl("swt_copyABIEntryPoint_v0")
 @usableFromInline func copyABIEntryPoint_v0() -> UnsafeMutableRawPointer {
@@ -101,11 +101,11 @@ extension ABI.Xcode16Beta1 {
 
 // MARK: -
 
-/// A common implementation for ``ABIv0/entryPoint-swift.type.property`` and
+/// A common implementation for ``ABI/v0/entryPoint-swift.type.property`` and
 /// ``copyABIEntryPoint_v0()`` that provides Xcode 16 Beta 1 compatibility.
 ///
 /// This function will be removed (with its logic incorporated into
-/// ``ABIv0/entryPoint-swift.type.property``) in a future update.
+/// ``ABI/v0/entryPoint-swift.type.property``) in a future update.
 private func _entryPoint(
   configurationJSON: UnsafeRawBufferPointer?,
   eventStreamVersionIfNil: Int? = nil,

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -611,7 +611,7 @@ func eventHandlerForStreamingEvents(
 
   return switch versionNumber {
   case nil:
-    eventHandler(for: ABI.currentVersion)
+    eventHandler(for: ABI.CurrentVersion.self)
 #if !SWT_NO_SNAPSHOT_TYPES
   case -1:
     // Legacy support for Xcode 16 betas. Support for this undocumented version

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -23,8 +23,8 @@ private import _TestingInternals
 /// - Returns: An exit code representing the result of running tests.
 ///
 /// External callers cannot call this function directly. The can use
-/// ``ABIv0/entryPoint-swift.type.property`` to get a reference to an ABI-stable
-/// version of this function.
+/// ``ABI/v0/entryPoint-swift.type.property`` to get a reference to an
+/// ABI-stable version of this function.
 func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Handler?) async -> CInt {
   let exitCode = Locked(rawValue: EXIT_SUCCESS)
 
@@ -259,8 +259,8 @@ public struct __CommandLineArguments_v0: Sendable {
   /// ``eventStreamOutput``.
   ///
   /// The corresponding stable schema is used to encode events to the event
-  /// stream (for example, ``ABIv0/Record`` is used if the value of this
-  /// property is `0`.)
+  /// stream. ``ABI/Record`` is used if the value of this property is `0` or
+  /// higher.
   ///
   /// If the value of this property is `nil`, the testing library assumes that
   /// the newest available schema should be used.

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -15,7 +15,6 @@ add_library(Testing
   ABI/ABI.swift
   ABI/Encoded/ABI.EncodedAttachment.swift
   ABI/Encoded/ABI.EncodedBacktrace.swift
-  ABI/Encoded/ABI.EncodedBug.swift
   ABI/Encoded/ABI.EncodedError.swift
   ABI/Encoded/ABI.EncodedEvent.swift
   ABI/Encoded/ABI.EncodedInstant.swift

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(Testing
   ABI/ABI.swift
   ABI/Encoded/ABI.EncodedAttachment.swift
   ABI/Encoded/ABI.EncodedBacktrace.swift
+  ABI/Encoded/ABI.EncodedBug.swift
   ABI/Encoded/ABI.EncodedError.swift
   ABI/Encoded/ABI.EncodedEvent.swift
   ABI/Encoded/ABI.EncodedInstant.swift

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -446,7 +446,7 @@ extension ExitTest {
     // events in the future, we can forward them too.) Always use the latest
     // version (even if experimental) since both the producer and consumer are
     // this exact version of the testing library.
-    let eventHandler = ABI.Record.eventHandler(encodeAsJSONLines: true, version: 1) { json in
+    let eventHandler = ABI.v1.eventHandler(encodeAsJSONLines: true) { json in
       _ = try? _backChannelForEntryPoint?.withLock {
         try _backChannelForEntryPoint?.write(json)
         try _backChannelForEntryPoint?.write("\n")
@@ -694,7 +694,7 @@ extension ExitTest {
   ///
   /// - Throws: Any error encountered attempting to decode or process the JSON.
   private static func _processRecord(_ recordJSON: UnsafeRawBufferPointer, fromBackChannel backChannel: borrowing FileHandle) throws {
-    let record = try JSON.decode(ABI.Record.self, from: recordJSON)
+    let record = try JSON.decode(ABI.Record<ABI.v1>.self, from: recordJSON)
 
     if case let .event(event) = record.kind, let issue = event.issue {
       // Translate the issue back into a "real" issue and record it

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -443,8 +443,10 @@ extension ExitTest {
 
     // Encode events as JSON and write them to the back channel file handle.
     // Only forward issue-recorded events. (If we start handling other kinds of
-    // events in the future, we can forward them too.)
-    let eventHandler = ABI.Record.eventHandler(encodeAsJSONLines: true) { json in
+    // events in the future, we can forward them too.) Always use the latest
+    // version (even if experimental) since both the producer and consumer are
+    // this exact version of the testing library.
+    let eventHandler = ABI.Record.eventHandler(encodeAsJSONLines: true, version: 1) { json in
       _ = try? _backChannelForEntryPoint?.withLock {
         try _backChannelForEntryPoint?.write(json)
         try _backChannelForEntryPoint?.write("\n")

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -348,6 +348,16 @@ func callExitTest(
 
 // MARK: - SwiftPM/tools integration
 
+extension ABI {
+  /// The ABI version to use for encoding and decoding events sent over the back
+  /// channel.
+  ///
+  /// The back channel always uses the latest ABI version (even if experimental)
+  /// since both the producer and consumer use this exact version of the testing
+  /// library.
+  fileprivate typealias BackChannelVersion = v1
+}
+
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
 extension ExitTest {
   /// A handler that is invoked when an exit test starts.
@@ -443,10 +453,8 @@ extension ExitTest {
 
     // Encode events as JSON and write them to the back channel file handle.
     // Only forward issue-recorded events. (If we start handling other kinds of
-    // events in the future, we can forward them too.) Always use the latest
-    // version (even if experimental) since both the producer and consumer are
-    // this exact version of the testing library.
-    let eventHandler = ABI.v1.eventHandler(encodeAsJSONLines: true) { json in
+    // events in the future, we can forward them too.)
+    let eventHandler = ABI.BackChannelVersion.eventHandler(encodeAsJSONLines: true) { json in
       _ = try? _backChannelForEntryPoint?.withLock {
         try _backChannelForEntryPoint?.write(json)
         try _backChannelForEntryPoint?.write("\n")
@@ -694,7 +702,7 @@ extension ExitTest {
   ///
   /// - Throws: Any error encountered attempting to decode or process the JSON.
   private static func _processRecord(_ recordJSON: UnsafeRawBufferPointer, fromBackChannel backChannel: borrowing FileHandle) throws {
-    let record = try JSON.decode(ABI.Record<ABI.v1>.self, from: recordJSON)
+    let record = try JSON.decode(ABI.Record<ABI.BackChannelVersion>.self, from: recordJSON)
 
     if case let .event(event) = record.kind, let issue = event.issue {
       // Translate the issue back into a "real" issue and record it

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -27,7 +27,7 @@ struct ABIEntryPointTests {
     arguments.verbosity = .min
 
     let result = try await _invokeEntryPointV0Experimental(passing: arguments) { recordJSON in
-      let record = try! JSON.decode(ABI.Record.self, from: recordJSON)
+      let record = try! JSON.decode(ABI.Record<ABI.v0>.self, from: recordJSON)
       _ = record.version
     }
 
@@ -62,7 +62,7 @@ struct ABIEntryPointTests {
       )
     }
 #endif
-    let abiEntryPoint = copyABIEntryPoint_v0().assumingMemoryBound(to: ABIEntryPoint_v0.self)
+    let abiEntryPoint = copyABIEntryPoint_v0().assumingMemoryBound(to: ABI.Xcode16Beta1.EntryPoint.self)
     defer {
       abiEntryPoint.deinitialize(count: 1)
       abiEntryPoint.deallocate()
@@ -89,7 +89,7 @@ struct ABIEntryPointTests {
     arguments.verbosity = .min
 
     let result = try await _invokeEntryPointV0(passing: arguments) { recordJSON in
-      let record = try! JSON.decode(ABI.Record.self, from: recordJSON)
+      let record = try! JSON.decode(ABI.Record<ABI.v0>.self, from: recordJSON)
       _ = record.version
     }
 
@@ -117,7 +117,7 @@ struct ABIEntryPointTests {
 
     try await confirmation("Test matched", expectedCount: 1...) { testMatched in
       _ = try await _invokeEntryPointV0(passing: arguments) { recordJSON in
-        let record = try! JSON.decode(ABI.Record.self, from: recordJSON)
+        let record = try! JSON.decode(ABI.Record<ABI.v0>.self, from: recordJSON)
         if case .test = record.kind {
           testMatched()
         } else {
@@ -166,6 +166,19 @@ struct ABIEntryPointTests {
     #expect(throws: DecodingError.self) {
       _ = try JSON.decode(__CommandLineArguments_v0.self, from: emptyBuffer)
     }
+  }
+
+  @Test func decodeWrongRecordVersion() throws {
+    let record = ABI.Record<ABI.v1>(encoding: Test {})
+    let error = try JSON.withEncoding(of: record) { recordJSON in
+      try #require(throws: DecodingError.self) {
+        _ = try JSON.decode(ABI.Record<ABI.v0>.self, from: recordJSON)
+      }
+    }
+    guard case let .dataCorrupted(context) = error else {
+      throw error
+    }
+    #expect(context.debugDescription == "Unexpected record version 1 (expected 0).")
   }
 #endif
 }

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -28,7 +28,7 @@ struct ABIEntryPointTests {
 
     let result = try await _invokeEntryPointV0Experimental(passing: arguments) { recordJSON in
       let record = try! JSON.decode(ABI.Record<ABI.v0>.self, from: recordJSON)
-      _ = record.version
+      _ = record.kind
     }
 
     #expect(result == EXIT_SUCCESS)
@@ -90,7 +90,7 @@ struct ABIEntryPointTests {
 
     let result = try await _invokeEntryPointV0(passing: arguments) { recordJSON in
       let record = try! JSON.decode(ABI.Record<ABI.v0>.self, from: recordJSON)
-      _ = record.version
+      _ = record.kind
     }
 
     #expect(result)

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -230,7 +230,6 @@ struct SwiftPMTests {
         arguments: [
           ("--event-stream-output-path", "--event-stream-version", 0),
           ("--experimental-event-stream-output", "--experimental-event-stream-version", 0),
-          ("--event-stream-output-path", "--event-stream-version", 1),
           ("--experimental-event-stream-output", "--experimental-event-stream-version", 1),
         ])
   func eventStreamOutput(outputArgumentName: String, versionArgumentName: String, version: Int) async throws {
@@ -296,6 +295,14 @@ struct SwiftPMTests {
       return nil
     }
     #expect(eventRecords.count == 4)
+  }
+
+  @Test("Experimental ABI version requires --experimental-event-stream-version argument")
+  func experimentalABIVersionNeedsExperimentalFlag() {
+    #expect(throws: (any Error).self) {
+      let experimentalVersion = ABI.CurrentVersion.versionNumber + 1
+      _ = try configurationForEntryPoint(withArguments: ["PATH", "--event-stream-version", "\(experimentalVersion)"])
+    }
   }
 #endif
 #endif


### PR DESCRIPTION
This PR plumbs the schema version (0 or 1) through the Swift types and functions that produce our JSON output, allowing them to change behaviour based on which version is in use.

As a proof-of-concept as much as anything else, this PR also adds an (unsupported) `_tags` field to the JSON output for a test record, but only with ABI version 1.

I've split this PR into two commits: the first plumbs the version through as an integer argument, while the second uses the type system to represent different ABI versions. The latter uses a protocol that we can extend so that different ABI versions have differing behaviours (although that's too coarse-grained for things like `_tags`.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
