### PR TITLE
JUnit XML recorder should ignore warning issues

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -122,7 +122,7 @@ extension Event.JUnitXMLRecorder {
       }
       return nil
     case let .issueRecorded(issue):
-      if issue.isKnown {
+      if issue.isKnown || issue.severity < .error {
         return nil
       }
       if let id = test?.id {

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -467,15 +467,18 @@ struct EventRecorderTests {
   @Test("JUnitXMLRecorder counts issues without associated tests")
   func junitRecorderCountsIssuesWithoutTests() async throws {
     let issue = Issue(kind: .unconditional)
-    let event = Event(.issueRecorded(issue), testID: nil, testCaseID: nil)
     let context = Event.Context(test: nil, testCase: nil, configuration: nil)
 
-    let recorder = Event.JUnitXMLRecorder { string in
-      if string.contains("<testsuite") {
-        #expect(string.contains(#"failures=1"#))
+    await confirmation { wroteTestSuite in
+      let recorder = Event.JUnitXMLRecorder { string in
+        if string.contains("<testsuite ") {
+          #expect(string.contains(#"failures="1""#))
+          wroteTestSuite()
+        }
       }
+      recorder.record(Event(.issueRecorded(issue), testID: nil, testCaseID: nil), in: context)
+      recorder.record(Event(.runEnded, testID: nil, testCaseID: nil), in: context)
     }
-    _ = recorder.record(event, in: context)
   }
 
   @Test("JUnitXMLRecorder ignores warning issues")

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -477,6 +477,23 @@ struct EventRecorderTests {
     }
     _ = recorder.record(event, in: context)
   }
+
+  @Test("JUnitXMLRecorder ignores warning issues")
+  func junitRecorderIgnoresWarningIssues() async throws {
+    let issue = Issue(kind: .unconditional, severity: .warning)
+    let context = Event.Context(test: nil, testCase: nil, configuration: nil)
+
+    await confirmation { wroteTestSuite in
+      let recorder = Event.JUnitXMLRecorder { string in
+        if string.contains("<testsuite ") {
+          #expect(string.contains(#"failures="0""#))
+          wroteTestSuite()
+        }
+      }
+      recorder.record(Event(.issueRecorded(issue), testID: nil, testCaseID: nil), in: context)
+      recorder.record(Event(.runEnded, testID: nil, testCaseID: nil), in: context)
+    }
+  }
 }
 
 // MARK: - Fixtures

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 #if canImport(XCTest)
 import XCTest
 #endif
@@ -368,8 +368,8 @@ extension Trait where Self == TimeLimitTrait {
 }
 
 extension Issue {
-  init(kind: Kind, sourceContext: SourceContext = .init()) {
-    self.init(kind: kind, comments: [], sourceContext: sourceContext)
+  init(kind: Kind, severity: Severity = .error, sourceContext: SourceContext = .init()) {
+    self.init(kind: kind, severity: severity, comments: [], sourceContext: sourceContext)
   }
 }
 


### PR DESCRIPTION
This updates `Event.JUnitXMLRecorder` to ignore `Issue` instances whose `severity` is less than `.error` (such as `.warning`).

### Motivation:

The concept of issue severity was recently added in #931 (but was reverted and re-landed in #952), and that did not adjust the JUnit XML recorder logic. The JUnit XML schema we currently attempt to adhere to does not appear to have a way to represent non-fatal issues, so I think it would be best for now to ignore these issues.

### Modifications:

- Implement the fix and a validating unit test.
- (Drive-by) Fix a nearby test I noticed wasn't actually working as intended and wasn't properly validating the fix it was intended to.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
