### PR TITLE
Fix some broken links in Documentation

### DIFF
--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -13,7 +13,7 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 This document outlines the JSON schemas used by the testing library for its ABI
 entry point and for the `--event-stream-output-path` command-line argument. For
 more information about the ABI entry point, see the documentation for
-[ABI.v0.EntryPoint](https://github.com/search?q=repo%3Aapple%2Fswift-testing%EntryPoint&type=code).
+[ABI.v0.EntryPoint](https://github.com/search?q=repo%3Aswiftlang%2Fswift-testing%20EntryPoint&type=code).
 
 ## Modified Backus-Naur form
 

--- a/Documentation/WASI.md
+++ b/Documentation/WASI.md
@@ -14,7 +14,7 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 because it provides instructions the reader must follow directly. -->
 
 To run tests for WebAssembly, install a Swift SDK for WebAssembly by following
-[these instructions](https://book.swiftwasm.org/getting-started/setup-snapshot.html).
+[these instructions](https://book.swiftwasm.org/getting-started/setup.html).
 
 Because `swift test` doesn't know what WebAssembly environment you'd like to use
 to run your tests, building tests and running them are two separate steps. To

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -397,7 +397,7 @@ Wherever possible, prefer to use Swift concurrency to validate asynchronous
 conditions. For example, if it's necessary to determine the result of an
 asynchronous Swift function, it can be awaited with `await`. For a function that
 takes a completion handler but which doesn't use `await`, a Swift
-[continuation](https://developer.apple.com/documentation/swift/withcheckedcontinuation(function:_:))
+[continuation](https://developer.apple.com/documentation/swift/withcheckedcontinuation(isolation:function:_:))
 can be used to convert the call into an `async`-compatible one.
 
 Some tests, especially those that test asynchronously-delivered events, cannot


### PR DESCRIPTION
I periodically run a broken link checker over swiftlang repositories. There were a few links pointing to outdated locations in swift-testing.