### PR TITLE
build: update missed callsites of `get_swift_testing_install_lib_dir`

### DIFF
--- a/Sources/_TestDiscovery/CMakeLists.txt
+++ b/Sources/_TestDiscovery/CMakeLists.txt
@@ -26,7 +26,6 @@ if(NOT BUILD_SHARED_LIBS)
   # When building a static library, install the internal library archive
   # alongside the main library. In shared library builds, the internal library
   # is linked into the main library and does not need to be installed separately.
-  get_swift_testing_install_lib_dir(STATIC_LIBRARY lib_destination_dir)
   install(TARGETS _TestDiscovery
-    ARCHIVE DESTINATION ${lib_destination_dir})
+    ARCHIVE DESTINATION "${SwiftTesting_INSTALL_LIBDIR}")
 endif()

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -32,7 +32,6 @@ if(NOT BUILD_SHARED_LIBS)
   # When building a static library, install the internal library archive
   # alongside the main library. In shared library builds, the internal library
   # is linked into the main library and does not need to be installed separately.
-  get_swift_testing_install_lib_dir(STATIC_LIBRARY lib_destination_dir)
   install(TARGETS _TestingInternals
-    ARCHIVE DESTINATION ${lib_destination_dir})
+    ARCHIVE DESTINATION "${SwiftTesting_INSTALL_LIBDIR}")
 endif()


### PR DESCRIPTION
This has been replaced with a global variable. Update the callsites to use that instead.