### PR TITLE
Revert "Require sendable userInfo values in JSON.withEncoding(of:userInfo:_:)"

### DIFF
--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -29,7 +29,7 @@ enum JSON {
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body` or by the encoding process.
-  static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: any Sendable] = [:], _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+  static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: Any] = [:], _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
 #if canImport(Foundation)
     let encoder = JSONEncoder()
 


### PR DESCRIPTION
Reverts swiftlang/swift-testing#955. Reverting the foundation change in https://github.com/swiftlang/swift-foundation/pull/1167.