### PR TITLE
build: restructure the installation location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,18 +32,21 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+set(CMAKE_INSTALL_RPATH $<IF:$<PLATFORM_ID:Darwin>,"@loader_path/..","$ORIGIN">)
+set(CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH YES)
+
 set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_Swift_LANGUAGE_VERSION 6)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
-if(NOT SWIFT_SYSTEM_NAME)
-  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    set(SWIFT_SYSTEM_NAME macosx)
-  else()
-    set(SWIFT_SYSTEM_NAME "$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
-  endif()
-endif()
-
+include(PlatformInfo)
 include(SwiftModuleInstallation)
+
+option(SwiftTesting_INSTALL_NESTED_SUBDIR "Install libraries under a platform and architecture subdirectory" NO)
+set(SwiftTesting_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SwiftTesting_PLATFORM_SUBDIR}$<$<AND:$<PLATFORM_ID:Darwin>,$<NOT:$<BOOL:${SwiftTesting_INSTALL_NESTED_SUBDIR}>>>:/testing>$<$<BOOL:${SwiftTesting_INSTALL_NESTED_SUBDIR}>:/${SwiftTesting_ARCH_SUBDIR}>")
+set(SwiftTesting_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SwiftTesting_PLATFORM_SUBDIR}$<$<AND:$<PLATFORM_ID:Darwin>,$<NOT:$<BOOL:${SwiftTesting_INSTALL_NESTED_SUBDIR}>>>:/testing>$<$<BOOL:${SwiftTesting_INSTALL_NESTED_SUBDIR}>:/${SwiftTesting_PLATFORM_SUBDIR}>")
+
+add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-no-toolchain-stdlib-rpath>)
+
 add_subdirectory(Sources)

--- a/cmake/modules/PlatformInfo.cmake
+++ b/cmake/modules/PlatformInfo.cmake
@@ -1,0 +1,48 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2025 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+set(print_target_info_invocation "${CMAKE_Swift_COMPILER}" -print-target-info)
+if(CMAKE_Swift_COMPILER_TARGET)
+  list(APPEND print_target_info_invocation -target ${CMAKE_Swift_COMPILER_TARGET})
+endif()
+execute_process(COMMAND ${print_target_info_invocation} OUTPUT_VARIABLE target_info_json)
+message(CONFIGURE_LOG "Swift Target Info: ${print_target_info_invocation}\n"
+"${target_info_json}")
+
+if(NOT SwiftTesting_MODULE_TRIPLE)
+  string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+  set(SwiftTesting_MODULE_TRIPLE "${module_triple}" CACHE STRING "Triple used for installed swift{doc,module,interface} files")
+  mark_as_advanced(SwiftTesting_MODULE_TRIPLE)
+
+  message(CONFIGURE_LOG "Swift Module Triple: ${module_triple}")
+endif()
+
+if(NOT SwiftTesting_PLATFORM_SUBDIR)
+  string(JSON platform GET "${target_info_json}" "target" "platform")
+  if(NOT platform)
+    if(NOT SWIFT_SYSTEM_NAME)
+      if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        set(platform macosx)
+      else()
+        set(platform $<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
+      endif()
+    endif()
+  endif()
+  set(SwiftTesting_PLATFORM_SUBDIR "${platform}" CACHE STRING "Platform name used for installed swift{doc,module,interface} files")
+  mark_as_advanced(SwiftTesting_PLATFORM_SUBDIR)
+
+  message(CONFIGURE_LOG "Swift Platform: ${platform}")
+endif()
+
+if(NOT SwiftTesting_ARCH_SUBDIR)
+  string(JSON arch GET "${target_info_json}" "target" "arch")
+  set(SwiftTesting_ARCH_SUBDIR "${arch}" CACHE STRING "Architecture used for setting the architecture subdirectory")
+  mark_as_advanced(SwiftTesting_ARCH_SUBDIR)
+
+  message(CONFIGURE_LOG "Swift Architecture: ${arch}")
+endif()

--- a/cmake/modules/SwiftModuleInstallation.cmake
+++ b/cmake/modules/SwiftModuleInstallation.cmake
@@ -6,62 +6,13 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-# Returns the os name in a variable
-#
-# Usage:
-#   get_swift_host_os(result_var_name)
-#
-#
-# Sets ${result_var_name} with the converted OS name derived from
-# CMAKE_SYSTEM_NAME.
-function(get_swift_host_os result_var_name)
-  set(${result_var_name} ${SWIFT_SYSTEM_NAME} PARENT_SCOPE)
-endfunction()
-
-# Returns the path to the Swift Testing library installation directory
-#
-# Usage:
-#   get_swift_testing_install_lib_dir(type result_var_name)
-#
-# Arguments:
-#   type: The type of the library (STATIC_LIBRARY, SHARED_LIBRARY, or EXECUTABLE).
-#         Typically, the value of the TYPE target property.
-#   result_var_name: The name of the variable to set
-function(get_swift_testing_install_lib_dir type result_var_name)
-  get_swift_host_os(swift_os)
-  if(type STREQUAL STATIC_LIBRARY)
-    set(swift swift_static)
-  else()
-    set(swift swift)
-  endif()
-
-  if(APPLE)
-    set(${result_var_name} "lib/${swift}/${swift_os}/testing" PARENT_SCOPE)
-  else()
-    set(${result_var_name} "lib/${swift}/${swift_os}" PARENT_SCOPE)
-  endif()
-endfunction()
-
 function(_swift_testing_install_target module)
-  target_compile_options(${module} PRIVATE "-no-toolchain-stdlib-rpath")
-
-  if(APPLE)
-    set_target_properties(${module} PROPERTIES
-      INSTALL_RPATH "@loader_path/.."
-      INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
-  else()
-    set_target_properties(${module} PROPERTIES
-      INSTALL_RPATH "$ORIGIN"
-      INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
-  endif()
+  install(TARGETS ${module}
+    ARCHIVE DESTINATION "${SwiftTesting_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${SwiftTesting_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   get_target_property(type ${module} TYPE)
-  get_swift_testing_install_lib_dir(${type} lib_destination_dir)
-
-  install(TARGETS ${module}
-    ARCHIVE DESTINATION "${lib_destination_dir}"
-    LIBRARY DESTINATION "${lib_destination_dir}"
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   if(type STREQUAL EXECUTABLE)
     return()
   endif()
@@ -71,18 +22,7 @@ function(_swift_testing_install_target module)
     set(module_name ${module})
   endif()
 
-  if(NOT SwiftTesting_MODULE_TRIPLE)
-    set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
-    if(CMAKE_Swift_COMPILER_TARGET)
-      list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
-    endif()
-    execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
-    string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
-    set(SwiftTesting_MODULE_TRIPLE "${module_triple}" CACHE STRING "swift module triple used for installed swiftmodule and swiftinterface files")
-    mark_as_advanced(SwiftTesting_MODULE_TRIPLE)
-  endif()
-
-  set(module_dir "${lib_destination_dir}/${module_name}.swiftmodule")
+  set(module_dir ${SwiftTesting_INSTALL_SWIFTMODULEDIR}/${module_name}.swiftmodule)
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
     DESTINATION "${module_dir}"
     RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftdoc)
@@ -104,9 +44,6 @@ endfunction()
 #   swiftcrossimport_dir: The path to the source .swiftcrossimport directory
 #     which will be installed.
 function(_swift_testing_install_swiftcrossimport module swiftcrossimport_dir)
-  get_target_property(type ${module} TYPE)
-  get_swift_testing_install_lib_dir(${type} lib_destination_dir)
-
   install(DIRECTORY "${swiftcrossimport_dir}"
-    DESTINATION "${lib_destination_dir}")
+    DESTINATION "${SwiftTesting_INSTALL_SWIFTMODULEDIR}")
 endfunction()


### PR DESCRIPTION
Clean up some of the module property handling to be more declarative. This reduces the operations that are being done on targets in favour of defaults.

Adopt the latest best practices for handling module installation. Introduce the new `SwiftTesting_INSTALL_NESTED_SUBDIR` option to allow installation into platform/architecture subdirectory allowing multi-architecture installations for platforms like Windows and Android. This is currently opt-in and requires a newer toolchain (something within the last ~2w) to detect the defaults. The values can be overridden by the user if desired.