### PR TITLE
Don't hard-code numeric representations of ABI versions.

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -98,7 +98,7 @@ extension ABI {
       sourceLocation = test.sourceLocation
       id = ID(encoding: test.id)
 
-      if V.versionNumber >= 1 {
+      if V.versionNumber >= ABI.v1.versionNumber {
         let tags = test.tags
         if !tags.isEmpty {
           _tags = tags.map(String.init(describing:))

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -632,14 +632,14 @@ func eventHandlerForStreamingEvents(
   case nil:
     eventHandler(for: ABI.CurrentVersion.self)
 #if !SWT_NO_SNAPSHOT_TYPES
-  case -1:
+  case ABI.Xcode16.versionNumber:
     // Legacy support for Xcode 16. Support for this undocumented version will
     // be removed in a future update. Do not use it.
     eventHandler(for: ABI.Xcode16.self)
 #endif
-  case 0:
+  case ABI.v0.versionNumber:
     eventHandler(for: ABI.v0.self)
-  case 1:
+  case ABI.v1.versionNumber:
     eventHandler(for: ABI.v1.self)
   case let .some(unsupportedVersionNumber):
     throw _EntryPointError.invalidArgument("--event-stream-version", value: "\(unsupportedVersionNumber)")

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -228,15 +228,15 @@ struct SwiftPMTests {
 
   @Test("--event-stream-output-path argument (writes to a stream and can be read back)",
         arguments: [
-          ("--event-stream-output-path", "--event-stream-version", 0),
-          ("--experimental-event-stream-output", "--experimental-event-stream-version", 0),
-          ("--experimental-event-stream-output", "--experimental-event-stream-version", 1),
+          ("--event-stream-output-path", "--event-stream-version", ABI.v0.versionNumber),
+          ("--experimental-event-stream-output", "--experimental-event-stream-version", ABI.v0.versionNumber),
+          ("--experimental-event-stream-output", "--experimental-event-stream-version", ABI.v1.versionNumber),
         ])
   func eventStreamOutput(outputArgumentName: String, versionArgumentName: String, version: Int) async throws {
     switch version {
-    case 0:
+    case ABI.v0.versionNumber:
       try await eventStreamOutput(outputArgumentName: outputArgumentName, versionArgumentName: versionArgumentName, version: ABI.v0.self)
-    case 1:
+    case ABI.v1.versionNumber:
       try await eventStreamOutput(outputArgumentName: outputArgumentName, versionArgumentName: versionArgumentName, version: ABI.v1.self)
     default:
       Issue.record("Unreachable event stream version \(version)")
@@ -282,7 +282,7 @@ struct SwiftPMTests {
     }
     #expect(testRecords.count == 1)
     for testRecord in testRecords {
-      if version.versionNumber >= 1 {
+      if version.versionNumber >= ABI.v1.versionNumber {
         #expect(testRecord._tags != nil)
       } else {
         #expect(testRecord._tags == nil)


### PR DESCRIPTION
This PR replaces some hard-coded ABI version numbers (`-1`, `0`, and `1`) with symbolic references. It also removes a common code path between the Xcode&nbsp;16-compatible C entry point and the formal "v0" one so that deleting the Xcode&nbsp;16 legacy paths will be easier later.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
