### PR TITLE
Show the number of test cases that ran at the end of a test

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -153,7 +153,7 @@ extension Event.HumanReadableOutputRecorder {
   ///   - test: to get the number of  `testCases` out of a ``Test``.
   ///   - verbose: If the level is very verbose, a detailed description is returned.
   ///
-  /// - Returns: A string describing the number of argument(s) in the test cases, or an empty string if it's not very verbose level.
+  /// - Returns: A string describing the number of test cases in the test, or an empty string if it's not very verbose level.
   ///
   private func _includeNumberOfTestCasesIfNedded(for test: Test, verbose: Int) -> String {
     if verbose == 2 && !test.isSuite { // very verbose

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -146,6 +146,36 @@ extension Event.HumanReadableOutputRecorder {
 
     return (errorIssueCount, warningIssueCount, knownIssueCount, totalIssueCount,  description)
   }
+  
+  /// Calculates the total number of arguments across all test cases in a sequence.
+  ///
+  /// - Parameters:
+  ///   - testCases: A sequence of `Test.Case` objects containing the test cases..
+  ///
+  /// - Returns: The total count of arguments across all test cases. If `testCases` is `nil` or empty, returns `0`.
+  ///
+  private func _numberOfArguments(for testCases: (any Sequence<Test.Case>)?) -> Int {
+      testCases?.reduce(into: 0) { result, testCase in
+          result += testCase.arguments.count
+      } ?? 0
+  }
+
+  /// Returns a formatted string describing the number of arguments in a test, based on verbosity level.
+  ///
+  /// - Parameters:
+  ///   - test: The `Test` object that contains a sequence of `testCases`.
+  ///   - verbose: If the level is very verbose, a detailed description is returned.
+  ///
+  /// - Returns: A string describing the number of arguments in the test cases, or an empty string if it's not very verbose level.
+  ///
+  private func _includeNumberOfArguments(_ test: Test, verbose: Int) -> String {
+      if verbose == 2 { // very verbose
+          let numberOfArguments = _numberOfArguments(for: test.testCases)
+          return " with \(numberOfArguments) " + (numberOfArguments > 1 ? "arguments" : "argument")
+      }
+      return ""
+  }
+
 }
 
 /// Generate a title for the specified test (either "Test" or "Suite"),
@@ -370,14 +400,14 @@ extension Event.HumanReadableOutputRecorder {
         CollectionOfOne(
           Message(
             symbol: .fail,
-            stringValue: "\(_capitalizedTitle(for: test)) \(testName) failed after \(duration)\(issues.description)."
+            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfArguments(test, verbose: verbosity)) failed after \(duration)\(issues.description)."
           )
         ) + _formattedComments(for: test)
       } else {
         [
           Message(
             symbol: .pass(knownIssueCount: issues.knownIssueCount),
-            stringValue: "\(_capitalizedTitle(for: test)) \(testName) passed after \(duration)\(issues.description)."
+            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfArguments(test, verbose: verbosity)) passed after \(duration)\(issues.description)."
           )
         ]
       }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -64,7 +64,7 @@ extension Event {
         var knownIssueCount = 0
         
         /// The number of test cases for the test.
-        var testCasesCount: Int = 0
+        var testCasesCount = 0
       }
 
       /// Data tracked on a per-test basis.

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -155,10 +155,10 @@ extension Event.HumanReadableOutputRecorder {
   ///
   /// - Returns: A string describing the number of test cases in the test, or an empty string if it's not very verbose level.
   ///
-  private func _includeNumberOfTestCasesIfNedded(for test: Test, verbose: Int) -> String {
+  private func _includeNumberOfTestCasesIfNeeded(for test: Test, verbose: Int) -> String {
     if verbose == 2 && !test.isSuite { // very verbose
         let testCasesCount =  test.testCases?.count(where: { _ in true }) ?? 0
-        return " with \(testCasesCount) " + (testCasesCount > 1 ? "test cases" : "test case")
+        return" with \(testCasesCount) \(testCasesCount > 1 ? "test cases" : "test case")"
       }
       return ""
   }
@@ -387,14 +387,14 @@ extension Event.HumanReadableOutputRecorder {
         CollectionOfOne(
           Message(
             symbol: .fail,
-            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfTestCasesIfNedded(for: test, verbose: verbosity)) failed after \(duration)\(issues.description)."
+            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfTestCasesIfNeeded(for: test, verbose: verbosity)) failed after \(duration)\(issues.description)."
           )
         ) + _formattedComments(for: test)
       } else {
         [
           Message(
             symbol: .pass(knownIssueCount: issues.knownIssueCount),
-            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfTestCasesIfNedded(for: test, verbose: verbosity)) passed after \(duration)\(issues.description)."
+            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfTestCasesIfNeeded(for: test, verbose: verbosity)) passed after \(duration)\(issues.description)."
           )
         ]
       }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -373,7 +373,7 @@ extension Event.HumanReadableOutputRecorder {
       let testData = testDataGraph?.value ?? .init(startInstant: instant)
       let issues = _issueCounts(in: testDataGraph)
       let duration = testData.startInstant.descriptionOfDuration(to: instant)
-      let testCasesCount = if verbosity >= 2 && test.isParameterized {
+      let testCasesCount = if test.isParameterized {
         " with \(testData.testCasesCount.counting("test case"))"
       } else {
         ""

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -155,7 +155,7 @@ extension Event.HumanReadableOutputRecorder {
   ///
   /// - Returns: A string describing the number of argument(s) in the test cases, or an empty string if it's not very verbose level.
   ///
-  private func _includeNumberOfTestCases(for test: Test, verbose: Int) -> String {
+  private func _includeNumberOfTestCasesIfNedded(for test: Test, verbose: Int) -> String {
     if verbose == 2 && !test.isSuite { // very verbose
         let testCasesCount =  test.testCases?.count(where: { _ in true }) ?? 0
         return " with \(testCasesCount) " + (testCasesCount > 1 ? "test cases" : "test case")
@@ -387,14 +387,14 @@ extension Event.HumanReadableOutputRecorder {
         CollectionOfOne(
           Message(
             symbol: .fail,
-            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfTestCases(for: test, verbose: verbosity)) failed after \(duration)\(issues.description)."
+            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfTestCasesIfNedded(for: test, verbose: verbosity)) failed after \(duration)\(issues.description)."
           )
         ) + _formattedComments(for: test)
       } else {
         [
           Message(
             symbol: .pass(knownIssueCount: issues.knownIssueCount),
-            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfTestCases(for: test, verbose: verbosity)) passed after \(duration)\(issues.description)."
+            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfTestCasesIfNedded(for: test, verbose: verbosity)) passed after \(duration)\(issues.description)."
           )
         ]
       }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -147,18 +147,21 @@ extension Event.HumanReadableOutputRecorder {
     return (errorIssueCount, warningIssueCount, knownIssueCount, totalIssueCount,  description)
   }
   
-  /// Returns a formatted string describing the number of arguments in a test, based on verbosity level.
+  /// Returns a formatted string describing the number of arguments in a test,
+  /// based on verbosity level.
   ///
   /// - Parameters:
   ///   - test: to get the number of  `testCases` out of a ``Test``.
-  ///   - verbose: If the level is very verbose, a detailed description is returned.
+  ///   - verbose: If the level is very verbose, a detailed description
+  ///     is returned.
   ///
-  /// - Returns: A string describing the number of test cases in the test, or an empty string if it's not very verbose level.
+  /// - Returns: A string describing the number of test cases in the test,
+  ///   or an empty string if it's not very verbose level.
   ///
   private func _includeNumberOfTestCasesIfNeeded(for test: Test, verbose: Int) -> String {
-    if verbose == 2 && !test.isSuite { // very verbose
+    if verbose >= 2 && test.isParameterized { // very verbose
         let testCasesCount =  test.testCases?.count(where: { _ in true }) ?? 0
-        return" with \(testCasesCount) \(testCasesCount > 1 ? "test cases" : "test case")"
+      return" with \(testCasesCount.counting("test case"))"
       }
       return ""
   }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -147,31 +147,18 @@ extension Event.HumanReadableOutputRecorder {
     return (errorIssueCount, warningIssueCount, knownIssueCount, totalIssueCount,  description)
   }
   
-  /// Calculates the total number of arguments across all test cases in a sequence.
-  ///
-  /// - Parameters:
-  ///   - testCases: A sequence of `Test.Case` objects containing the test cases..
-  ///
-  /// - Returns: The total count of arguments across all test cases. If `testCases` is `nil` or empty, returns `0`.
-  ///
-  private func _numberOfArguments(for testCases: (any Sequence<Test.Case>)?) -> Int {
-      testCases?.reduce(into: 0) { result, testCase in
-          result += testCase.arguments.count
-      } ?? 0
-  }
-
   /// Returns a formatted string describing the number of arguments in a test, based on verbosity level.
   ///
   /// - Parameters:
-  ///   - test: The `Test` object that contains a sequence of `testCases`.
+  ///   - test: to get the number of  `testCases` out of a ``Test``.
   ///   - verbose: If the level is very verbose, a detailed description is returned.
   ///
-  /// - Returns: A string describing the number of arguments in the test cases, or an empty string if it's not very verbose level.
+  /// - Returns: A string describing the number of argument(s) in the test cases, or an empty string if it's not very verbose level.
   ///
-  private func _includeNumberOfArguments(_ test: Test, verbose: Int) -> String {
-      if verbose == 2 { // very verbose
-          let numberOfArguments = _numberOfArguments(for: test.testCases)
-          return " with \(numberOfArguments) " + (numberOfArguments > 1 ? "arguments" : "argument")
+  private func _includeNumberOfTestCases(for test: Test, verbose: Int) -> String {
+    if verbose == 2 && !test.isSuite { // very verbose
+        let testCasesCount =  test.testCases?.count(where: { _ in true }) ?? 0
+        return " with \(testCasesCount) " + (testCasesCount > 1 ? "test cases" : "test case")
       }
       return ""
   }
@@ -400,14 +387,14 @@ extension Event.HumanReadableOutputRecorder {
         CollectionOfOne(
           Message(
             symbol: .fail,
-            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfArguments(test, verbose: verbosity)) failed after \(duration)\(issues.description)."
+            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfTestCases(for: test, verbose: verbosity)) failed after \(duration)\(issues.description)."
           )
         ) + _formattedComments(for: test)
       } else {
         [
           Message(
             symbol: .pass(knownIssueCount: issues.knownIssueCount),
-            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfArguments(test, verbose: verbosity)) passed after \(duration)\(issues.description)."
+            stringValue: "\(_capitalizedTitle(for: test)) \(testName)\(_includeNumberOfTestCases(for: test, verbose: verbosity)) passed after \(duration)\(issues.description)."
           )
         ]
       }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -149,7 +149,6 @@ extension Event.HumanReadableOutputRecorder {
 
     return (errorIssueCount, warningIssueCount, knownIssueCount, totalIssueCount,  description)
   }
-
 }
 
 /// Generate a title for the specified test (either "Test" or "Suite"),

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -183,14 +183,14 @@ struct EventRecorderTests {
   @Test(
     "number of arguments based on verbosity level at the end of test run",
     arguments: [
-      ("f()", #".* Test f\(\) failed after .*"# ,  0),
-      ("f()", #".* Test f\(\) failed after .*"# ,  2),
-      ("d(_:)", #".* Test d\(_:\) with .+ test cases passed after.*"# , 2),
-      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"# , 1),
-      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"# , 2),
+      ("f()", #".* Test f\(\) failed after .*"#, 0),
+      ("f()", #".* Test f\(\) failed after .*"#, 2),
+      ("d(_:)", #".* Test d\(_:\) with .+ test cases passed after.*"#, 2),
+      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"#, 1),
+      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"#, 2),
     ]
   )
-  func numberOfArgumentsAtTheEndOfTests(testName: String, expectedPattern: String, verbosity: Int) async throws {
+  func numberOfTestsCasesAtTestEnd(testName: String, expectedPattern: String, verbosity: Int) async throws {
     let stream = Stream()
 
     var configuration = Configuration()

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -183,9 +183,11 @@ struct EventRecorderTests {
   @Test(
     "number of arguments based on verbosity level at the end of test run",
     arguments: [
-      ("f()", #".*"# ,  0),
-      ("g()", #".* with .+ argument.*"# , 2),
-      ("PredictablyFailingTests", #".*"# , 1),
+      ("f()", #".* Test f\(\) failed after .*"# ,  0),
+      ("f()", #".* Test f\(\) with 1 test case failed after .*"# ,  2),
+      ("d(_:)", #".* Test d\(_:\) with .+ test cases passed after.*"# , 2),
+      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"# , 1),
+      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"# , 2),
     ]
   )
   func numberOfArgumentsAtTheEndOfTests(testName: String, expectedPattern: String, verbosity: Int) async throws {
@@ -206,8 +208,9 @@ struct EventRecorderTests {
     }
 
     let aurgmentRegex = try Regex(expectedPattern)
+    
     #expect(
-      (try? buffer
+      (try buffer
         .split(whereSeparator: \.isNewline)
         .compactMap(aurgmentRegex.wholeMatch(in:))
         .first) != nil
@@ -572,6 +575,11 @@ struct EventRecorderTests {
       #expect(Bool(false))
     }
   }
+  
+  @Test(.hidden, arguments: [1, 2, 3])
+  func d(_ arg: Int) {
+    #expect(arg > 0)
+  }
 
   @Test(.hidden) func g() {
     #expect(Bool(false))
@@ -602,3 +610,4 @@ struct EventRecorderTests {
     }
   }
 }
+

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -184,6 +184,7 @@ struct EventRecorderTests {
     "number of arguments based on verbosity level at the end of test run",
     arguments: [
       ("f()", #".* Test f\(\) failed after .*"#),
+      ("h()", #".* Test h\(\) passed after .+"#),
       ("l(_:)", #".* Test l\(_:\) with .+ test cases passed after.*"#),
       ("m(_:)", #".* Test m\(_:\) with .+ test cases failed after.*"#),
       ("n(_:)", #".* Test n\(_:\) with .+ test case passed after.*"#),

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -217,7 +217,6 @@ struct EventRecorderTests {
     )
   }
 
-
   @available(_regexAPI, *)
   @Test(
     "Issue counts are summed correctly on test end",
@@ -610,4 +609,3 @@ struct EventRecorderTests {
     }
   }
 }
-

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -181,7 +181,7 @@ struct EventRecorderTests {
   
   @available(_regexAPI, *)
   @Test(
-    "number of arguments based on verbosity level at the end of test run",
+    "Log the total number of test cases in parameterized tests at the end of the test run",
     arguments: [
       ("f()", #".* Test f\(\) failed after .*"#),
       ("h()", #".* Test h\(\) passed after .+"#),
@@ -191,7 +191,7 @@ struct EventRecorderTests {
       ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"#),
     ]
   )
-  func numberOfTestsCasesAtTestEnd(testName: String, expectedPattern: String) async throws {
+  func numberOfTestCasesAtTestEnd(testName: String, expectedPattern: String) async throws {
     let stream = Stream()
 
     var configuration = Configuration()

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -183,14 +183,14 @@ struct EventRecorderTests {
   @Test(
     "number of arguments based on verbosity level at the end of test run",
     arguments: [
-      ("f()", #".* Test f\(\) failed after .*"#, 0),
-      ("f()", #".* Test f\(\) failed after .*"#, 2),
-      ("d(_:)", #".* Test d\(_:\) with .+ test cases passed after.*"#, 2),
-      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"#, 1),
-      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"#, 2),
+      ("f()", #".* Test f\(\) failed after .*"#),
+      ("l(_:)", #".* Test l\(_:\) with .+ test cases passed after.*"#),
+      ("m(_:)", #".* Test m\(_:\) with .+ test cases failed after.*"#),
+      ("n(_:)", #".* Test n\(_:\) with .+ test case passed after.*"#),
+      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"#),
     ]
   )
-  func numberOfTestsCasesAtTestEnd(testName: String, expectedPattern: String, verbosity: Int) async throws {
+  func numberOfTestsCasesAtTestEnd(testName: String, expectedPattern: String) async throws {
     let stream = Stream()
 
     var configuration = Configuration()
@@ -198,7 +198,6 @@ struct EventRecorderTests {
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
-    configuration.verbosity = verbosity
 
     await runTest(for: PredictablyFailingTests.self, configuration: configuration)
 
@@ -227,7 +226,7 @@ struct EventRecorderTests {
       ("i()", #".* Test i\(\) failed after .+ seconds with 2 issues \(including 1 warning\)\."#),
       ("j()", #".* Test j\(\) passed after .+ seconds with 1 warning and 1 known issue\."#),
       ("k()", #".* Test k\(\) passed after .+ seconds with 1 known issue\."#),
-      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .+ seconds with 13 issues \(including 3 warnings and 6 known issues\)\."#),
+      ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .+ seconds with 16 issues \(including 3 warnings and 6 known issues\)\."#),
     ]
   )
   func issueCountSummingAtTestEnd(testName: String, expectedPattern: String) async throws {
@@ -322,7 +321,7 @@ struct EventRecorderTests {
         .compactMap(runFailureRegex.wholeMatch(in:))
         .first
     )
-    #expect(match.output.1 == 9)
+    #expect(match.output.1 == 12)
     #expect(match.output.2 == 5)
   }
 
@@ -574,11 +573,6 @@ struct EventRecorderTests {
       #expect(Bool(false))
     }
   }
-  
-  @Test(.hidden, arguments: [1, 2, 3])
-  func d(_ arg: Int) {
-    #expect(arg > 0)
-  }
 
   @Test(.hidden) func g() {
     #expect(Bool(false))
@@ -607,5 +601,20 @@ struct EventRecorderTests {
     withKnownIssue {
       Issue(kind: .unconditional, severity: .warning, comments: [], sourceContext: .init()).record()
     }
+  }
+  
+  @Test(.hidden, arguments: [1, 2, 3])
+  func l(_ arg: Int) {
+    #expect(arg > 0)
+  }
+  
+  @Test(.hidden, arguments: [1, 2, 3])
+  func m(_ arg: Int) {
+      #expect(arg < 0)
+  }
+  
+  @Test(.hidden, arguments: [1])
+  func n(_ arg: Int) {
+    #expect(arg > 0)
   }
 }

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -184,7 +184,7 @@ struct EventRecorderTests {
     "number of arguments based on verbosity level at the end of test run",
     arguments: [
       ("f()", #".* Test f\(\) failed after .*"# ,  0),
-      ("f()", #".* Test f\(\) with 1 test case failed after .*"# ,  2),
+      ("f()", #".* Test f\(\) failed after .*"# ,  2),
       ("d(_:)", #".* Test d\(_:\) with .+ test cases passed after.*"# , 2),
       ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"# , 1),
       ("PredictablyFailingTests", #".* Suite PredictablyFailingTests failed after .*"# , 2),


### PR DESCRIPTION
### Motivation:

To have the number of test cases at the end of the test in for parameterized tests, so the logs don’t easily get buried.

### Modifications:

Log the number of test cases for parameterized tests at the end of a test.

### Result:

If the user runs the parameterized tests, an extra piece of information (with * test cases) would get bound to the end log.

Resolves #943.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
