### PR TITLE
Remove the "Result" section of this project's Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,10 +8,6 @@ _[Explain here the context, and why you're making that change. What is the probl
 
 _[Describe the modifications you've done.]_
 
-### Result:
-
-_[After your change, what will change.]_
-
 ### Checklist:
 
 - [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).


### PR DESCRIPTION
This removes the "Result" section from this project's GitHub Pull Request template.

### Motivation:

I frequently find that in practice, the other sections of the PR template cover the result our outcome of the PR already, so the result section isn't needed and I delete it.

### Result:

This section no longer exists! 😅 🪦

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
