### PR TITLE
Enable upcoming feature 'MemberImportVisibility' and fix issues it reveals

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -202,6 +202,8 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("AccessLevelOnImport"),
       .enableUpcomingFeature("InternalImportsByDefault"),
 
+      .enableUpcomingFeature("MemberImportVisibility"),
+
       // This setting is enabled in the package, but not in the toolchain build
       // (via CMake). Enabling it is dependent on acceptance of the @section
       // proposal via Swift Evolution.

--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -9,6 +9,8 @@
 //
 
 #if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
+private import Foundation
+
 extension ABI.Version {
   /// Post-process encoded JSON and write it to a file.
   ///

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -9,6 +9,7 @@
 //
 
 public import SwiftSyntax
+import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 
 #if !hasFeature(SymbolLinkageMarkers) && SWT_NO_LEGACY_TEST_DISCOVERY

--- a/Sources/TestingMacros/PragmaMacro.swift
+++ b/Sources/TestingMacros/PragmaMacro.swift
@@ -8,6 +8,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+import SwiftDiagnostics
+import SwiftParser
 public import SwiftSyntax
 public import SwiftSyntaxMacros
 

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -8,7 +8,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+import SwiftDiagnostics
 public import SwiftSyntax
+import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 
 #if !hasFeature(SymbolLinkageMarkers) && SWT_NO_LEGACY_TEST_DISCOVERY

--- a/Sources/TestingMacros/Support/Additions/MacroExpansionContextAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/MacroExpansionContextAdditions.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftDiagnostics
 

--- a/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TokenSyntaxAdditions.swift
@@ -8,6 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+import SwiftParser
 import SwiftSyntax
 
 extension TokenSyntax {

--- a/Sources/TestingMacros/Support/Argument.swift
+++ b/Sources/TestingMacros/Support/Argument.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// A type describing an argument to a function, closure, etc.
 ///

--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 /// A syntax rewriter that removes leading `Self.` tokens from member access

--- a/Sources/TestingMacros/Support/AvailabilityGuards.swift
+++ b/Sources/TestingMacros/Support/AvailabilityGuards.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 /// A structure describing a single platform/version pair from an `@available()`

--- a/Sources/TestingMacros/Support/CommentParsing.swift
+++ b/Sources/TestingMacros/Support/CommentParsing.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Find a common whitespace prefix among all lines in a string and trim it.
 ///

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 /// The result of parsing the condition argument passed to `#expect()` or

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -9,7 +9,9 @@
 //
 
 import SwiftDiagnostics
+import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 extension AttributeInfo {

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -9,7 +9,9 @@
 //
 
 import SwiftDiagnostics
+import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
 

--- a/Sources/TestingMacros/Support/SourceCodeCapturing.swift
+++ b/Sources/TestingMacros/Support/SourceCodeCapturing.swift
@@ -8,7 +8,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 /// Get a swift-syntax expression initializing an instance of `__Expression`
 /// from an arbitrary syntax node.

--- a/Sources/TestingMacros/Support/SourceLocationGeneration.swift
+++ b/Sources/TestingMacros/Support/SourceLocationGeneration.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 /// Get an expression initializing an instance of ``SourceLocation`` from an

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 /// An enumeration representing the different kinds of test content known to the

--- a/Sources/TestingMacros/TagMacro.swift
+++ b/Sources/TestingMacros/TagMacro.swift
@@ -9,6 +9,7 @@
 //
 
 public import SwiftSyntax
+import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 
 /// A type describing the expansion of the `@Tag` attribute macro.

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -8,7 +8,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+import SwiftDiagnostics
 public import SwiftSyntax
+import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 
 #if !hasFeature(SymbolLinkageMarkers) && SWT_NO_LEGACY_TEST_DISCOVERY

--- a/Tests/TestingMacrosTests/PragmaMacroTests.swift
+++ b/Tests/TestingMacrosTests/PragmaMacroTests.swift
@@ -11,8 +11,10 @@
 import Testing
 @testable import TestingMacros
 
+import SwiftDiagnostics
 import SwiftParser
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 @Suite("PragmaMacro Tests")
 struct PragmaMacroTests {

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -11,6 +11,7 @@
 import Testing
 @testable import TestingMacros
 
+import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftParser
 import SwiftSyntax

--- a/Tests/TestingMacrosTests/TestSupport/Parse.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Parse.swift
@@ -10,6 +10,7 @@
 
 @testable import TestingMacros
 
+import SwiftBasicFormat
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -91,7 +91,8 @@ struct AttachmentTests {
       // Write the attachment to disk, then read it back.
       let filePath = try attachment.write(toFileInDirectoryAtPath: temporaryDirectory(), appending: suffixes.next()!)
       createdFilePaths.append(filePath)
-      let fileName = try #require(filePath.split { $0 == "/" || $0 == #"\"# }.last)
+      let filePathComponents = filePath.split { $0 == "/" || $0 == #"\"# }
+      let fileName = try #require(filePathComponents.last)
       if i == 0 {
         #expect(fileName == baseFileName)
       } else {
@@ -118,7 +119,8 @@ struct AttachmentTests {
     defer {
       remove(filePath)
     }
-    let fileName = try #require(filePath.split { $0 == "/" || $0 == #"\"# }.last)
+    let filePathComponents = filePath.split { $0 == "/" || $0 == #"\"# }
+    let fileName = try #require(filePathComponents.last)
     #expect(fileName == "loremipsum-\(suffix).tgz.gif.jpeg.html")
     try compare(attachableValue, toContentsOfFileAtPath: filePath)
   }


### PR DESCRIPTION
This enables the `MemberImportVisibility` upcoming Swift feature described in [SE-0444: Member import visibility](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md), then fixes the new issues that enabling it reveals.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
