### PR TITLE
Represent non-encodable test argument values in Test.Case.ID

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -124,9 +124,13 @@ extension ABI {
     var displayName: String
 
     init(encoding testCase: borrowing Test.Case) {
+      guard let arguments = testCase.arguments else {
+        preconditionFailure("Attempted to initialize an EncodedTestCase encoding a test case which is not parameterized: \(testCase)")
+      }
+
       // TODO: define an encodable form of Test.Case.ID
       id = String(describing: testCase.id)
-      displayName = testCase.arguments.lazy
+      displayName = arguments.lazy
         .map(\.value)
         .map(String.init(describingForTest:))
         .joined(separator: ", ")

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -125,7 +125,7 @@ extension ABI {
 
     init(encoding testCase: borrowing Test.Case) {
       guard let arguments = testCase.arguments else {
-        preconditionFailure("Attempted to initialize an EncodedTestCase encoding a test case which is not parameterized: \(testCase)")
+        preconditionFailure("Attempted to initialize an EncodedTestCase encoding a test case which is not parameterized: \(testCase). Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
       }
 
       // TODO: define an encodable form of Test.Case.ID

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -171,8 +171,12 @@ extension Test.Case {
   /// - Parameters:
   ///   - includeTypeNames: Whether the qualified type name of each argument's
   ///     runtime type should be included. Defaults to `false`.
+  ///
+  /// - Returns: A string containing the arguments of this test case formatted
+  ///   for presentation, or an empty string if this test cases is
+  ///   non-parameterized.
   fileprivate func labeledArguments(includingQualifiedTypeNames includeTypeNames: Bool = false) -> String {
-    arguments.lazy
+    (arguments ?? []).lazy
       .map { argument in
         let valueDescription = String(describingForTest: argument.value)
 
@@ -494,14 +498,14 @@ extension Event.HumanReadableOutputRecorder {
       return result
 
     case .testCaseStarted:
-      guard let testCase = eventContext.testCase, testCase.isParameterized else {
+      guard let testCase = eventContext.testCase, testCase.isParameterized, let arguments = testCase.arguments else {
         break
       }
 
       return [
         Message(
           symbol: .default,
-          stringValue: "Passing \(testCase.arguments.count.counting("argument")) \(testCase.labeledArguments(includingQualifiedTypeNames: verbosity > 0)) to \(testName)"
+          stringValue: "Passing \(arguments.count.counting("argument")) \(testCase.labeledArguments(includingQualifiedTypeNames: verbosity > 0)) to \(testName)"
         )
       ]
 

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -176,7 +176,9 @@ extension Test.Case {
   ///   for presentation, or an empty string if this test cases is
   ///   non-parameterized.
   fileprivate func labeledArguments(includingQualifiedTypeNames includeTypeNames: Bool = false) -> String {
-    (arguments ?? []).lazy
+    guard let arguments else { return "" }
+
+    return arguments.lazy
       .map { argument in
         let valueDescription = String(describingForTest: argument.value)
 

--- a/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
+++ b/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
@@ -43,76 +43,57 @@ public protocol CustomTestArgumentEncodable: Sendable {
   func encodeTestArgument(to encoder: some Encoder) throws
 }
 
-/// Get the best encodable representation of a test argument value, if any.
-///
-/// - Parameters:
-///   - value: The value for which an encodable representation is requested.
-///
-/// - Returns: The best encodable representation of `value`, if one is available,
-///   otherwise `nil`.
-///
-/// For a description of the heuristics used to obtain an encodable
-/// representation of an argument value, see <doc:ParameterizedTesting>.
-func encodableArgumentValue(for value: some Sendable) -> (any Encodable)? {
-#if canImport(Foundation)
-  // Helper for opening an existential.
-  func customArgumentWrapper(for value: some CustomTestArgumentEncodable) -> some Encodable {
-    _CustomArgumentWrapper(rawValue: value)
-  }
-
-  return if let customEncodable = value as? any CustomTestArgumentEncodable {
-    customArgumentWrapper(for: customEncodable)
-  } else if let rawRepresentable = value as? any RawRepresentable, let encodableRawValue = rawRepresentable.rawValue as? any Encodable {
-    encodableRawValue
-  } else if let encodable = value as? any Encodable {
-    encodable
-  } else if let identifiable = value as? any Identifiable, let encodableID = identifiable.id as? any Encodable {
-    encodableID
-  } else {
-    nil
-  }
-#else
-  return nil
-#endif
-}
-
 extension Test.Case.Argument.ID {
-  /// Initialize this instance with an ID for the specified test argument.
+  /// Initialize an ID instance with the specified test argument value.
   ///
   /// - Parameters:
   ///   - value: The value of a test argument for which to get an ID.
-  ///   - encodableValue: An encodable representation of `value`, if any, with
-  ///     which to attempt to encode a stable representation.
   ///   - parameter: The parameter of the test function to which this argument
   ///     value was passed.
   ///
-  /// If a representation of `value` can be successfully encoded, the value of
-  /// this instance's `bytes` property will be the the bytes of that encoded
-  /// JSON representation and the value of its `isStable` property will be
-  /// `true`. Otherwise, the value of its `bytes` property will be the bytes of
-  /// a textual description of `value` and the value of `isStable` will be
-  /// `false` to reflect that the representation is not considered stable.
+  /// - Returns: `nil` if a stable ID cannot be formed from the specified test
+  ///   argument value.
+  ///
+  /// - Throws: Any error encountered while attempting to encode `value`.
+  ///
+  /// If a stable representation of `value` can be encoded successfully, the
+  /// value of this instance's `bytes` property will be the the bytes of that
+  /// encoded JSON representation and this instance may be considered stable. If
+  /// no stable representation of `value` can be obtained, `nil` is returned. If
+  /// a stable representation was obtained but failed to encode, the error
+  /// resulting from the encoding attempt is thrown.
   ///
   /// This function is not part of the public interface of the testing library.
   ///
   /// ## See Also
   ///
   /// - ``CustomTestArgumentEncodable``
-  init(identifying value: some Sendable, encodableValue: (any Encodable)?, parameter: Test.Parameter) {
+  init?(identifying value: some Sendable, parameter: Test.Parameter) throws {
 #if canImport(Foundation)
-    if let encodableValue {
-      do {
-        self = .init(bytes: try Self._encode(encodableValue, parameter: parameter), isStable: true)
-        return
-      } catch {
-        // FIXME: Capture the error and propagate to the user, not as a test
-        // failure but as an advisory warning. A missing argument ID will
-        // prevent re-running the test case, but is not a blocking issue.
-      }
+    func customArgumentWrapper(for value: some CustomTestArgumentEncodable) -> some Encodable {
+      _CustomArgumentWrapper(rawValue: value)
     }
-#endif
 
-    self = .init(bytes: String(describingForTest: value).utf8, isStable: false)
+    let encodableValue: (any Encodable)? = if let customEncodable = value as? any CustomTestArgumentEncodable {
+      customArgumentWrapper(for: customEncodable)
+    } else if let rawRepresentable = value as? any RawRepresentable, let encodableRawValue = rawRepresentable.rawValue as? any Encodable {
+      encodableRawValue
+    } else if let encodable = value as? any Encodable {
+      encodable
+    } else if let identifiable = value as? any Identifiable, let encodableID = identifiable.id as? any Encodable {
+      encodableID
+    } else {
+      nil
+    }
+
+    guard let encodableValue else {
+      return nil
+    }
+
+    self.init(bytes: try Self._encode(encodableValue, parameter: parameter))
+#else
+    nil
+#endif
   }
 
 #if canImport(Foundation)

--- a/Sources/Testing/Parameterization/Test.Case.Generator.swift
+++ b/Sources/Testing/Parameterization/Test.Case.Generator.swift
@@ -257,10 +257,12 @@ extension Test.Case {
 
 extension Test.Case.Generator: Sequence {
   func makeIterator() -> some IteratorProtocol<Test.Case> {
-    sequence(state: (
+    let state = (
       iterator: _sequence.makeIterator(),
-      testCaseIDs: [Test.Case.ID: Int]()
-    )) { state in
+      testCaseIDs: [Test.Case.ID: Int](minimumCapacity: underestimatedCount)
+    )
+
+    return sequence(state: state) { state in
       guard let element = state.iterator.next() else {
         return nil
       }

--- a/Sources/Testing/Parameterization/Test.Case.Generator.swift
+++ b/Sources/Testing/Parameterization/Test.Case.Generator.swift
@@ -267,14 +267,17 @@ extension Test.Case.Generator: Sequence {
 
       var testCase = _mapElement(element)
 
-      // Store the original, unmodified test case ID. We're about to modify a
-      // property which affects it, and we want to update state based on the
-      // original one.
-      let testCaseID = testCase.id
+      if testCase.isParameterized {
+        // Store the original, unmodified test case ID. We're about to modify a
+        // property which affects it, and we want to update state based on the
+        // original one.
+        let testCaseID = testCase.id
 
-      // Ensure test cases with identical IDs each have a unique discriminator.
-      testCase.discriminator = state.testCaseIDs[testCaseID, default: 0]
-      state.testCaseIDs[testCaseID] = testCase.discriminator + 1
+        // Ensure test cases with identical IDs each have a unique discriminator.
+        let discriminator = state.testCaseIDs[testCaseID, default: 0]
+        testCase.discriminator = discriminator
+        state.testCaseIDs[testCaseID] = discriminator + 1
+      }
 
       return testCase
     }

--- a/Sources/Testing/Parameterization/Test.Case.ID.swift
+++ b/Sources/Testing/Parameterization/Test.Case.ID.swift
@@ -127,4 +127,4 @@ extension Test.Case.ID: Codable {
 
 // MARK: - Equatable, Hashable
 
-extension Test.Case.ID: Hashable {}
+extension Test.Case.ID: Equatable, Hashable {}

--- a/Sources/Testing/Parameterization/Test.Case.ID.swift
+++ b/Sources/Testing/Parameterization/Test.Case.ID.swift
@@ -72,7 +72,7 @@ extension Test.Case.ID: CustomStringConvertible {
 // MARK: - Codable
 
 extension Test.Case.ID: Codable {
-  public init(from decoder: some Decoder) throws {
+  public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
     // The `argumentIDs` property is Optional but the meaning of `nil` has

--- a/Sources/Testing/Parameterization/Test.Case.ID.swift
+++ b/Sources/Testing/Parameterization/Test.Case.ID.swift
@@ -18,17 +18,25 @@ extension Test.Case {
   public struct ID: Sendable {
     /// The IDs of the arguments of this instance's associated ``Test/Case``, in
     /// the order they appear in ``Test/Case/arguments``.
-    public var argumentIDs: [Argument.ID]
+    ///
+    /// The value of this property is `nil` for the ID of the single test case
+    /// associated with a non-parameterized test function.
+    public var argumentIDs: [Argument.ID]?
 
     /// A number used to distinguish this test case from others associated with
-    /// the same test function whose arguments have the same ID.
+    /// the same parameterized test function whose arguments have the same ID.
+    ///
+    /// The value of this property is `nil` for the ID of the single test case
+    /// associated with a non-parameterized test function.
     ///
     /// ## See Also
     ///
     /// - ``Test/Case/discriminator``
-    public var discriminator: Int
+    public var discriminator: Int?
 
-    public init(argumentIDs: [Argument.ID], discriminator: Int) {
+    init(argumentIDs: [Argument.ID]?, discriminator: Int?) {
+      precondition((argumentIDs == nil) == (discriminator == nil))
+
       self.argumentIDs = argumentIDs
       self.discriminator = discriminator
     }
@@ -39,13 +47,13 @@ extension Test.Case {
     /// The value of this property is `true` if all of the argument IDs for this
     /// instance are stable, otherwise it is `false`.
     public var isStable: Bool {
-      argumentIDs.allSatisfy(\.isStable)
+      (argumentIDs ?? []).allSatisfy(\.isStable)
     }
   }
 
   @_spi(ForToolsIntegrationOnly)
   public var id: ID {
-    ID(argumentIDs: arguments.map(\.id), discriminator: discriminator)
+    ID(argumentIDs: arguments.map { $0.map(\.id) }, discriminator: discriminator)
   }
 }
 
@@ -53,7 +61,11 @@ extension Test.Case {
 
 extension Test.Case.ID: CustomStringConvertible {
   public var description: String {
-    "argumentIDs: \(argumentIDs), discriminator: \(discriminator)"
+    if let argumentIDs, let discriminator {
+      "argumentIDs: \(argumentIDs), discriminator: \(discriminator)"
+    } else {
+      "non-parameterized"
+    }
   }
 }
 
@@ -63,18 +75,53 @@ extension Test.Case.ID: Codable {
   public init(from decoder: some Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    // The `argumentIDs` property was optional when this type was first
-    // introduced, and a `nil` value represented a non-stable test case ID.
-    // To maintain previous behavior, if this value is absent when decoding,
-    // default to a single argument ID marked as non-stable.
-    let argumentIDs = try container.decodeIfPresent([Test.Case.Argument.ID].self, forKey: .argumentIDs)
-      ?? [Test.Case.Argument.ID(bytes: [], isStable: false)]
+    // The `argumentIDs` property is Optional but the meaning of `nil` has
+    // changed since this type was first introduced: it now identifies a
+    // non-parameterized test case, whereas it originally identified a
+    // parameterized test case for which one or more arguments could not be
+    // encoded. If it's present in the decoding container, accept whatever value
+    // is decoded (which may be `nil`). If it's absent, default to a single
+    // argument ID marked as non-stable to maintain previous behavior.
+    let argumentIDs: [Test.Case.Argument.ID]? = if container.contains(.argumentIDs) {
+      try container.decode(type(of: argumentIDs), forKey: .argumentIDs)
+    } else {
+      [Test.Case.Argument.ID(bytes: [], isStable: false)]
+    }
 
     // The `discriminator` property was added after this type was first
-    // introduced. It can safely default to zero when absent.
-    let discriminator = try container.decodeIfPresent(type(of: discriminator), forKey: .discriminator) ?? 0
+    // introduced. If it's present in the decoding container, accept whatever
+    // value is decoded (which may be `nil`). If it's absent, default to `nil`
+    // if `argumentIDs` was interpreted as a non-parameterized test above, or
+    // else 0, to maintain previous behavior.
+    let discriminator: Int? = if container.contains(.discriminator) {
+      try container.decode(type(of: discriminator), forKey: .discriminator)
+    } else {
+      if let argumentIDs {
+        argumentIDs.isEmpty ? nil : 0
+      } else {
+        nil
+      }
+    }
 
     self.init(argumentIDs: argumentIDs, discriminator: discriminator)
+  }
+
+  public func encode(to encoder: some Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    // The `argumentIDs` property is Optional but the meaning of `nil` has
+    // changed since this type was first introduced: it now identifies a
+    // non-parameterized test case, whereas it originally identified a
+    // parameterized test case for which one or more arguments could not be
+    // encoded. Explicitly encode `nil` values here, rather than omitting them,
+    // so that when decoding we can distinguish these two scenarios.
+    try container.encode(argumentIDs, forKey: .argumentIDs)
+
+    // The `discriminator` property was added after this type was first
+    // introduced. Explicitly encode `nil` values here, rather than omitting
+    // them, so that when decoding we can distinguish the older vs. newer
+    // implementations.
+    try container.encode(discriminator, forKey: .discriminator)
   }
 }
 

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -293,16 +293,6 @@ extension Test.Case.Argument.ID: Codable {
 
 // MARK: - Equatable, Hashable
 
-extension Test.Case: Equatable, Hashable {
-  public static func ==(lhs: Test.Case, rhs: Test.Case) -> Bool {
-    lhs.id == rhs.id
-  }
-
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(id)
-  }
-}
-
 extension Test.Parameter: Hashable {}
 extension Test.Case.Argument.ID: Hashable {}
 

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -340,8 +340,8 @@ extension Test.Case.Argument {
   /// A serializable snapshot of a ``Test/Case/Argument`` instance.
   @_spi(ForToolsIntegrationOnly)
   public struct Snapshot: Sendable, Codable {
-    /// The ID of this parameterized test argument.
-    public var id: Test.Case.Argument.ID
+    /// The ID of this parameterized test argument, if any.
+    public var id: Test.Case.Argument.ID?
 
     /// A representation of this parameterized test argument's
     /// ``Test/Case/Argument/value`` property.
@@ -359,20 +359,6 @@ extension Test.Case.Argument {
       id = argument.id
       value = Expression.Value(reflecting: argument.value) ?? .init(describing: argument.value)
       parameter = argument.parameter
-    }
-
-    public init(from decoder: some Decoder) throws {
-      let container = try decoder.container(keyedBy: CodingKeys.self)
-
-      // The `id` property was optional when this type was first introduced,
-      // and a `nil` value represented an argument whose ID was non-stable.
-      // To maintain previous behavior, if this value is absent when decoding,
-      // default to an argument ID marked as non-stable.
-      id = try container.decodeIfPresent(Test.Case.Argument.ID.self, forKey: .id)
-        ?? ID(bytes: [], isStable: false)
-
-      value = try container.decode(type(of: value), forKey: .value)
-      parameter = try container.decode(type(of: parameter), forKey: .parameter)
     }
   }
 }

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -276,8 +276,9 @@ extension Test {
 // MARK: - Codable
 
 extension Test.Parameter: Codable {}
+
 extension Test.Case.Argument.ID: Codable {
-  public init(from decoder: some Decoder) throws {
+  public init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
     // The `isStable` property was added after this type was introduced.

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -293,7 +293,7 @@ extension Test.Case.Argument.ID: Codable {
 
 // MARK: - Equatable, Hashable
 
-extension Test.Case: Hashable {
+extension Test.Case: Equatable, Hashable {
   public static func ==(lhs: Test.Case, rhs: Test.Case) -> Bool {
     lhs.id == rhs.id
   }
@@ -331,7 +331,11 @@ extension Test.Case {
     ///   - testCase: The original test case to snapshot.
     public init(snapshotting testCase: borrowing Test.Case) {
       id = testCase.id
-      arguments = (testCase.arguments ?? []).map(Test.Case.Argument.Snapshot.init)
+      arguments = if let arguments = testCase.arguments {
+        arguments.map(Test.Case.Argument.Snapshot.init)
+      } else {
+        []
+      }
     }
   }
 }

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -57,7 +57,7 @@ struct EventTests {
     let testID = Test.ID(moduleName: "ModuleName",
                          nameComponents: ["NameComponent1", "NameComponent2"],
                          sourceLocation: #_sourceLocation)
-    let testCaseID = Test.Case.ID(argumentIDs: [], discriminator: 0)
+    let testCaseID = Test.Case.ID(argumentIDs: nil, discriminator: nil)
     let event = Event(kind, testID: testID, testCaseID: testCaseID, instant: .now)
     let eventSnapshot = Event.Snapshot(snapshotting: event)
     let decoded = try JSON.encodeAndDecode(eventSnapshot)

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -57,7 +57,7 @@ struct EventTests {
     let testID = Test.ID(moduleName: "ModuleName",
                          nameComponents: ["NameComponent1", "NameComponent2"],
                          sourceLocation: #_sourceLocation)
-    let testCaseID = Test.Case.ID(argumentIDs: nil, discriminator: nil)
+    let testCaseID = Test.Case.ID(argumentIDs: nil, discriminator: nil, isStable: true)
     let event = Event(kind, testID: testID, testCaseID: testCaseID, instant: .now)
     let eventSnapshot = Event.Snapshot(snapshotting: event)
     let decoded = try JSON.encodeAndDecode(eventSnapshot)

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -57,7 +57,7 @@ struct EventTests {
     let testID = Test.ID(moduleName: "ModuleName",
                          nameComponents: ["NameComponent1", "NameComponent2"],
                          sourceLocation: #_sourceLocation)
-    let testCaseID = Test.Case.ID(argumentIDs: nil)
+    let testCaseID = Test.Case.ID(argumentIDs: [], discriminator: 0)
     let event = Event(kind, testID: testID, testCaseID: testCaseID, instant: .now)
     let eventSnapshot = Event.Snapshot(snapshotting: event)
     let decoded = try JSON.encodeAndDecode(eventSnapshot)

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -20,10 +20,10 @@ struct Test_Case_Argument_IDTests {
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
-    #expect(testCase.arguments.count == 1)
-    let argument = try #require(testCase.arguments.first)
-    let argumentID = try #require(argument.id)
-    #expect(String(decoding: argumentID.bytes, as: UTF8.self) == "123")
+    let arguments = try #require(testCase.arguments)
+    #expect(arguments.count == 1)
+    let argument = try #require(arguments.first)
+    #expect(String(decoding: argument.id.bytes, as: UTF8.self) == "123")
   }
 
   @Test("One CustomTestArgumentEncodable parameter")
@@ -34,11 +34,11 @@ struct Test_Case_Argument_IDTests {
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
-    #expect(testCase.arguments.count == 1)
-    let argument = try #require(testCase.arguments.first)
-    let argumentID = try #require(argument.id)
+    let arguments = try #require(testCase.arguments)
+    #expect(arguments.count == 1)
+    let argument = try #require(arguments.first)
 #if canImport(Foundation)
-    let decodedArgument = try argumentID.bytes.withUnsafeBufferPointer { argumentID in
+    let decodedArgument = try argument.id.bytes.withUnsafeBufferPointer { argumentID in
       try JSON.decode(MyCustomTestArgument.self, from: .init(argumentID))
     }
     #expect(decodedArgument == MyCustomTestArgument(x: 123, y: "abc"))
@@ -53,10 +53,10 @@ struct Test_Case_Argument_IDTests {
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
-    #expect(testCase.arguments.count == 1)
-    let argument = try #require(testCase.arguments.first)
-    let argumentID = try #require(argument.id)
-    #expect(String(decoding: argumentID.bytes, as: UTF8.self) == #""abc""#)
+    let arguments = try #require(testCase.arguments)
+    #expect(arguments.count == 1)
+    let argument = try #require(arguments.first)
+    #expect(String(decoding: argument.id.bytes, as: UTF8.self) == #""abc""#)
   }
 
   @Test("One RawRepresentable parameter")
@@ -67,10 +67,10 @@ struct Test_Case_Argument_IDTests {
     ) { _ in }
     let testCases = try #require(test.testCases)
     let testCase = try #require(testCases.first { _ in true })
-    #expect(testCase.arguments.count == 1)
-    let argument = try #require(testCase.arguments.first)
-    let argumentID = try #require(argument.id)
-    #expect(String(decoding: argumentID.bytes, as: UTF8.self) == #""abc""#)
+    let arguments = try #require(testCase.arguments)
+    #expect(arguments.count == 1)
+    let argument = try #require(arguments.first)
+    #expect(String(decoding: argument.id.bytes, as: UTF8.self) == #""abc""#)
   }
 }
 

--- a/Tests/TestingTests/Test.Case.ArgumentTests.swift
+++ b/Tests/TestingTests/Test.Case.ArgumentTests.swift
@@ -19,10 +19,10 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
-      try #require(testCase.arguments.count == 1)
+      let arguments = try #require(context.testCase?.arguments)
+      try #require(arguments.count == 1)
 
-      let argument = testCase.arguments[0]
+      let argument = arguments[0]
       #expect(argument.value as? String == "value")
       #expect(argument.parameter.index == 0)
       #expect(argument.parameter.firstName == "x")
@@ -38,17 +38,17 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
-      try #require(testCase.arguments.count == 2)
+      let arguments = try #require(context.testCase?.arguments)
+      try #require(arguments.count == 2)
 
       do {
-        let argument = testCase.arguments[0]
+        let argument = arguments[0]
         #expect(argument.value as? String == "value")
         #expect(argument.parameter.index == 0)
         #expect(argument.parameter.firstName == "x")
       }
       do {
-        let argument = testCase.arguments[1]
+        let argument = arguments[1]
         #expect(argument.value as? Int == 123)
         #expect(argument.parameter.index == 1)
         #expect(argument.parameter.firstName == "y")
@@ -65,10 +65,10 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
-      try #require(testCase.arguments.count == 1)
+      let arguments = try #require(context.testCase?.arguments)
+      try #require(arguments.count == 1)
 
-      let argument = testCase.arguments[0]
+      let argument = arguments[0]
       #expect(argument.value as? (String) == ("value"))
       #expect(argument.parameter.index == 0)
       #expect(argument.parameter.firstName == "x")
@@ -84,10 +84,10 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
-      try #require(testCase.arguments.count == 1)
+      let arguments = try #require(context.testCase?.arguments)
+      try #require(arguments.count == 1)
 
-      let argument = testCase.arguments[0]
+      let argument = arguments[0]
       let value = try #require(argument.value as? (String, Int))
       #expect(value.0 == "value")
       #expect(value.1 == 123)
@@ -105,17 +105,17 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
-      try #require(testCase.arguments.count == 2)
+      let arguments = try #require(context.testCase?.arguments)
+      try #require(arguments.count == 2)
 
       do {
-        let argument = testCase.arguments[0]
+        let argument = arguments[0]
         #expect(argument.value as? String == "value")
         #expect(argument.parameter.index == 0)
         #expect(argument.parameter.firstName == "x")
       }
       do {
-        let argument = testCase.arguments[1]
+        let argument = arguments[1]
         #expect(argument.value as? Int == 123)
         #expect(argument.parameter.index == 1)
         #expect(argument.parameter.firstName == "y")
@@ -132,10 +132,10 @@ struct Test_Case_ArgumentTests {
       guard case .testCaseStarted = event.kind else {
         return
       }
-      let testCase = try #require(context.testCase)
-      try #require(testCase.arguments.count == 1)
+      let arguments = try #require(context.testCase?.arguments)
+      try #require(arguments.count == 1)
 
-      let argument = testCase.arguments[0]
+      let argument = arguments[0]
       let value = try #require(argument.value as? (String, Int))
       #expect(value.0 == "value")
       #expect(value.1 == 123)

--- a/Tests/TestingTests/Test.Case.GeneratorTests.swift
+++ b/Tests/TestingTests/Test.Case.GeneratorTests.swift
@@ -1,0 +1,31 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+@Suite("Test.Case.Generator Tests")
+struct Test_Case_GeneratorTests {
+  @Test func uniqueDiscriminators() throws {
+    let generator = Test.Case.Generator(
+      arguments: [1, 1, 1],
+      parameters: [Test.Parameter(index: 0, firstName: "x", type: Int.self)],
+      testFunction: { _ in }
+    )
+
+    let testCases = Array(generator)
+    #expect(testCases.count == 3)
+
+    let firstCase = try #require(testCases.first)
+    #expect(firstCase.id.discriminator == 0)
+
+    let discriminators = Set(testCases.map(\.id.discriminator))
+    #expect(discriminators.count == 3)
+  }
+}

--- a/Tests/TestingTests/Test.CaseTests.swift
+++ b/Tests/TestingTests/Test.CaseTests.swift
@@ -19,7 +19,8 @@ struct Test_CaseTests {
       body: {}
     )
     #expect(testCase.id.isStable)
-    #expect(testCase.arguments.allSatisfy { $0.id.isStable })
+    let arguments = try #require(testCase.arguments)
+    #expect(arguments.allSatisfy { $0.id.isStable })
   }
 
   @Test func twoStableArguments() throws {
@@ -32,7 +33,8 @@ struct Test_CaseTests {
       body: {}
     )
     #expect(testCase.id.isStable)
-    #expect(testCase.arguments.allSatisfy { $0.id.isStable })
+    let arguments = try #require(testCase.arguments)
+    #expect(arguments.allSatisfy { $0.id.isStable })
   }
 
   @Test("Two arguments: one non-stable, followed by one stable")
@@ -46,7 +48,8 @@ struct Test_CaseTests {
       body: {}
     )
     #expect(!testCase.id.isStable)
-    #expect(testCase.arguments.allSatisfy { !$0.id.isStable })
+    let arguments = try #require(testCase.arguments)
+    #expect(arguments.allSatisfy { !$0.id.isStable })
   }
 }
 

--- a/Tests/TestingTests/Test.CaseTests.swift
+++ b/Tests/TestingTests/Test.CaseTests.swift
@@ -1,0 +1,61 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+@Suite("Test.Case Tests")
+struct Test_CaseTests {
+  @Test func singleStableArgument() throws {
+    let testCase = Test.Case(
+      values: [1],
+      parameters: [Test.Parameter(index: 0, firstName: "x", type: Int.self)],
+      body: {}
+    )
+    #expect(testCase.id.isStable)
+    #expect(testCase.arguments.allSatisfy { $0.id.isStable })
+  }
+
+  @Test func twoStableArguments() throws {
+    let testCase = Test.Case(
+      values: [1, "a"],
+      parameters: [
+        Test.Parameter(index: 0, firstName: "x", type: Int.self),
+        Test.Parameter(index: 1, firstName: "y", type: String.self),
+      ],
+      body: {}
+    )
+    #expect(testCase.id.isStable)
+    #expect(testCase.arguments.allSatisfy { $0.id.isStable })
+  }
+
+  @Test("Two arguments: one non-stable, followed by one stable")
+  func nonStableAndStableArgument() throws {
+    let testCase = Test.Case(
+      values: [NonCodable(), IssueRecordingEncodable()],
+      parameters: [
+        Test.Parameter(index: 0, firstName: "x", type: NonCodable.self),
+        Test.Parameter(index: 1, firstName: "y", type: IssueRecordingEncodable.self),
+      ],
+      body: {}
+    )
+    #expect(!testCase.id.isStable)
+    #expect(testCase.arguments.allSatisfy { !$0.id.isStable })
+  }
+}
+
+// MARK: - Fixtures, helpers
+
+private struct NonCodable {}
+
+private struct IssueRecordingEncodable: Encodable {
+  func encode(to encoder: any Encoder) throws {
+    Issue.record("Unexpected attempt to encode an instance of \(Self.self)")
+  }
+}

--- a/Tests/TestingTests/TestCaseSelectionTests.swift
+++ b/Tests/TestingTests/TestCaseSelectionTests.swift
@@ -85,8 +85,9 @@ struct TestCaseSelectionTests {
     }
 
     let selectedTestCase = try #require(fixtureTest.testCases?.first { testCase in
-      guard let firstArg = testCase.arguments.first?.value as? String,
-            let secondArg = testCase.arguments.last?.value as? Int
+      guard let arguments = testCase.arguments,
+            let firstArg = arguments.first?.value as? String,
+            let secondArg = arguments.last?.value as? Int
       else {
         return false
       }

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -9,8 +9,13 @@
 //
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
 #if canImport(XCTest)
 import XCTest
+#endif
+
+#if canImport(Foundation)
+import Foundation
 #endif
 
 extension Tag {
@@ -348,6 +353,24 @@ extension JSON {
       try JSON.decode(T.self, from: data)
     }
   }
+
+#if canImport(Foundation)
+  /// Decode a value from JSON data.
+  ///
+  /// - Parameters:
+  ///   - type: The type of value to decode.
+  ///   - jsonRepresentation: Data of the JSON encoding of the value to decode.
+  ///
+  /// - Returns: An instance of `T` decoded from `jsonRepresentation`.
+  ///
+  /// - Throws: Whatever is thrown by the decoding process.
+  @_disfavoredOverload
+  static func decode<T>(_ type: T.Type, from jsonRepresentation: Data) throws -> T where T: Decodable {
+    try jsonRepresentation.withUnsafeBytes { bytes in
+      try JSON.decode(type, from: bytes)
+    }
+  }
+#endif
 }
 
 @available(_clockAPI, *)


### PR DESCRIPTION
This expands `Test.Case.ID` to represent combinations of arguments which aren't fully encodable, and uniquely distinguishes test cases associated with the same parameterized test function which have otherwise identical IDs.

### Motivation:

It is possible to declare a parameterized test function with a collection of arguments that includes the same element more than once. As a trivial example:

```swift
@Test(arguments: [1, 1])
func repeatedArg(value: Int) { ... }
```

This can happen in more realistic scenarios if you dynamically construct a collection of arguments that accidentally or intentionally includes the same value more than once.

The testing library attempts to form a unique identifier for each argument passed to a parameterized test. It does so by checking whether the value conforms to `Encodable`, or one of the other protocols mentioned in the documentation (see [Run selected test cases](https://swiftpackageindex.com/swiftlang/swift-testing/main/documentation/testing/parameterizedtesting#Run-selected-test-cases)).

One problem with the current implementation is that if the value _doesn't_ conform to one of those known protocols, the testing library gives up and doesn't produce a unique identifier for that test case at all. Specifically, in that situation the `argumentIDs` property of `Test.Case.ID` will have a value of `nil`.

Another problem is that if an argument is passed more than once, the derived identifiers for each argument's test case will be the same and the result reporting will be ambiguous at best; or worse, the lack of a unique identifier could cause an integrated tool to misbehave or crash. (Current versions of Xcode 16 experience this issue non-deterministically for projects which have test parallelization enabled.) To solve this, there needs to be a way to deterministically distinguish test cases which, from the testing library's perspective, appear identical—either because they actually are the same value, or because they encode to the same representation.

### Modifications:

- Add a new `isStable` boolean property to `Test.Case.Argument.ID` representing whether or not the testing library was able to encode a stable representation of the argument value it identifies.
- Add a new SPI property named `discriminator` to `Test.Case` which distinguishes test cases associated with the same test function whose arguments are identical.
- Add a corresponding property to `Test.Case.ID` with the same name, `discriminator`.
- Change the `Test.Case.ID.argumentIDs` property to non-Optional, so that it always has a value even if one or more argument IDs is non-stable.
- Add a derived boolean property `isStable` to `Test.Case.ID` whose value is `true` iff all of its argument IDs are stable.
- Add `Hashable` conformance to `Test.Case`, since the reason for avoiding such conformance has been resolved.
- Add new tests.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves #995
Resolves rdar://119522099
