### PR TITLE
Update proposals to reflect implementation status, Swift version, and forum discussion links

### DIFF
--- a/Documentation/Proposals/0001-refactor-bug-inits.md
+++ b/Documentation/Proposals/0001-refactor-bug-inits.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SWT-0001](0001-refactor-bug-inits.md)
 * Authors: [Jonathan Grynspan](https://github.com/grynspan)
-* Status: **Accepted**
+* Status: **Implemented (Swift 6.0)**
 * Implementation: [swiftlang/swift-testing#401](https://github.com/swiftlang/swift-testing/pull/401)
 * Review: ([pitch](https://forums.swift.org/t/pitch-dedicated-bug-functions-for-urls-and-ids/71842)), ([acceptance](https://forums.swift.org/t/swt-0001-dedicated-bug-functions-for-urls-and-ids/71842/2))
 

--- a/Documentation/Proposals/0002-json-abi.md
+++ b/Documentation/Proposals/0002-json-abi.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SWT-0002](0002-json-abi.md)
 * Authors: [Jonathan Grynspan](https://github.com/grynspan)
-* Status: **Accepted**
+* Status: **Implemented (Swift 6.0)**
 * Implementation: [swiftlang/swift-testing#383](https://github.com/swiftlang/swift-testing/pull/383),
   [swiftlang/swift-testing#402](https://github.com/swiftlang/swift-testing/pull/402)
 * Review: ([pitch](https://forums.swift.org/t/pitch-a-stable-json-based-abi-for-tools-integration/72627)), ([acceptance](https://forums.swift.org/t/pitch-a-stable-json-based-abi-for-tools-integration/72627/4))

--- a/Documentation/Proposals/0003-make-serialized-trait-api.md
+++ b/Documentation/Proposals/0003-make-serialized-trait-api.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SWT-0003](0003-make-serialized-trait-api.md)
 * Authors: [Dennis Weissmann](https://github.com/dennisweissmann)
-* Status: **Accepted**
+* Status: **Implemented (Swift 6.0)**
 * Implementation: 
 [swiftlang/swift-testing#535](https://github.com/swiftlang/swift-testing/pull/535)
 * Review: 

--- a/Documentation/Proposals/0004-constrain-the-granularity-of-test-time-limit-durations.md
+++ b/Documentation/Proposals/0004-constrain-the-granularity-of-test-time-limit-durations.md
@@ -3,7 +3,7 @@
 * Proposal: 
 [SWT-0004](0004-constrain-the-granularity-of-test-time-limit-durations.md)
 * Authors: [Dennis Weissmann](https://github.com/dennisweissmann)
-* Status: **Accepted**
+* Status: **Implemented (Swift 6.0)**
 * Implementation: 
 [swiftlang/swift-testing#534](https://github.com/swiftlang/swift-testing/pull/534)
 * Review: 

--- a/Documentation/Proposals/0005-ranged-confirmations.md
+++ b/Documentation/Proposals/0005-ranged-confirmations.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SWT-0005](0005-ranged-confirmations.md)
 * Authors: [Jonathan Grynspan](https://github.com/grynspan)
-* Status: **Accepted**
+* Status: **Implemented (Swift 6.1)**
 * Bug: rdar://138499457
 * Implementation: [swiftlang/swift-testing#598](https://github.com/swiftlang/swift-testing/pull/598), [swiftlang/swift-testing#689](https://github.com/swiftlang/swift-testing/pull689)
 * Review: ([pitch](https://forums.swift.org/t/pitch-range-based-confirmations/74589)),

--- a/Documentation/Proposals/0006-return-errors-from-expect-throws.md
+++ b/Documentation/Proposals/0006-return-errors-from-expect-throws.md
@@ -2,10 +2,10 @@
 
 * Proposal: [SWT-0006](0006-return-errors-from-expect-throws.md)
 * Authors: [Jonathan Grynspan](https://github.com/grynspan)
-* Status: **Awaiting review**
+* Status: **Implemented (Swift 6.1)**
 * Bug: rdar://138235250
 * Implementation: [swiftlang/swift-testing#780](https://github.com/swiftlang/swift-testing/pull/780)
-* Review: ([pitch](https://forums.swift.org/t/pitch-returning-errors-from-expect-throws/75567))
+* Review: ([pitch](https://forums.swift.org/t/pitch-returning-errors-from-expect-throws/75567)), ([acceptance](https://forums.swift.org/t/pitch-returning-errors-from-expect-throws/75567/5))
 
 ## Introduction
 

--- a/Documentation/Proposals/0007-test-scoping-traits.md
+++ b/Documentation/Proposals/0007-test-scoping-traits.md
@@ -2,9 +2,9 @@
 
 * Proposal: [SWT-0007](0007-test-scoping-traits.md)
 * Authors: [Stuart Montgomery](https://github.com/stmontgomery)
-* Status: **Awaiting review**
+* Status: **Implemented (Swift 6.1)**
 * Implementation: [swiftlang/swift-testing#733](https://github.com/swiftlang/swift-testing/pull/733), [swiftlang/swift-testing#86](https://github.com/swiftlang/swift-testing/pull/86)
-* Review: ([pitch](https://forums.swift.org/t/pitch-custom-test-execution-traits/75055))
+* Review: ([pitch](https://forums.swift.org/t/pitch-custom-test-execution-traits/75055)), ([review](https://forums.swift.org/t/proposal-test-scoping-traits/76676)), ([acceptance](https://forums.swift.org/t/proposal-test-scoping-traits/76676/3))
 
 ### Revision history
 


### PR DESCRIPTION
This updates some details in the accepted proposals in the repository, to better reflect their current status and match the convention used by proposals in the [swift-evolution](https://github.com/swiftlang/swift-evolution) repo.

## Modifications

- Update the _Status_ field of all accepted proposals which have been fully implemented to "Implemented".
- Indicate the Swift version in which those proposals were implemented.
- Add any missing links to Forum reviews or acceptance posts.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
