### PR TITLE
Restrict use of a new overload of `contains()` to Apple platforms that have it.

### DIFF
--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -301,7 +301,9 @@ struct AttachmentTests {
           #expect(buffer.count > 32)
           #expect(buffer[0] == UInt8(ascii: "P"))
           #expect(buffer[1] == UInt8(ascii: "K"))
-          #expect(buffer.contains("loremipsum.txt".utf8))
+          if #available(_regexAPI, *) {
+            #expect(buffer.contains("loremipsum.txt".utf8))
+          }
         }
         valueAttached()
       }


### PR DESCRIPTION
We have one test that uses a newer overload of [`contains()`](https://developer.apple.com/documentation/swift/collection/contains(_:)) that doesn't exist on older Apple platforms. This PR ensures that our use of that method is constrained to platforms that have it.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
