### PR TITLE
Add ConditionTraitTests to cover the Swift 6.0 compiler issue for custom trait + closure + macro

### DIFF
--- a/Tests/TestingTests/Traits/ConditionTraitTests.swift
+++ b/Tests/TestingTests/Traits/ConditionTraitTests.swift
@@ -1,0 +1,44 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable import Testing
+
+@Suite("Condition Trait Tests", .tags(.traitRelated))
+struct ConditionTraitTests {
+  #if compiler(>=6.1)
+  @Test(
+    ".enabled trait",
+    .enabled { true },
+    .bug("https://github.com/swiftlang/swift/issues/76409", "Verify the custom trait with closure causes @Test macro to fail is fixed")
+  )
+  func enabledTraitClosure() throws {}
+  #endif
+
+  @Test(
+    ".enabled if trait",
+    .enabled(if: true)
+  )
+  func enabledTraitIf() throws {}
+
+  #if compiler(>=6.1)
+  @Test(
+    ".disabled trait",
+    .disabled { false },
+    .bug("https://github.com/swiftlang/swift/issues/76409", "Verify the custom trait with closure causes @Test macro to fail is fixed")
+  )
+  func disabledTraitClosure() throws {}
+  #endif
+
+  @Test(
+    ".disabled if trait",
+    .disabled(if: false)
+  )
+  func disabledTraitIf() throws {}
+}


### PR DESCRIPTION
See https://github.com/swiftlang/swift-testing/issues/1006#issuecomment-2708665563

### Motivation:

Add test case for avoid regression.

### Modifications:

Add ConditionTraitTests test case to cover it

### Result:

If will cause a compiler crash for Swift 6.0 compiler.

And it should work fine on the latest Swift 6.1 compiler. 

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
