### PR TITLE
Silence a warning on the latest 6.2-dev toolchain when building a test.

### DIFF
--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -144,7 +144,7 @@ final class IssueTests: XCTestCase {
     static func f(_ x: Int) -> Bool { false }
     static func g(label x: Int) -> Bool { false }
     static func h(_ x: () -> Void) -> Bool { false }
-    static func j(_ x: Int) -> Never? { nil }
+    static func j(_ x: Int) -> Int? { nil }
     static func k(_ x: inout Int) -> Bool { false }
     static func m(_ x: Bool) -> Bool { false }
     static func n(_ x: Int) throws -> Bool { false }


### PR DESCRIPTION
We are getting a (sort of spurious but also not really) warning when building a test where we have a particularly weird bit of code:

```swift
func f() -> Never? { nil }
try #require(f()) // ⚠️ warning: will never be executed
```

The code in question _will_ be executed, but will always throw an `ExpectationFailedError`. The compiler's getting a bit confused because the expansion of the macro includes a call to a function that returns `T`, where `T` is the type of the expression being unwrapped. Since `T` is `Never` in this context, the compiler infers that that function does not return. The compiler's inference is correct, but it's unclear what exactly it thinks will never be executed here.

In any event, the warning is spurious and does not indicate a problem with the test, so I'm changing the return type of the problematic function from `Never?` to `Int?` to make the compiler happy.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
