### PR TITLE
Add an overview of test serialization to the XCTest migration guide

### DIFF
--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -273,7 +273,7 @@ with optional expressions to unwrap them:
 
 ### Record issues
 
-Finally, XCTest has a function, [`XCTFail()`](https://developer.apple.com/documentation/xctest/1500970-xctfail),
+XCTest has a function, [`XCTFail()`](https://developer.apple.com/documentation/xctest/1500970-xctfail),
 that causes a test to fail immediately and unconditionally. This function is
 useful when the syntax of the language prevents the use of an `XCTAssert()`
 function. To record an unconditional issue using the testing library, use the
@@ -691,6 +691,58 @@ of issues:
     ```
   }
 }
+
+### Run tests sequentially
+
+By default, the testing library runs all tests in a suite in parallel. The
+default behavior of XCTest is to run each test in a suite sequentially. If your tests use
+shared state, for example, global variables, you may see expected behavior
+including unreliable test outcomes when you run tests in parallel.
+
+Annotate your test suite with ``Trait/serialized`` to run tests within that
+suite serially:
+
+@Row {
+  @Column {
+    ```swift
+    // Before
+    class RefrigeratorTests : XCTestCase
+      func testLightComesOn() async {
+        try FoodTruck.shared.refrigerator.openDoor()
+        XCTAssertEqual(FoodTruck.shared.refrigerator.lightState == .on)
+      }
+      
+      func testLightGoesOut() async {
+        try FoodTruck.shared.refrigerator.openDoor()
+        try FoodTruck.shared.refrigerator.closeDoor()
+        XCTAssertEqual(FoodTruck.shared.refrigerator.lightState == .off)
+      }
+    }
+    ```
+  }
+  @Column {
+    ```swift
+    // After
+    @Suite(.serialized)
+    class RefrigeratorTests {
+      @Test
+      func lightComesOn() async {
+        try FoodTruck.shared.refrigerator.openDoor()
+        #expect(FoodTruck.shared.refrigerator.lightState == .on)
+      }
+      
+      @Test
+      func lightGoesOut() async {
+        try FoodTruck.shared.refrigerator.openDoor()
+        try FoodTruck.shared.refrigerator.closeDoor()
+        #expect(FoodTruck.shared.refrigerator.lightState == .off)
+      }
+    }
+    ```
+  }
+}
+
+For more information, see <doc:Parallelization>.
 
 ## See Also
 

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -706,7 +706,7 @@ suite serially:
   @Column {
     ```swift
     // Before
-    class RefrigeratorTests : XCTestCase
+    class RefrigeratorTests : XCTestCase {
       func testLightComesOn() throws {
         try FoodTruck.shared.refrigerator.openDoor()
         XCTAssertEqual(FoodTruck.shared.refrigerator.lightState == .on)

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -695,9 +695,9 @@ of issues:
 ### Run tests sequentially
 
 By default, the testing library runs all tests in a suite in parallel. The
-default behavior of XCTest is to run each test in a suite sequentially. If your tests use
-shared state, for example, global variables, you may see expected behavior
-including unreliable test outcomes when you run tests in parallel.
+default behavior of XCTest is to run each test in a suite sequentially. If your
+tests use shared state such as global variables, you may see unexpected
+behavior including unreliable test outcomes when you run tests in parallel.
 
 Annotate your test suite with ``Trait/serialized`` to run tests within that
 suite serially:
@@ -707,12 +707,12 @@ suite serially:
     ```swift
     // Before
     class RefrigeratorTests : XCTestCase
-      func testLightComesOn() async {
+      func testLightComesOn() throws {
         try FoodTruck.shared.refrigerator.openDoor()
         XCTAssertEqual(FoodTruck.shared.refrigerator.lightState == .on)
       }
       
-      func testLightGoesOut() async {
+      func testLightGoesOut() throws {
         try FoodTruck.shared.refrigerator.openDoor()
         try FoodTruck.shared.refrigerator.closeDoor()
         XCTAssertEqual(FoodTruck.shared.refrigerator.lightState == .off)
@@ -725,14 +725,12 @@ suite serially:
     // After
     @Suite(.serialized)
     class RefrigeratorTests {
-      @Test
-      func lightComesOn() async {
+      @Test func lightComesOn() throws {
         try FoodTruck.shared.refrigerator.openDoor()
         #expect(FoodTruck.shared.refrigerator.lightState == .on)
       }
       
-      @Test
-      func lightGoesOut() async {
+      @Test func lightGoesOut() throws {
         try FoodTruck.shared.refrigerator.openDoor()
         try FoodTruck.shared.refrigerator.closeDoor()
         #expect(FoodTruck.shared.refrigerator.lightState == .off)


### PR DESCRIPTION
Describe test serialization in the article about migrating tests from XCTest.

### Motivation:

Because XCTest runs tests in a suite serially by default, tests that people migrate from XCTest may encounter issues if they run in parallel.

### Modifications:

Add an example of serializing a test suite to the migration guide, along with links to the docs about test parallelization.

### Result:

The documentation on migrating tests from XCTest includes guidance on serializing tests within a suite.

### Checklist:

- [X] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [X] If public symbols are renamed or modified, DocC references should be updated.
