### PR TITLE
Remove references to Xcode 16 Beta 1 (just Xcode 16, please.)

### DIFF
--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -70,9 +70,9 @@ extension ABI.Version {
 }
 
 #if !SWT_NO_SNAPSHOT_TYPES
-// MARK: - Xcode 16 Beta 1 compatibility
+// MARK: - Xcode 16 compatibility
 
-extension ABI.Xcode16Beta1 {
+extension ABI.Xcode16 {
   static func eventHandler(
     encodeAsJSONLines: Bool,
     forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
@@ -80,8 +80,8 @@ extension ABI.Xcode16Beta1 {
     return { event, context in
       if case .testDiscovered = event.kind {
         // Discard events of this kind rather than forwarding them to avoid a
-        // crash in Xcode 16 Beta 1 (which does not expect any events to occur
-        // before .runStarted.)
+        // crash in Xcode 16 (which does not expect any events to occur before
+        // .runStarted.)
         return
       }
 

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -48,10 +48,10 @@ extension ABI {
 
 extension ABI {
 #if !SWT_NO_SNAPSHOT_TYPES
-  /// A namespace and version type for Xcode 16 Beta 1 compatibility.
+  /// A namespace and version type for Xcode&nbsp;16 compatibility.
   ///
   /// - Warning: This type will be removed in a future update.
-  enum Xcode16Beta1: Sendable, Version {
+  enum Xcode16: Sendable, Version {
     static var versionNumber: Int {
       -1
     }

--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -66,11 +66,11 @@ extension ABI.v0 {
 }
 
 #if !SWT_NO_SNAPSHOT_TYPES
-// MARK: - Xcode 16 Beta 1 compatibility
+// MARK: - Xcode 16 compatibility
 
-extension ABI.Xcode16Beta1 {
-  /// An older signature for ``ABI/v0/EntryPoint-swift.typealias`` used by Xcode
-  /// 16 Beta 1.
+extension ABI.Xcode16 {
+  /// An older signature for ``ABI/v0/EntryPoint-swift.typealias`` used by
+  /// Xcode&nbsp;16.
   ///
   /// - Warning: This type will be removed in a future update.
   @available(*, deprecated, message: "Use ABI.v0.EntryPoint instead.")
@@ -81,13 +81,13 @@ extension ABI.Xcode16Beta1 {
 }
 
 /// An older signature for ``ABI/v0/entryPoint-swift.type.property`` used by
-/// Xcode 16 Beta 1.
+/// Xcode&nbsp;16.
 ///
 /// - Warning: This function will be removed in a future update.
 @available(*, deprecated, message: "Use ABI.v0.entryPoint (swt_abiv0_getEntryPoint()) instead.")
 @_cdecl("swt_copyABIEntryPoint_v0")
 @usableFromInline func copyABIEntryPoint_v0() -> UnsafeMutableRawPointer {
-  let result = UnsafeMutablePointer<ABI.Xcode16Beta1.EntryPoint>.allocate(capacity: 1)
+  let result = UnsafeMutablePointer<ABI.Xcode16.EntryPoint>.allocate(capacity: 1)
   result.initialize { configurationJSON, recordHandler in
     try await _entryPoint(
       configurationJSON: configurationJSON,
@@ -102,7 +102,7 @@ extension ABI.Xcode16Beta1 {
 // MARK: -
 
 /// A common implementation for ``ABI/v0/entryPoint-swift.type.property`` and
-/// ``copyABIEntryPoint_v0()`` that provides Xcode 16 Beta 1 compatibility.
+/// ``copyABIEntryPoint_v0()`` that provides Xcode&nbsp;16 compatibility.
 ///
 /// This function will be removed (with its logic incorporated into
 /// ``ABI/v0/entryPoint-swift.type.property``) in a future update.
@@ -125,9 +125,9 @@ private func _entryPoint(
   let eventHandler = try eventHandlerForStreamingEvents(version: args?.eventStreamVersion, encodeAsJSONLines: false, forwardingTo: recordHandler)
   let exitCode = await entryPoint(passing: args, eventHandler: eventHandler)
 
-  // To maintain compatibility with Xcode 16 Beta 1, suppress custom exit codes.
-  // (This is also needed by ABI.v0.entryPoint to correctly treat the no-tests
-  // as a successful run.)
+  // To maintain compatibility with Xcode 16, suppress custom exit codes. (This
+  // is also needed by ABI.v0.entryPoint to correctly treat the no-tests as a
+  // successful run.)
   if exitCode == EXIT_NO_TESTS_FOUND {
     return EXIT_SUCCESS
   }

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -633,9 +633,9 @@ func eventHandlerForStreamingEvents(
     eventHandler(for: ABI.CurrentVersion.self)
 #if !SWT_NO_SNAPSHOT_TYPES
   case -1:
-    // Legacy support for Xcode 16 betas. Support for this undocumented version
-    // will be removed in a future update. Do not use it.
-    eventHandler(for: ABI.Xcode16Beta1.self)
+    // Legacy support for Xcode 16. Support for this undocumented version will
+    // be removed in a future update. Do not use it.
+    eventHandler(for: ABI.Xcode16.self)
 #endif
   case 0:
     eventHandler(for: ABI.v0.self)

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -62,7 +62,7 @@ struct ABIEntryPointTests {
       )
     }
 #endif
-    let abiEntryPoint = copyABIEntryPoint_v0().assumingMemoryBound(to: ABI.Xcode16Beta1.EntryPoint.self)
+    let abiEntryPoint = copyABIEntryPoint_v0().assumingMemoryBound(to: ABI.Xcode16.EntryPoint.self)
     defer {
       abiEntryPoint.deinitialize(count: 1)
       abiEntryPoint.deallocate()


### PR DESCRIPTION
This PR replaces references to Xcode 16 Beta 1, which are generally centred around our JSON ABI, with references to Xcode 16. All versions of Xcode 16 use a legacy JSON schema, not just Beta 1.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
