### PR TITLE
Corrects use of XCTAssertEqual macro in parallelization examples.

### DIFF
--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -709,13 +709,13 @@ suite serially:
     class RefrigeratorTests : XCTestCase {
       func testLightComesOn() throws {
         try FoodTruck.shared.refrigerator.openDoor()
-        XCTAssertEqual(FoodTruck.shared.refrigerator.lightState == .on)
+        XCTAssertEqual(FoodTruck.shared.refrigerator.lightState, .on)
       }
       
       func testLightGoesOut() throws {
         try FoodTruck.shared.refrigerator.openDoor()
         try FoodTruck.shared.refrigerator.closeDoor()
-        XCTAssertEqual(FoodTruck.shared.refrigerator.lightState == .off)
+        XCTAssertEqual(FoodTruck.shared.refrigerator.lightState, .off)
       }
     }
     ```


### PR DESCRIPTION
Fixes a typo in the "before" example of adopting test serialization.

### Motivation:

The example of XCTest tests that need to run in series doesn't compile.

### Modifications:

Correct the code in the example.

### Result:

A documentation change that means the code snippet in the example is correct.

### Checklist:

- [X] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [X] If public symbols are renamed or modified, DocC references should be updated.
