### PR TITLE
Add a `reserved` argument to the test content record accessor signature.

### DIFF
--- a/Documentation/ABI/TestContent.md
+++ b/Documentation/ABI/TestContent.md
@@ -44,7 +44,8 @@ testing library have the following layout:
 typealias Accessor = @convention(c) (
   _ outValue: UnsafeMutableRawPointer,
   _ type: UnsafeRawPointer,
-  _ hint: UnsafeRawPointer?
+  _ hint: UnsafeRawPointer?,
+  _ reserved: UnsafeRawPointer?
 ) -> CBool
 
 typealias TestContentRecord = (
@@ -63,7 +64,8 @@ If needed, this type can be represented in C as a structure:
 typedef bool (* SWTAccessor)(
   void *outValue,
   const void *type,
-  const void *_Nullable hint
+  const void *_Nullable hint,
+  const void *_Nullable reserved
 );
 
 struct SWTTestContentRecord {
@@ -117,7 +119,7 @@ If `accessor` is `nil`, the test content record is ignored. The testing library
 may, in the future, define record kinds that do not provide an accessor function
 (that is, they represent pure compile-time information only.)
 
-The third argument to this function, `type`, is a pointer to the type[^mightNotBeSwift]
+The second argument to this function, `type`, is a pointer to the type[^mightNotBeSwift]
 (not a bitcast Swift type) of the value expected to be written to `outValue`.
 This argument helps to prevent memory corruption if two copies of Swift Testing
 or a third-party library are inadvertently loaded into the same process. If the
@@ -134,11 +136,14 @@ accessor function must return `false` and must not modify `outValue`.
   [`std::type_info`](https://en.cppreference.com/w/cpp/types/type_info), and
   write a C++ class instance to `outValue` using [placement `new`](https://en.cppreference.com/w/cpp/language/new#Placement_new).
 
-The fourth argument to this function, `hint`, is an optional input that can be
+The third argument to this function, `hint`, is an optional input that can be
 passed to help the accessor function determine if its corresponding test content
 record matches what the caller is looking for. If the caller passes `nil` as the
 `hint` argument, the accessor behaves as if it matched (that is, no additional
 filtering is performed.)
+
+The fourth argument to this function, `reserved`, is reserved for future use.
+Accessor functions should assume it is `nil` and must not access it.
 
 The concrete Swift type of the value written to `outValue`, the type pointed to
 by `type`, and the value pointed to by `hint` depend on the kind of record:

--- a/Documentation/ABI/TestContent.md
+++ b/Documentation/ABI/TestContent.md
@@ -45,7 +45,7 @@ typealias Accessor = @convention(c) (
   _ outValue: UnsafeMutableRawPointer,
   _ type: UnsafeRawPointer,
   _ hint: UnsafeRawPointer?,
-  _ reserved: UnsafeRawPointer?
+  _ reserved: UInt
 ) -> CBool
 
 typealias TestContentRecord = (
@@ -65,7 +65,7 @@ typedef bool (* SWTAccessor)(
   void *outValue,
   const void *type,
   const void *_Nullable hint,
-  const void *_Nullable reserved
+  uintptr_t reserved
 );
 
 struct SWTTestContentRecord {
@@ -143,7 +143,7 @@ record matches what the caller is looking for. If the caller passes `nil` as the
 filtering is performed.)
 
 The fourth argument to this function, `reserved`, is reserved for future use.
-Accessor functions should assume it is `nil` and must not access it.
+Accessor functions should assume it is `0` and must not access it.
 
 The concrete Swift type of the value written to `outValue`, the type pointed to
 by `type`, and the value pointed to by `hint` depend on the kind of record:

--- a/Sources/Testing/Discovery+Macro.swift
+++ b/Sources/Testing/Discovery+Macro.swift
@@ -28,7 +28,8 @@ protocol DiscoverableAsTestContent: _TestDiscovery.DiscoverableAsTestContent, ~C
 public typealias __TestContentRecordAccessor = @convention(c) (
   _ outValue: UnsafeMutableRawPointer,
   _ type: UnsafeRawPointer,
-  _ hint: UnsafeRawPointer?
+  _ hint: UnsafeRawPointer?,
+  _ reserved: UnsafeRawPointer?
 ) -> CBool
 
 /// The content of a test content record.

--- a/Sources/Testing/Discovery+Macro.swift
+++ b/Sources/Testing/Discovery+Macro.swift
@@ -29,7 +29,7 @@ public typealias __TestContentRecordAccessor = @convention(c) (
   _ outValue: UnsafeMutableRawPointer,
   _ type: UnsafeRawPointer,
   _ hint: UnsafeRawPointer?,
-  _ reserved: UnsafeRawPointer?
+  _ reserved: UInt
 ) -> CBool
 
 /// The content of a test content record.

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -484,7 +484,7 @@ extension ExitTestConditionMacro {
         """
         @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
         enum \(enumName) {
-          private nonisolated static let accessor: Testing.__TestContentRecordAccessor = { outValue, type, hint in
+          private nonisolated static let accessor: Testing.__TestContentRecordAccessor = { outValue, type, hint, _ in
             Testing.ExitTest.__store(
               \(exitTestIDExpr),
               \(bodyThunkName),

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -149,7 +149,7 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
     result.append(
       """
       @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")
-      private nonisolated static let \(accessorName): Testing.__TestContentRecordAccessor = { outValue, type, _ in
+      private nonisolated static let \(accessorName): Testing.__TestContentRecordAccessor = { outValue, type, _, _ in
         Testing.Test.__store(\(generatorName), into: outValue, asTypeAt: type)
       }
       """

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -474,7 +474,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     result.append(
       """
       @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")
-      private \(staticKeyword(for: typeName)) nonisolated let \(accessorName): Testing.__TestContentRecordAccessor = { outValue, type, _ in
+      private \(staticKeyword(for: typeName)) nonisolated let \(accessorName): Testing.__TestContentRecordAccessor = { outValue, type, _, _ in
         Testing.Test.__store(\(generatorName), into: outValue, asTypeAt: type)
       }
       """

--- a/Sources/_TestDiscovery/TestContentRecord.swift
+++ b/Sources/_TestDiscovery/TestContentRecord.swift
@@ -25,7 +25,7 @@ private typealias _TestContentRecordAccessor = @convention(c) (
   _ outValue: UnsafeMutableRawPointer,
   _ type: UnsafeRawPointer,
   _ hint: UnsafeRawPointer?,
-  _ reserved: UnsafeRawPointer?
+  _ reserved: UInt
 ) -> CBool
 
 /// The content of a test content record.
@@ -161,10 +161,10 @@ public struct TestContentRecord<T> where T: DiscoverableAsTestContent & ~Copyabl
       withUnsafeTemporaryAllocation(of: T.self, capacity: 1) { buffer in
         let initialized = if let hint {
           withUnsafePointer(to: hint) { hint in
-            accessor(buffer.baseAddress!, type, hint, nil)
+            accessor(buffer.baseAddress!, type, hint, 0)
           }
         } else {
-          accessor(buffer.baseAddress!, type, nil, nil)
+          accessor(buffer.baseAddress!, type, nil, 0)
         }
         guard initialized else {
           return nil

--- a/Sources/_TestDiscovery/TestContentRecord.swift
+++ b/Sources/_TestDiscovery/TestContentRecord.swift
@@ -24,7 +24,8 @@
 private typealias _TestContentRecordAccessor = @convention(c) (
   _ outValue: UnsafeMutableRawPointer,
   _ type: UnsafeRawPointer,
-  _ hint: UnsafeRawPointer?
+  _ hint: UnsafeRawPointer?,
+  _ reserved: UnsafeRawPointer?
 ) -> CBool
 
 /// The content of a test content record.
@@ -160,10 +161,10 @@ public struct TestContentRecord<T> where T: DiscoverableAsTestContent & ~Copyabl
       withUnsafeTemporaryAllocation(of: T.self, capacity: 1) { buffer in
         let initialized = if let hint {
           withUnsafePointer(to: hint) { hint in
-            accessor(buffer.baseAddress!, type, hint)
+            accessor(buffer.baseAddress!, type, hint, nil)
           }
         } else {
-          accessor(buffer.baseAddress!, type, nil)
+          accessor(buffer.baseAddress!, type, nil, nil)
         }
         guard initialized else {
           return nil

--- a/Tests/TestingTests/DiscoveryTests.swift
+++ b/Tests/TestingTests/DiscoveryTests.swift
@@ -93,7 +93,7 @@ struct DiscoveryTests {
     private static let record: __TestContentRecord = (
       0xABCD1234,
       0,
-      { outValue, type, hint in
+      { outValue, type, hint, _ in
         guard type.load(as: Any.Type.self) == MyTestContent.self else {
           return false
         }


### PR DESCRIPTION
This PR adds a `reserved` argument to `__TestContentRecordAccessor` for our future use.

Resolves rdar://146818672.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
