### PR TITLE
Suppress `.unsafeFlags()` in Package.swift when tagging for release.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let git = Context.gitInformation
 
 /// Whether or not this package is being built for development rather than
 /// distribution as a package dependency.
-let buildingForDevelopment = (git?.currentTag != nil)
+let buildingForDevelopment = (git?.currentTag == nil)
 
 let package = Package(
   name: "swift-testing",


### PR DESCRIPTION
This PR removes the unsafe flags we specify in our Package.swift manifest when the package has been tagged in Git (which indicates it's a release or prerelease.) This allows a package to add Swift Testing as a package dependency without breaking its own ability to be added as a package dependency due to the use of unsafe flags.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
