### PR TITLE
Avoid calling `unsafeBitCast(_:to:)` to cast C function pointers.

### DIFF
--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -34,7 +34,7 @@ typealias ProcessID = Never
 /// `__GLIBC_PREREQ()` is insufficient because `_DEFAULT_SOURCE` may not be
 /// defined at the point spawn.h is first included.
 private let _posix_spawn_file_actions_addclosefrom_np = symbol(named: "posix_spawn_file_actions_addclosefrom_np").map {
-  unsafeBitCast($0, to: (@convention(c) (UnsafeMutablePointer<posix_spawn_file_actions_t>, CInt) -> CInt).self)
+  castCFunction(at: $0, to: (@convention(c) (UnsafeMutablePointer<posix_spawn_file_actions_t>, CInt) -> CInt).self)
 }
 #endif
 

--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -101,7 +101,7 @@ private nonisolated(unsafe) let _waitThreadNoChildrenCondition = {
 /// only declared if `_GNU_SOURCE` is set, but setting it causes build errors
 /// due to conflicts with Swift's Glibc module.
 private let _pthread_setname_np = symbol(named: "pthread_setname_np").map {
-  unsafeBitCast($0, to: (@convention(c) (pthread_t, UnsafePointer<CChar>) -> CInt).self)
+  castCFunction(at: $0, to: (@convention(c) (pthread_t, UnsafePointer<CChar>) -> CInt).self)
 }
 #endif
 

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -339,7 +339,7 @@ extension Backtrace {
 #if _runtime(_ObjC) && !SWT_NO_DYNAMIC_LINKING
     if Environment.flag(named: "SWT_FOUNDATION_ERROR_BACKTRACING_ENABLED") == true {
       let _CFErrorSetCallStackCaptureEnabled = symbol(named: "_CFErrorSetCallStackCaptureEnabled").map {
-        unsafeBitCast($0, to: (@convention(c) (DarwinBoolean) -> DarwinBoolean).self)
+        castCFunction(at: $0, to: (@convention(c) (DarwinBoolean) -> DarwinBoolean).self)
       }
       _ = _CFErrorSetCallStackCaptureEnabled?(true)
       return _CFErrorSetCallStackCaptureEnabled != nil

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -74,7 +74,7 @@ enum Environment {
   /// system, the value of this property is `nil`.
   private static let _environ_lock_np = {
     symbol(named: "environ_lock_np").map {
-      unsafeBitCast($0, to: (@convention(c) () -> Void).self)
+      castCFunction(at: $0, to: (@convention(c) () -> Void).self)
     }
   }()
 
@@ -84,7 +84,7 @@ enum Environment {
   /// system, the value of this property is `nil`.
   private static let _environ_unlock_np = {
     symbol(named: "environ_unlock_np").map {
-      unsafeBitCast($0, to: (@convention(c) () -> Void).self)
+      castCFunction(at: $0, to: (@convention(c) () -> Void).self)
     }
   }()
 #endif

--- a/Sources/Testing/Support/GetSymbol.swift
+++ b/Sources/Testing/Support/GetSymbol.swift
@@ -66,13 +66,13 @@ func symbol(in handle: ImageAddress? = nil, named symbolName: String) -> UnsafeR
     // If the caller supplied a module, use it.
     if let handle {
       return GetProcAddress(handle, symbolName).map {
-        unsafeBitCast($0, to: UnsafeRawPointer.self)
+        castCFunction($0, to: UnsafeRawPointer.self)
       }
     }
 
     return HMODULE.all.lazy
       .compactMap { GetProcAddress($0, symbolName) }
-      .map { unsafeBitCast($0, to: UnsafeRawPointer.self) }
+      .map { castCFunction($0, to: UnsafeRawPointer.self) }
       .first
   }
 #else

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -65,7 +65,7 @@ let operatingSystemVersion: String = {
   // basically always lies on Windows 10, so don't bother calling it on a
   // fallback path.
   let RtlGetVersion = symbol(in: GetModuleHandleA("ntdll.dll"), named: "RtlGetVersion").map {
-    unsafeBitCast($0, to: (@convention(c) (UnsafeMutablePointer<OSVERSIONINFOW>) -> NTSTATUS).self)
+    castCFunction(at: $0, to: (@convention(c) (UnsafeMutablePointer<OSVERSIONINFOW>) -> NTSTATUS).self)
   }
   if let RtlGetVersion {
     var versionInfo = OSVERSIONINFOW()

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -57,7 +57,7 @@ struct ABIEntryPointTests {
     let copyABIEntryPoint_v0 = try withTestingLibraryImageAddress { testingLibrary in
       try #require(
         symbol(in: testingLibrary, named: "swt_copyABIEntryPoint_v0").map {
-          unsafeBitCast($0, to: (@convention(c) () -> UnsafeMutableRawPointer).self)
+          castCFunction(at: $0, to: (@convention(c) () -> UnsafeMutableRawPointer).self)
         }
       )
     }
@@ -140,7 +140,7 @@ struct ABIEntryPointTests {
     let abiv0_getEntryPoint = try withTestingLibraryImageAddress { testingLibrary in
       try #require(
         symbol(in: testingLibrary, named: "swt_abiv0_getEntryPoint").map {
-          unsafeBitCast($0, to: (@convention(c) () -> UnsafeRawPointer).self)
+          castCFunction(at: $0, to: (@convention(c) () -> UnsafeRawPointer).self)
         }
       )
     }


### PR DESCRIPTION
This PR replaces calls to `unsafeBitCast(_:to:)` (where the value being cast is a C function pointer) with calls to an internal function that checks that the value being cast is actually a C function pointer. This is intended to make the code in question more self-documenting (by making it clear what kind of cast is being performed.)

The function does then call `unsafeBitCast(_:to:)`, but it's in one place only instead of many places—the call sites are all now self-documenting.

Also fixed one place we're using `unsafeBitCast(_:to:)` to cast a metatype where, as of Swift 6.1, we don't need to anymore.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
