### PR TITLE
Begin installing textual .swiftinterface instead of binary .swiftmodule in toolchain builds for non-Apple platforms

### DIFF
--- a/cmake/modules/SwiftModuleInstallation.cmake
+++ b/cmake/modules/SwiftModuleInstallation.cmake
@@ -86,19 +86,9 @@ function(_swift_testing_install_target module)
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
     DESTINATION "${module_dir}"
     RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftdoc)
-  if(APPLE)
-    # Only Darwin has stable ABI. 
-    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftinterface
-      DESTINATION "${module_dir}"
-      RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftinterface)
-  else()
-    # Only install the binary .swiftmodule on platforms which do not have a
-    # stable ABI. Other platforms will use the textual .swiftinterface
-    # (installed above) and this limits access to this module's SPIs.
-    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
-      DESTINATION "${module_dir}"
-      RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftmodule)
-  endif()
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftinterface
+    DESTINATION "${module_dir}"
+    RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftinterface)
 endfunction()
 
 # Install the specified .swiftcrossimport directory for the specified declaring


### PR DESCRIPTION
This modifies the CMake rules to begin installing textual .swiftinterface files instead of binary .swiftmodule files when performing a toolchain build for non-Apple platforms.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Fixes rdar://140587787
