### PR TITLE
Fix crash when loading test content records from the type metadata section.

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -469,10 +469,10 @@ extension ExitTestConditionMacro {
       // Create another local type for legacy test discovery.
       var recordDecl: DeclSyntax?
 #if !SWT_NO_LEGACY_TEST_DISCOVERY
-      let className = context.makeUniqueName("__🟡$")
+      let legacyEnumName = context.makeUniqueName("__🟡$")
       recordDecl = """
-      private final class \(className): Testing.__TestContentRecordContainer {
-        override nonisolated class var __testContentRecord: Testing.__TestContentRecord {
+      enum \(legacyEnumName): Testing.__TestContentRecordContainer {
+        nonisolated static var __testContentRecord: Testing.__TestContentRecord {
           \(enumName).testContentRecord
         }
       }

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -166,12 +166,12 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
 
 #if !SWT_NO_LEGACY_TEST_DISCOVERY
     // Emit a type that contains a reference to the test content record.
-    let className = context.makeUniqueName("__🟡$")
+    let enumName = context.makeUniqueName("__🟡$")
     result.append(
       """
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-      final class \(className): Testing.__TestContentRecordContainer {
-        override nonisolated class var __testContentRecord: Testing.__TestContentRecord {
+      enum \(enumName): Testing.__TestContentRecordContainer {
+        nonisolated static var __testContentRecord: Testing.__TestContentRecord {
           \(testContentRecordName)
         }
       }

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -491,12 +491,12 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
 
 #if !SWT_NO_LEGACY_TEST_DISCOVERY
     // Emit a type that contains a reference to the test content record.
-    let className = context.makeUniqueName(thunking: functionDecl, withPrefix: "__🟡$")
+    let enumName = context.makeUniqueName(thunking: functionDecl, withPrefix: "__🟡$")
     result.append(
       """
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
-      final class \(className): Testing.__TestContentRecordContainer {
-        override nonisolated class var __testContentRecord: Testing.__TestContentRecord {
+      enum \(enumName): Testing.__TestContentRecordContainer {
+        nonisolated static var __testContentRecord: Testing.__TestContentRecord {
           \(testContentRecordName)
         }
       }

--- a/Sources/_TestDiscovery/DiscoverableAsTestContent.swift
+++ b/Sources/_TestDiscovery/DiscoverableAsTestContent.swift
@@ -39,4 +39,17 @@ public protocol DiscoverableAsTestContent: Sendable, ~Copyable {
   /// By default, this type equals `Never`, indicating that this type of test
   /// content does not support hinting during discovery.
   associatedtype TestContentAccessorHint = Never
+
+#if !SWT_NO_LEGACY_TEST_DISCOVERY
+  /// A string present in the names of types containing test content records
+  /// associated with this type.
+  @available(swift, deprecated: 100000.0, message: "Do not adopt this functionality in new code. It will be removed in a future release.")
+  static var _testContentTypeNameHint: String { get }
+#endif
+}
+
+extension DiscoverableAsTestContent where Self: ~Copyable {
+  public static var _testContentTypeNameHint: String {
+    "__🟡$"
+  }
 }


### PR DESCRIPTION
Looks like #880 and/or #1010 caused a regression: the compiler appears to be dead-code-stripping the classes we emit to contain test content records. This PR changes the design back to using a protocol so that the members we need are always covered by `@_alwaysEmitConformanceMetadata`. This makes `_TestDiscovery` a little harder to use with legacy lookup, but it's all experimental and eventually going to be removed anyway.

Resolves rdar://146809312.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
