### PR TITLE
[Experimental] Implement JSON coding without using Foundation or `Codable`.

### DIFF
--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 @_spi(Experimental) public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 @_spi(Experimental) public import Testing
 private import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+NSSecureCoding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 @_spi(Experimental) public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 @_spi(Experimental) public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Data+Attachable.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Data+Attachable.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 @_spi(Experimental) public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/EncodingFormat.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/EncodingFormat.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 @_spi(Experimental) import Testing
 import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/_AttachableURLContainer.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/_AttachableURLContainer.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 @_spi(Experimental) public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Events/Clock+Date.swift
+++ b/Sources/Overlays/_Testing_Foundation/Events/Clock+Date.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_UTC_CLOCK
+#if !SWT_NO_FOUNDATION && canImport(Foundation) && !SWT_NO_UTC_CLOCK
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import Testing
 public import Foundation
 

--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -55,13 +55,13 @@ extension ABI.Version {
     let humanReadableOutputRecorder = Event.HumanReadableOutputRecorder()
     return { [eventHandler = eventHandlerCopy] event, context in
       if case .testDiscovered = event.kind, let test = context.test {
-        try? JSON.withEncoding(of: ABI.Record<Self>(encoding: test)) { testJSON in
+        JSON.withEncoding(of: ABI.Record<Self>(encoding: test)) { testJSON in
           eventHandler(testJSON)
         }
       } else {
         let messages = humanReadableOutputRecorder.record(event, in: context, verbosity: 0)
         if let eventRecord = ABI.Record<Self>(encoding: event, in: context, messages: messages) {
-          try? JSON.withEncoding(of: eventRecord, eventHandler)
+          JSON.withEncoding(of: eventRecord, eventHandler)
         }
       }
     }

--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -8,9 +8,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
-private import Foundation
-
 extension ABI.Version {
   /// Post-process encoded JSON and write it to a file.
   ///
@@ -96,12 +93,9 @@ extension ABI.Xcode16 {
         eventContext: Event.Context.Snapshot(snapshotting: context)
       )
       try? JSON.withEncoding(of: snapshot) { eventAndContextJSON in
-        eventAndContextJSON.withUnsafeBytes { eventAndContextJSON in
-          eventHandler(eventAndContextJSON)
-        }
+        eventHandler(eventAndContextJSON)
       }
     }
   }
 }
-#endif
 #endif

--- a/Sources/Testing/ABI/ABI.Record.swift
+++ b/Sources/Testing/ABI/ABI.Record.swift
@@ -96,6 +96,6 @@ extension ABI.Record: JSON.Serializable {
       dict["payload"] = event.makeJSONValue()
     }
 
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }

--- a/Sources/Testing/ABI/ABI.Record.swift
+++ b/Sources/Testing/ABI/ABI.Record.swift
@@ -41,26 +41,13 @@ extension ABI {
   }
 }
 
-// MARK: - Codable
+// MARK: - Decodable
 
-extension ABI.Record: Codable {
+extension ABI.Record: Decodable {
   private enum CodingKeys: String, CodingKey {
     case version
     case kind
     case payload
-  }
-
-  func encode(to encoder: any Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(V.versionNumber, forKey: .version)
-    switch kind {
-    case let .test(test):
-      try container.encode("test", forKey: .kind)
-      try container.encode(test, forKey: .payload)
-    case let .event(event):
-      try container.encode("event", forKey: .kind)
-      try container.encode(event, forKey: .payload)
-    }
   }
 
   init(from decoder: any Decoder) throws {
@@ -91,5 +78,21 @@ extension ABI.Record: Codable {
         )
       )
     }
+  }
+}
+
+extension ABI.Record: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+    try dict.updateValue(V.versionNumber, forKey: "version")
+    switch kind {
+    case let .test(test):
+      try dict.updateValue("test", forKey: "kind")
+      try dict.updateValue(test, forKey: "payload")
+    case let .event(event):
+      try dict.updateValue("event", forKey: "kind")
+      try dict.updateValue(event, forKey: "payload")
+    }
+    return try dict.makeJSON()
   }
 }

--- a/Sources/Testing/ABI/ABI.Record.swift
+++ b/Sources/Testing/ABI/ABI.Record.swift
@@ -82,17 +82,20 @@ extension ABI.Record: Decodable {
 }
 
 extension ABI.Record: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
-    try dict.updateValue(V.versionNumber, forKey: "version")
+  func makeJSONValue() -> JSON.Value {
+    var dict = [
+      "version": V.versionNumber.makeJSONValue()
+    ]
+
     switch kind {
     case let .test(test):
-      try dict.updateValue("test", forKey: "kind")
-      try dict.updateValue(test, forKey: "payload")
+      dict["kind"] = "test".makeJSONValue()
+      dict["payload"] = test.makeJSONValue()
     case let .event(event):
-      try dict.updateValue("event", forKey: "kind")
-      try dict.updateValue(event, forKey: "payload")
+      dict["kind"] = "event".makeJSONValue()
+      dict["payload"] = event.makeJSONValue()
     }
-    return try dict.makeJSON()
+
+    return .object(dict)
   }
 }

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -20,7 +20,6 @@ extension ABI {
     /// The numeric representation of this ABI version.
     static var versionNumber: Int { get }
 
-#if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
     /// Create an event handler that encodes events as JSON and forwards them to
     /// an ABI-friendly event handler.
     ///
@@ -39,7 +38,6 @@ extension ABI {
       encodeAsJSONLines: Bool,
       forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
     ) -> Event.Handler
-#endif
   }
 
   /// The current supported ABI version (ignoring any experimental versions.)
@@ -50,6 +48,10 @@ extension ABI {
 
 extension ABI {
 #if !SWT_NO_SNAPSHOT_TYPES
+#if SWT_NO_FOUNDATION || !canImport(Foundation)
+#error("Platform-specific misconfiguration: Foundation is required for snapshot type support")
+#endif
+
   /// A namespace and version type for Xcode&nbsp;16 compatibility.
   ///
   /// - Warning: This type will be removed in a future update.

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -39,6 +39,6 @@ extension ABI.EncodedAttachment: JSON.Serializable {
     if let path {
       dict["path"] = path.makeJSONValue()
     }
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -34,11 +34,11 @@ extension ABI.EncodedAttachment: Decodable {}
 // MARK: - JSON.Serializable
 
 extension ABI.EncodedAttachment: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
+  func makeJSONValue() -> JSON.Value {
+    var dict = [String: JSON.Value]()
     if let path {
-      try dict.updateValue(path, forKey: "path")
+      dict["path"] = path.makeJSONValue()
     }
-    return try dict.makeJSON()
+    return .object(dict)
   }
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -27,6 +27,18 @@ extension ABI {
   }
 }
 
-// MARK: - Codable
+// MARK: - Decodable
 
-extension ABI.EncodedAttachment: Codable {}
+extension ABI.EncodedAttachment: Decodable {}
+
+// MARK: - JSON.Serializable
+
+extension ABI.EncodedAttachment: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+    if let path {
+      try dict.updateValue(path, forKey: "path")
+    }
+    return try dict.makeJSON()
+  }
+}

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
@@ -60,6 +60,6 @@ extension Backtrace.SymbolicatedAddress: JSON.Serializable {
       dict["symbolName"] = symbolName.makeJSONValue()
     }
 
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
@@ -42,23 +42,24 @@ extension ABI.EncodedBacktrace: Decodable {
 // MARK: - JSON.Serializable
 
 extension ABI.EncodedBacktrace: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
-    try dict.updateValue(symbolicatedAddresses, forKey: "symbolicatedAddresses")
-    return try dict.makeJSON()
+  func makeJSONValue() -> JSON.Value {
+    symbolicatedAddresses.makeJSONValue()
   }
 }
 
 extension Backtrace.SymbolicatedAddress: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
-    try dict.updateValue(address, forKey: "address")
+  func makeJSONValue() -> JSON.Value {
+    var dict = [
+      "address": address.makeJSONValue()
+    ]
+
     if let offset {
-      try dict.updateValue(offset, forKey: "offset")
+      dict["offset"] = offset.makeJSONValue()
     }
     if let symbolName {
-      try dict.updateValue(symbolName, forKey: "symbolName")
+      dict["symbolName"] = symbolName.makeJSONValue()
     }
-    return try dict.makeJSON()
+
+    return .object(dict)
   }
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
@@ -31,14 +31,34 @@ extension ABI {
   }
 }
 
-// MARK: - Codable
+// MARK: - Decodable
 
-extension ABI.EncodedBacktrace: Codable {
-  func encode(to encoder: any Encoder) throws {
-    try symbolicatedAddresses.encode(to: encoder)
-  }
-
+extension ABI.EncodedBacktrace: Decodable {
   init(from decoder: any Decoder) throws {
     self.symbolicatedAddresses = try [Backtrace.SymbolicatedAddress](from: decoder)
+  }
+}
+
+// MARK: - JSON.Serializable
+
+extension ABI.EncodedBacktrace: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+    try dict.updateValue(symbolicatedAddresses, forKey: "symbolicatedAddresses")
+    return try dict.makeJSON()
+  }
+}
+
+extension Backtrace.SymbolicatedAddress: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+    try dict.updateValue(address, forKey: "address")
+    if let offset {
+      try dict.updateValue(offset, forKey: "offset")
+    }
+    if let symbolName {
+      try dict.updateValue(symbolName, forKey: "symbolName")
+    }
+    return try dict.makeJSON()
   }
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
@@ -67,7 +67,7 @@ extension ABI.EncodedError: JSON.Serializable {
       "domain": domain.makeJSONValue(),
       "code": code.makeJSONValue()
     ]
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
@@ -61,12 +61,13 @@ extension ABI.EncodedError: Decodable {}
 // MARK: - JSON.Serializable
 
 extension ABI.EncodedError: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
-    try dict.updateValue(description, forKey: "description")
-    try dict.updateValue(domain, forKey: "domain")
-    try dict.updateValue(code, forKey: "code")
-    return try dict.makeJSON()
+  func makeJSONValue() -> JSON.Value {
+    let dict = [
+      "description": description.makeJSONValue(),
+      "domain": domain.makeJSONValue(),
+      "code": code.makeJSONValue()
+    ]
+    return .object(dict)
   }
 }
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
@@ -54,9 +54,21 @@ extension ABI.EncodedError: Error {
   }
 }
 
-// MARK: - Codable
+// MARK: - Decodable
 
-extension ABI.EncodedError: Codable {}
+extension ABI.EncodedError: Decodable {}
+
+// MARK: - JSON.Serializable
+
+extension ABI.EncodedError: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+    try dict.updateValue(description, forKey: "description")
+    try dict.updateValue(domain, forKey: "domain")
+    try dict.updateValue(code, forKey: "code")
+    return try dict.makeJSON()
+  }
+}
 
 // MARK: - CustomTestStringConvertible
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -135,7 +135,7 @@ extension ABI.EncodedEvent: JSON.Serializable {
       dict["_testCase"] = _testCase.makeJSONValue()
     }
 
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -115,26 +115,27 @@ extension ABI.EncodedEvent.Kind: Decodable {}
 // MARK: - JSON.Serializable
 
 extension ABI.EncodedEvent: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
+  func makeJSONValue() -> JSON.Value {
+    var dict = [
+      "kind": kind.makeJSONValue(),
+      "instant": instant.makeJSONValue(),
+      "messages": messages.makeJSONValue(),
+    ]
 
-    try dict.updateValue(kind, forKey: "kind")
-    try dict.updateValue(instant, forKey: "instant")
     if let issue {
-      try dict.updateValue(issue, forKey: "issue")
+      dict["issue"] = issue.makeJSONValue()
     }
     if let _attachment {
-      try dict.updateValue(_attachment, forKey: "_attachment")
+      dict["_attachment"] = _attachment.makeJSONValue()
     }
-    try dict.updateValue(messages, forKey: "messages")
     if let testID {
-      try dict.updateValue(testID, forKey: "testID")
+      dict["testID"] = testID.makeJSONValue()
     }
     if let _testCase {
-      try dict.updateValue(_testCase, forKey: "_testCase")
+      dict["_testCase"] = _testCase.makeJSONValue()
     }
 
-    return try dict.makeJSON()
+    return .object(dict)
   }
 }
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -107,7 +107,35 @@ extension ABI {
   }
 }
 
-// MARK: - Codable
+// MARK: - Decodable
 
-extension ABI.EncodedEvent: Codable {}
-extension ABI.EncodedEvent.Kind: Codable {}
+extension ABI.EncodedEvent: Decodable {}
+extension ABI.EncodedEvent.Kind: Decodable {}
+
+// MARK: - JSON.Serializable
+
+extension ABI.EncodedEvent: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+
+    try dict.updateValue(kind, forKey: "kind")
+    try dict.updateValue(instant, forKey: "instant")
+    if let issue {
+      try dict.updateValue(issue, forKey: "issue")
+    }
+    if let _attachment {
+      try dict.updateValue(_attachment, forKey: "_attachment")
+    }
+    try dict.updateValue(messages, forKey: "messages")
+    if let testID {
+      try dict.updateValue(testID, forKey: "testID")
+    }
+    if let _testCase {
+      try dict.updateValue(_testCase, forKey: "_testCase")
+    }
+
+    return try dict.makeJSON()
+  }
+}
+
+extension ABI.EncodedEvent.Kind: JSON.Serializable {}

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
@@ -42,12 +42,11 @@ extension ABI.EncodedInstant: Decodable {}
 // MARK: - JSON.Serializable
 
 extension ABI.EncodedInstant: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
-
-    try dict.updateValue(absolute, forKey: "absolute")
-    try dict.updateValue(since1970, forKey: "since1970")
-
-    return try dict.makeJSON()
+  func makeJSONValue() -> JSON.Value {
+    let dict = [
+      "absolute": absolute.makeJSONValue(),
+      "since1970": since1970.makeJSONValue()
+    ]
+    return .object(dict)
   }
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
@@ -47,6 +47,6 @@ extension ABI.EncodedInstant: JSON.Serializable {
       "absolute": absolute.makeJSONValue(),
       "since1970": since1970.makeJSONValue()
     ]
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
@@ -35,6 +35,19 @@ extension ABI {
   }
 }
 
-// MARK: - Codable
+// MARK: - Decodable
 
-extension ABI.EncodedInstant: Codable {}
+extension ABI.EncodedInstant: Decodable {}
+
+// MARK: - JSON.Serializable
+
+extension ABI.EncodedInstant: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+
+    try dict.updateValue(absolute, forKey: "absolute")
+    try dict.updateValue(since1970, forKey: "since1970")
+
+    return try dict.makeJSON()
+  }
+}

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -88,7 +88,7 @@ extension ABI.EncodedIssue: JSON.Serializable {
       dict["_error"] = _error.makeJSONValue()
     }
 
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -72,22 +72,23 @@ extension ABI.EncodedIssue.Severity: Decodable {}
 // MARK: - JSON.Serializable
 
 extension ABI.EncodedIssue: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
+  func makeJSONValue() -> JSON.Value {
+    var dict = [
+      "_severity": _severity.makeJSONValue(),
+      "isKnown": isKnown.makeJSONValue()
+    ]
 
-    try dict.updateValue(_severity, forKey: "_severity")
-    try dict.updateValue(isKnown, forKey: "isKnown")
     if let sourceLocation {
-      try dict.updateValue(sourceLocation, forKey: "sourceLocation")
+      dict["sourceLocation"] = sourceLocation.makeJSONValue()
     }
     if let _backtrace {
-      try dict.updateValue(_backtrace, forKey: "_backtrace")
+      dict["_backtrace"] = _backtrace.makeJSONValue()
     }
     if let _error {
-      try dict.updateValue(_error, forKey: "_error")
+      dict["_error"] = _error.makeJSONValue()
     }
 
-    return try dict.makeJSON()
+    return .object(dict)
   }
 }
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
@@ -74,7 +74,21 @@ extension ABI {
   }
 }
 
-// MARK: - Codable
+// MARK: - Decodable
 
-extension ABI.EncodedMessage: Codable {}
-extension ABI.EncodedMessage.Symbol: Codable {}
+extension ABI.EncodedMessage: Decodable {}
+extension ABI.EncodedMessage.Symbol: Decodable {}
+
+// MARK: - JSON.Serializable
+
+extension ABI.EncodedMessage: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+
+    try dict.updateValue(symbol, forKey: "symbol")
+    try dict.updateValue(text, forKey: "text")
+
+    return try dict.makeJSON()
+  }
+}
+extension ABI.EncodedMessage.Symbol: JSON.Serializable {}

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
@@ -82,13 +82,12 @@ extension ABI.EncodedMessage.Symbol: Decodable {}
 // MARK: - JSON.Serializable
 
 extension ABI.EncodedMessage: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
-
-    try dict.updateValue(symbol, forKey: "symbol")
-    try dict.updateValue(text, forKey: "text")
-
-    return try dict.makeJSON()
+  func makeJSONValue() -> JSON.Value {
+    let dict = [
+      "symbol": symbol.makeJSONValue(),
+      "text": text.makeJSONValue(),
+    ]
+    return .object(dict)
   }
 }
 extension ABI.EncodedMessage.Symbol: JSON.Serializable {}

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
@@ -87,7 +87,7 @@ extension ABI.EncodedMessage: JSON.Serializable {
       "symbol": symbol.makeJSONValue(),
       "text": text.makeJSONValue(),
     ]
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }
 extension ABI.EncodedMessage.Symbol: JSON.Serializable {}

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedSourceLocation.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedSourceLocation.swift
@@ -35,14 +35,13 @@ extension ABI.EncodedSourceLocation: Decodable {
 // MARK: - JSON.Serializable
 
 extension ABI.EncodedSourceLocation: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
-
-    try dict.updateValue(sourceLocation._filePath, forKey: "_filePath")
-    try dict.updateValue(sourceLocation.fileID, forKey: "fileID")
-    try dict.updateValue(sourceLocation.line, forKey: "line")
-    try dict.updateValue(sourceLocation.column, forKey: "column")
-
-    return try dict.makeJSON()
+  func makeJSONValue() -> JSON.Value {
+    let dict = [
+      "_filePath": sourceLocation._filePath.makeJSONValue(),
+      "fileID": sourceLocation.fileID.makeJSONValue(),
+      "line": sourceLocation.line.makeJSONValue(),
+      "column": sourceLocation.column.makeJSONValue(),
+    ]
+    return .object(dict)
   }
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedSourceLocation.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedSourceLocation.swift
@@ -1,0 +1,48 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension ABI {
+  /// A type implementing the JSON encoding of ``SourceLocation`` for the ABI
+  /// entry point and event stream output.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  struct EncodedSourceLocation<V>: Sendable where V: ABI.Version {
+    var sourceLocation: SourceLocation
+
+    init(encoding sourceLocation: borrowing SourceLocation) {
+      self.sourceLocation = copy sourceLocation
+    }
+  }
+}
+
+// MARK: - Decodable
+
+extension ABI.EncodedSourceLocation: Decodable {
+  init(from decoder: any Decoder) throws {
+    self.sourceLocation = try SourceLocation(from: decoder)
+  }
+}
+
+// MARK: - JSON.Serializable
+
+extension ABI.EncodedSourceLocation: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+
+    try dict.updateValue(sourceLocation._filePath, forKey: "_filePath")
+    try dict.updateValue(sourceLocation.fileID, forKey: "fileID")
+    try dict.updateValue(sourceLocation.line, forKey: "line")
+    try dict.updateValue(sourceLocation.column, forKey: "column")
+
+    return try dict.makeJSON()
+  }
+}

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedSourceLocation.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedSourceLocation.swift
@@ -42,6 +42,6 @@ extension ABI.EncodedSourceLocation: JSON.Serializable {
       "line": sourceLocation.line.makeJSONValue(),
       "column": sourceLocation.column.makeJSONValue(),
     ]
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -161,7 +161,7 @@ extension ABI.EncodedTest: JSON.Serializable {
       dict["_tags"] = _tags.makeJSONValue()
     }
 
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }
 extension ABI.EncodedTest.Kind: JSON.Serializable {}
@@ -178,6 +178,6 @@ extension ABI.EncodedTestCase: JSON.Serializable {
       "id": id.makeJSONValue(),
       "displayName": displayName.makeJSONValue(),
     ]
-    return .object(dict)
+    return dict.makeJSONValue()
   }
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -38,24 +38,16 @@ extension ABI {
     var displayName: String?
 
     /// The source location of this test.
-    var sourceLocation: SourceLocation
+    var sourceLocation: EncodedSourceLocation<V>
 
     /// A type implementing the JSON encoding of ``Test/ID`` for the ABI entry
     /// point and event stream output.
-    struct ID: Codable {
+    struct ID: Sendable {
       /// The string value representing the corresponding test ID.
       var stringValue: String
 
       init(encoding testID: borrowing Test.ID) {
         stringValue = String(describing: copy testID)
-      }
-
-      func encode(to encoder: any Encoder) throws {
-        try stringValue.encode(to: encoder)
-      }
-
-      init(from decoder: any Decoder) throws {
-        stringValue = try String(from: decoder)
       }
     }
 
@@ -95,7 +87,7 @@ extension ABI {
       }
       name = test.name
       displayName = test.displayName
-      sourceLocation = test.sourceLocation
+      sourceLocation = EncodedSourceLocation(encoding: test.sourceLocation)
       id = ID(encoding: test.id)
 
       if V.versionNumber >= ABI.v1.versionNumber {
@@ -134,8 +126,58 @@ extension ABI {
   }
 }
 
-// MARK: - Codable
+// MARK: - Decodable
 
-extension ABI.EncodedTest: Codable {}
-extension ABI.EncodedTest.Kind: Codable {}
-extension ABI.EncodedTestCase: Codable {}
+extension ABI.EncodedTest: Decodable {}
+extension ABI.EncodedTest.Kind: Decodable {}
+extension ABI.EncodedTest.ID: Decodable {
+  init(from decoder: any Decoder) throws {
+    stringValue = try String(from: decoder)
+  }
+}
+extension ABI.EncodedTestCase: Decodable {}
+
+// MARK: - JSON.Serializable
+
+extension ABI.EncodedTest: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+
+    try dict.updateValue(kind, forKey: "kind")
+    try dict.updateValue(name, forKey: "name")
+    if let displayName {
+      try dict.updateValue(displayName, forKey: "displayName")
+    }
+    try dict.updateValue(sourceLocation, forKey: "sourceLocation")
+    try dict.updateValue(id, forKey: "id")
+    if let _testCases {
+      try dict.updateValue(_testCases, forKey: "_testCases")
+    }
+    if let isParameterized {
+      try dict.updateValue(isParameterized, forKey: "isParameterized")
+    }
+    if let _tags {
+      try dict.updateValue(_tags, forKey: "_tags")
+    }
+
+    return try dict.makeJSON()
+  }
+}
+extension ABI.EncodedTest.Kind: JSON.Serializable {}
+
+extension ABI.EncodedTest.ID: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    try stringValue.makeJSON()
+  }
+}
+
+extension ABI.EncodedTestCase: JSON.Serializable {
+  func makeJSON() throws -> some Collection<UInt8> {
+    var dict = JSON.HeterogenousDictionary()
+
+    try dict.updateValue(id, forKey: "id")
+    try dict.updateValue(displayName, forKey: "displayName")
+
+    return try dict.makeJSON()
+  }
+}

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -140,44 +140,44 @@ extension ABI.EncodedTestCase: Decodable {}
 // MARK: - JSON.Serializable
 
 extension ABI.EncodedTest: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
+  func makeJSONValue() -> JSON.Value {
+    var dict = [
+      "kind": kind.makeJSONValue(),
+      "name": name.makeJSONValue(),
+      "sourceLocation": sourceLocation.makeJSONValue(),
+      "id": id.makeJSONValue(),
+    ]
 
-    try dict.updateValue(kind, forKey: "kind")
-    try dict.updateValue(name, forKey: "name")
     if let displayName {
-      try dict.updateValue(displayName, forKey: "displayName")
+      dict["displayName"] = displayName.makeJSONValue()
     }
-    try dict.updateValue(sourceLocation, forKey: "sourceLocation")
-    try dict.updateValue(id, forKey: "id")
     if let _testCases {
-      try dict.updateValue(_testCases, forKey: "_testCases")
+      dict["_testCases"] = _testCases.makeJSONValue()
     }
     if let isParameterized {
-      try dict.updateValue(isParameterized, forKey: "isParameterized")
+      dict["isParameterized"] = isParameterized.makeJSONValue()
     }
     if let _tags {
-      try dict.updateValue(_tags, forKey: "_tags")
+      dict["_tags"] = _tags.makeJSONValue()
     }
 
-    return try dict.makeJSON()
+    return .object(dict)
   }
 }
 extension ABI.EncodedTest.Kind: JSON.Serializable {}
 
 extension ABI.EncodedTest.ID: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    try stringValue.makeJSON()
+  func makeJSONValue() -> JSON.Value {
+    stringValue.makeJSONValue()
   }
 }
 
 extension ABI.EncodedTestCase: JSON.Serializable {
-  func makeJSON() throws -> some Collection<UInt8> {
-    var dict = JSON.HeterogenousDictionary()
-
-    try dict.updateValue(id, forKey: "id")
-    try dict.updateValue(displayName, forKey: "displayName")
-
-    return try dict.makeJSON()
+  func makeJSONValue() -> JSON.Value {
+    let dict = [
+      "id": id.makeJSONValue(),
+      "displayName": displayName.makeJSONValue(),
+    ]
+    return .object(dict)
   }
 }

--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_ABI_ENTRY_POINT
+#if !SWT_NO_ABI_ENTRY_POINT
 private import _TestingInternals
 
 extension ABI.v0 {

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -337,7 +337,6 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   }
 
 #if !SWT_NO_FILE_IO
-#if canImport(Foundation)
   // Configuration for the test run passed in as a JSON file (experimental)
   //
   // This argument should always be the first one we parse.
@@ -388,7 +387,6 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
       }
     }
   }
-#endif
 
   // XML output
   if let xunitOutputIndex = args.firstIndex(of: "--xunit-output"), !isLastArgument(at: xunitOutputIndex) {
@@ -516,7 +514,6 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     configuration.attachmentsPath = attachmentsPath
   }
 
-#if canImport(Foundation)
   // Event stream output (experimental)
   if let eventStreamOutputPath = args.eventStreamOutputPath {
     let file = try FileHandle(forWritingAtPath: eventStreamOutputPath)
@@ -531,7 +528,6 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
       oldEventHandler(event, context)
     }
   }
-#endif
 #endif
 
   // Filtering
@@ -604,7 +600,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
   return configuration
 }
 
-#if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
+#if !SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT
 /// Create an event handler that streams events to the given file using the
 /// specified ABI version.
 ///

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(Testing
   ABI/Encoded/ABI.EncodedInstant.swift
   ABI/Encoded/ABI.EncodedIssue.swift
   ABI/Encoded/ABI.EncodedMessage.swift
+  ABI/Encoded/ABI.EncodedSourceLocation.swift
   ABI/Encoded/ABI.EncodedTest.swift
   Attachments/Attachable.swift
   Attachments/AttachableContainer.swift

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -81,6 +81,8 @@ add_library(Testing
   Support/GetSymbol.swift
   Support/Graph.swift
   Support/JSON.swift
+  Support/JSON.Serializable.swift
+  Support/JSON.Value.swift
   Support/Locked.swift
   Support/Locked+Platform.swift
   Support/Versions.swift

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -36,7 +36,7 @@ private import _TestingInternals
 public struct ExitTest: Sendable, ~Copyable {
   /// A type whose instances uniquely identify instances of ``ExitTest``.
   @_spi(ForToolsIntegrationOnly)
-  public struct ID: Sendable, Equatable, Codable {
+  public struct ID: Sendable, Equatable, Codable, JSON.Serializable {
     /// An underlying UUID (stored as two `UInt64` values to avoid relying on
     /// `UUID` from Foundation or any platform-specific interfaces.)
     private var _lo: UInt64
@@ -45,6 +45,10 @@ public struct ExitTest: Sendable, ~Copyable {
     init(_ uuid: (UInt64, UInt64)) {
       self._lo = uuid.0
       self._hi = uuid.1
+    }
+
+    func makeJSON() throws -> some Collection<UInt8> {
+      try [_lo.makeJSON(), _hi.makeJSON()].joined()
     }
   }
 
@@ -778,7 +782,7 @@ extension ExitTest {
       }
       let sourceContext = SourceContext(
         backtrace: nil, // `issue._backtrace` will have the wrong address space.
-        sourceLocation: issue.sourceLocation
+        sourceLocation: issue.sourceLocation?.sourceLocation
       )
       var issueCopy = Issue(kind: issueKind, comments: comments, sourceContext: sourceContext)
       issueCopy.isKnown = issue.isKnown

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -47,8 +47,12 @@ public struct ExitTest: Sendable, ~Copyable {
       self._hi = uuid.1
     }
 
-    func makeJSON() throws -> some Collection<UInt8> {
-      try [_lo.makeJSON(), _hi.makeJSON()].joined()
+    func makeJSONValue() -> JSON.Value {
+      let dict = [
+        "_lo": _lo.makeJSONValue(),
+        "_hi": _hi.makeJSONValue()
+      ]
+      return .object(dict)
     }
   }
 
@@ -751,6 +755,10 @@ extension ExitTest {
       } catch {
         // NOTE: an error caught here indicates a decoding problem.
         // TODO: should we record these issues as systemic instead?
+        FileHandle.stdout.withLock {
+          try! FileHandle.stdout.write(recordJSON)
+          try! FileHandle.stdout.write("\n")
+        }
         Issue(for: error).record()
       }
     }

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -52,7 +52,7 @@ public struct ExitTest: Sendable, ~Copyable {
         "_lo": _lo.makeJSONValue(),
         "_hi": _hi.makeJSONValue()
       ]
-      return .object(dict)
+      return dict.makeJSONValue()
     }
   }
 
@@ -626,7 +626,7 @@ extension ExitTest {
 
       // Insert a specific variable that tells the child process which exit test
       // to run.
-      try JSON.withEncoding(of: exitTest.id) { json in
+      JSON.withEncoding(of: exitTest.id) { json in
         childEnvironment["SWT_EXPERIMENTAL_EXIT_TEST_ID"] = String(decoding: json, as: UTF8.self)
       }
 

--- a/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
+++ b/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
@@ -62,7 +62,7 @@ extension Test.Case.Argument.ID {
   ///
   /// - ``CustomTestArgumentEncodable``
   init?(identifying value: some Sendable, parameter: Test.Parameter) throws {
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
     func customArgumentWrapper(for value: some CustomTestArgumentEncodable) -> some Encodable {
       _CustomArgumentWrapper(rawValue: value)
     }
@@ -89,7 +89,7 @@ extension Test.Case.Argument.ID {
 #endif
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   /// Encode the specified test argument value and store its encoded
   /// representation as an array of bytes suitable for storing in an instance of
   /// ``Test/Case/Argument/ID-swift.struct``.

--- a/Sources/Testing/Support/JSON.Serializable.swift
+++ b/Sources/Testing/Support/JSON.Serializable.swift
@@ -76,8 +76,8 @@ extension String: JSON.Serializable {
 
 extension Array: JSON.Serializable where Element: JSON.Serializable {
   func makeJSONValue() -> JSON.Value {
-    let arrayCopy = self.map { $0.makeJSONValue() }
-    return .array(arrayCopy)
+    let selfCopy = self.map { $0.makeJSONValue() }
+    return .array(selfCopy)
   }
 }
 
@@ -85,13 +85,14 @@ extension Array: JSON.Serializable where Element: JSON.Serializable {
 
 extension Dictionary: JSON.Serializable where Key == String, Value: JSON.Serializable {
   func makeJSONValue() -> JSON.Value {
-    let dictCopy = self.mapValues { $0.makeJSONValue() }
-    return .object(dictCopy)
+    let selfCopy = self.mapValues { $0.makeJSONValue() }
+    return .object(selfCopy)
   }
 }
 
 // MARK: - Optional and RawRepresentable
 
+#if SWT_ENCODE_JSON_NULL_VALUES
 extension Optional: JSON.Serializable where Wrapped: JSON.Serializable {
   func makeJSONValue() -> JSON.Value {
     guard let value = self else {
@@ -100,6 +101,7 @@ extension Optional: JSON.Serializable where Wrapped: JSON.Serializable {
     return value.makeJSONValue()
   }
 }
+#endif
 
 extension RawRepresentable where Self: JSON.Serializable, RawValue: JSON.Serializable {
   func makeJSONValue() -> JSON.Value {

--- a/Sources/Testing/Support/JSON.Serializable.swift
+++ b/Sources/Testing/Support/JSON.Serializable.swift
@@ -1,0 +1,172 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension JSON {
+  protocol Serializable {
+    /// A type representing the result of by ``makeJSON()``.
+    associatedtype JSONBytes: Collection where JSONBytes.Element == UInt8
+
+    /// Serialize this value as JSON.
+    ///
+    /// - Returns: The sequence of bytes representing this value as JSON.
+    ///
+    /// - Throws: Any error that prevented serializing this value.
+    func makeJSON() throws -> JSONBytes
+  }
+}
+
+extension JSON.Serializable {
+  /// Write the JSON representation of this value to the given file handle.
+  ///
+  /// - Parameters:
+  ///   - file: The file to write to. A trailing newline is not written.
+  ///   - flushAfterward: Whether or not to flush the file (with `fflush()`)
+  ///     after writing. If `true`, `fflush()` is called even if an error
+  ///     occurred while writing.
+  ///
+  /// - Throws: Any error that occurred while writing `bytes`. If an error
+  ///   occurs while flushing the file, it is not thrown.
+  func writeJSON(to file: borrowing FileHandle, flushAfterward: Bool = true) throws {
+    try file.write(makeJSON(), flushAfterward: flushAfterward)
+  }
+}
+
+// MARK: - Arbitrary bytes
+
+extension JSON {
+  struct Verbatim<S>: JSON.Serializable where S: Collection, S.Element == UInt8 {
+    private var _bytes: S
+
+    init(_ bytes: S) {
+      _bytes = bytes
+    }
+
+    func makeJSON() throws -> S {
+      _bytes
+    }
+  }
+}
+
+// MARK: - Scalars
+
+extension Bool: JSON.Serializable {
+  func makeJSON() throws -> UnsafeBufferPointer<UInt8> {
+    let stringValue: StaticString = self ? "true" : "false"
+    return UnsafeBufferPointer(start: stringValue.utf8Start, count: stringValue.utf8CodeUnitCount)
+  }
+}
+
+extension Numeric where Self: CustomStringConvertible & JSON.Serializable {
+  func makeJSON() throws -> String.UTF8View {
+    String(describing: self).utf8
+  }
+}
+
+extension Int: JSON.Serializable {}
+extension UInt64: JSON.Serializable {}
+extension Double: JSON.Serializable {}
+
+extension String: JSON.Serializable {
+  func makeJSON() throws -> [UInt8] {
+    var result = [UInt8]()
+
+    let scalars = self.unicodeScalars
+    result.reserveCapacity(scalars.underestimatedCount + 2)
+
+    do {
+      result.append(UInt8(ascii: #"""#))
+      defer {
+        result.append(UInt8(ascii: #"""#))
+      }
+
+      for scalar in scalars {
+        switch scalar {
+        case Unicode.Scalar(0x0000) ..< Unicode.Scalar(0x0020):
+          let hexValue = String(scalar.value, radix: 16)
+          let leadingZeroes = repeatElement(UInt8(ascii: "0"), count: 4 - hexValue.count)
+          result += leadingZeroes
+          result += hexValue.utf8
+        case #"""#, #"\"#:
+          result += #"\\#(scalar)"#.utf8
+        default:
+          result += scalar.utf8
+        }
+      }
+    }
+
+    return result
+  }
+}
+
+// MARK: - Arrays
+
+extension Array: JSON.Serializable where Element: JSON.Serializable {
+  func makeJSON() throws -> [UInt8] {
+    var result = [UInt8]()
+
+    do {
+      result.append(UInt8(ascii: "["))
+      defer {
+        result.append(UInt8(ascii: "]"))
+      }
+
+      result += try self.lazy.map { element in
+        try element.makeJSON()
+      }.joined(separator: CollectionOfOne(UInt8(ascii: ",")))
+    }
+
+    return result
+  }
+}
+
+// MARK: - Dictionaries
+
+extension Dictionary: JSON.Serializable where Key == String, Value: JSON.Serializable {
+  func makeJSON() throws -> [UInt8] {
+    var result = [UInt8]()
+
+    do {
+      result.append(UInt8(ascii: #"{"#))
+      defer {
+        result.append(UInt8(ascii: #"}"#))
+      }
+
+      result += try self.sorted { lhs, rhs in
+        lhs.key < rhs.key
+      }.map { key, value in
+        let serializedKey = try key.makeJSON()
+        let serializedValue = try value.makeJSON()
+        return serializedKey + CollectionOfOne(UInt8(ascii: ":")) + serializedValue
+      }.joined(separator: CollectionOfOne(UInt8(ascii: #","#)))
+    }
+
+    return result
+  }
+}
+
+extension JSON {
+  typealias HeterogenousDictionary = Dictionary<String, JSON.Verbatim<[UInt8]>>
+}
+
+extension JSON.HeterogenousDictionary {
+  @discardableResult
+  mutating func updateValue(_ value: some JSON.Serializable, forKey key: String) throws -> Value? {
+    let serializedValue = try JSON.Verbatim(Array(value.makeJSON()))
+    return updateValue(serializedValue as Value, forKey: key)
+  }
+}
+
+// MARK: - RawRepresentable
+
+extension RawRepresentable where Self: JSON.Serializable, RawValue: JSON.Serializable {
+  func makeJSON() throws -> RawValue.JSONBytes {
+    try rawValue.makeJSON()
+  }
+}

--- a/Sources/Testing/Support/JSON.Value.swift
+++ b/Sources/Testing/Support/JSON.Value.swift
@@ -1,0 +1,213 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension JSON {
+  /// An enumeration representing the different kinds of value that can be
+  /// encoded directly as JSON.
+  enum Value: Sendable {
+    /// The `null` constant (`nil` in Swift.)
+    case null
+
+    /// A boolean value.
+    case bool(Bool)
+
+    /// A signed integer value.
+    case int64(Int64)
+
+    /// An unsigned integer value.
+    case uint64(UInt64)
+
+    /// A floating point value.
+    case double(Double)
+
+    /// A string.
+    case string(String)
+
+    /// An array of values.
+    case array([JSON.Value])
+
+    /// An object (a dictionary in Swift.)
+    case object([String: JSON.Value])
+  }
+}
+
+extension JSON.Value {
+  /// Call a function and pass it the JSON representation of a JSON keyword.
+  ///
+  /// - Parameters:
+  ///   - value: A string representing the keyword. `StaticString` is used so
+  ///     that the bytes representing the keyword can be acquired cheaply.
+  ///   - body: The function to invoke. A buffer containing the JSON
+  ///     representation of this keyword is passed.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  private static func _withUnsafeBytesForKeyword<R>(_ value: StaticString, _ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    // NOTE: StaticString.withUTF8Buffer does not rethrow.
+    try withExtendedLifetime(value) {
+      let buffer = UnsafeBufferPointer(start: value.utf8Start, count: value.utf8CodeUnitCount)
+      return try body(.init(buffer))
+    }
+  }
+
+  /// Call a function and pass it the JSON representation of a numeric value.
+  ///
+  /// - Parameters:
+  ///   - value: A numeric value.
+  ///   - body: The function to invoke. A buffer containing the JSON
+  ///     representation of `value` is passed.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  private static func _withUnsafeBytesForNumericValue<V, R>(_ value: V, _ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R where V: Numeric {
+    var string = String(describing: value)
+    return try string.withUTF8 { utf8 in
+      try body(.init(utf8))
+    }
+  }
+
+  /// Call a function and pass it the JSON representation of a string.
+  ///
+  /// - Parameters:
+  ///   - value: A string.
+  ///   - body: The function to invoke. A buffer containing the JSON
+  ///     representation of `value` is passed.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  private static func _withUnsafeBytesForString<R>(_ value: String, _ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    var result = [UInt8]()
+
+    do {
+      result.append(UInt8(ascii: #"""#))
+      defer {
+        result.append(UInt8(ascii: #"""#))
+      }
+
+      let scalars = value.unicodeScalars
+      result.reserveCapacity(scalars.underestimatedCount + 2)
+
+      for scalar in scalars {
+        switch scalar {
+        case Unicode.Scalar(0x0000) ..< Unicode.Scalar(0x0020):
+          let hexValue = String(scalar.value, radix: 16)
+          let leadingZeroes = repeatElement(UInt8(ascii: "0"), count: 4 - hexValue.count)
+          result += leadingZeroes
+          result += hexValue.utf8
+        case #"""#, #"\"#:
+          result += #"\\#(scalar)"#.utf8
+        default:
+          result += scalar.utf8
+        }
+      }
+    }
+
+    return try result.withUnsafeBytes(body)
+  }
+
+  /// Call a function and pass it the JSON representation of an array.
+  ///
+  /// - Parameters:
+  ///   - value: An array of JSON values.
+  ///   - body: The function to invoke. A buffer containing the JSON
+  ///     representation of `value` is passed.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  private static func _withUnsafeBytesForArray<R>(_ value: [JSON.Value], _ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    var result = [UInt8]()
+
+    do {
+      result.append(UInt8(ascii: "["))
+      defer {
+        result.append(UInt8(ascii: "]"))
+      }
+
+      result += value.lazy.map { element in
+        element.withUnsafeBytes { bytes in
+          Array(bytes)
+        }
+      }.joined(separator: CollectionOfOne(UInt8(ascii: ",")))
+    }
+
+    return try result.withUnsafeBytes(body)
+  }
+
+  /// Call a function and pass it the JSON representation of an object (a
+  /// dictionary in Swift).
+  ///
+  /// - Parameters:
+  ///   - value: A JSON object.
+  ///   - body: The function to invoke. A buffer containing the JSON
+  ///     representation of `value` is passed.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  private static func _withUnsafeBytesForObject<R>(_ value: [String: JSON.Value], _ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    var result = [UInt8]()
+
+    do {
+      result.append(UInt8(ascii: "{"))
+      defer {
+        result.append(UInt8(ascii: "}"))
+      }
+
+      result += value.sorted { lhs, rhs in
+        lhs.key < rhs.key
+      }.map { key, value in
+        key.makeJSONValue().withUnsafeBytes { serializedKey in
+          value.withUnsafeBytes { serializedValue in
+            var result = Array(serializedKey)
+            result.append(UInt8(ascii: ":"))
+            result += serializedValue
+            return result
+          }
+        }
+      }.joined(separator: CollectionOfOne(UInt8(ascii: ",")))
+    }
+
+    return try result.withUnsafeBytes(body)
+  }
+
+  /// Call a function and pass it the JSON representation of this JSON value.
+  ///
+  /// - Parameters:
+  ///   - body: The function to invoke. A buffer containing the JSON
+  ///     representation of this value is passed.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    switch self {
+    case .null:
+      return try Self._withUnsafeBytesForKeyword("null", body)
+    case let .bool(value):
+      return try Self._withUnsafeBytesForKeyword(value ? "true" : "false", body)
+    case let .int64(value):
+      return try Self._withUnsafeBytesForNumericValue(value, body)
+    case let .uint64(value):
+      return try Self._withUnsafeBytesForNumericValue(value, body)
+    case let .double(value):
+      return try Self._withUnsafeBytesForNumericValue(value, body)
+    case let .string(value):
+      return try Self._withUnsafeBytesForString(value, body)
+    case let .array(value):
+      return try Self._withUnsafeBytesForArray(value, body)
+    case let .object(value):
+      return try Self._withUnsafeBytesForObject(value, body)
+    }
+  }
+}

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -24,10 +24,7 @@ enum JSON {
   ///
   /// - Throws: Whatever is thrown by `body` or by the encoding process.
   static func withEncoding<J, R>(of value: J, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R where J: JSON.Serializable {
-    let json = try value.makeJSON()
-    return try json.withContiguousStorageIfAvailable { json in
-      try body(.init(json))
-    } ?? Array(json).withUnsafeBytes { json in
+    try value.makeJSONValue().withUnsafeBytes { json in
       try body(json)
     }
   }

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -8,15 +8,41 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 private import Foundation
 #endif
 
 enum JSON {
+  /// Encode a value as JSON.
+  ///
+  /// - Parameters:
+  ///   - value: The value to encode.
+  ///   - userInfo: Any user info to pass into the encoder during encoding.
+  ///   - body: A function to call.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body` or by the encoding process.
+  static func withEncoding<J, R>(of value: J, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R where J: JSON.Serializable {
+    let json = try value.makeJSON()
+    return try json.withContiguousStorageIfAvailable { json in
+      try body(.init(json))
+    } ?? Array(json).withUnsafeBytes { json in
+      try body(json)
+    }
+  }
+}
+
+// MARK: - Foundation-based JSON support
+
+extension JSON {
   /// Whether or not pretty-printed JSON is enabled for this process.
   ///
   /// This is a debugging tool that can be used by developers working on the
   /// testing library to improve the readability of JSON output.
+  ///
+  /// This property is only used by the Foundation-based overload of
+  /// `withEncoding()`. It is ignored when using ``JSON/Serializable``.
   private static let _prettyPrintingEnabled = Environment.flag(named: "SWT_PRETTY_PRINT_JSON") == true
 
   /// Encode a value as JSON.
@@ -29,8 +55,9 @@ enum JSON {
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body` or by the encoding process.
+  @_disfavoredOverload
   static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: any Sendable] = [:], _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
     let encoder = JSONEncoder()
 
     // Keys must be sorted to ensure deterministic matching of encoded data.
@@ -60,7 +87,7 @@ enum JSON {
   ///
   /// - Throws: Whatever is thrown by the decoding process.
   static func decode<T>(_ type: T.Type, from jsonRepresentation: UnsafeRawBufferPointer) throws -> T where T: Decodable {
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
     try withExtendedLifetime(jsonRepresentation) {
       let byteCount = jsonRepresentation.count
       let data = if byteCount > 0 {

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -23,8 +23,8 @@ enum JSON {
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body` or by the encoding process.
-  static func withEncoding<J, R>(of value: J, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R where J: JSON.Serializable {
-    try value.makeJSONValue().withUnsafeBytes { json in
+  static func withEncoding<J, E, R>(of value: J, _ body: (UnsafeRawBufferPointer) throws(E) -> R) throws(E) -> R where J: JSON.Serializable {
+    try value.makeJSONValue().withUnsafeBytes { json throws(E) in
       try body(json)
     }
   }

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -8,12 +8,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_ABI_ENTRY_POINT
-@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
-
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 private import Foundation
 #endif
+
+#if !SWT_NO_ABI_ENTRY_POINT
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
 private import _TestingInternals
 
 @Suite("ABI entry point tests")
@@ -27,8 +28,10 @@ struct ABIEntryPointTests {
     arguments.verbosity = .min
 
     let result = try await _invokeEntryPointV0Experimental(passing: arguments) { recordJSON in
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
       let record = try! JSON.decode(ABI.Record<ABI.v0>.self, from: recordJSON)
       _ = record.kind
+#endif
     }
 
     #expect(result == EXIT_SUCCESS)
@@ -160,7 +163,7 @@ struct ABIEntryPointTests {
     return try await abiEntryPoint(.init(argumentsJSON), recordHandler)
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   @Test func decodeEmptyConfiguration() throws {
     let emptyBuffer = UnsafeRawBufferPointer(start: nil, count: 0)
     #expect(throws: DecodingError.self) {

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 import Foundation
 @_spi(Experimental) import _Testing_Foundation
 #endif
@@ -246,7 +246,7 @@ struct AttachmentTests {
     }
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 #if !SWT_NO_FILE_IO
   @Test func attachContentsOfFileURL() async throws {
     let data = try #require("<!doctype html>".data(using: .utf8))
@@ -468,7 +468,7 @@ extension AttachmentTests {
       try test(value)
     }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
     @Test func data() throws {
       let value = try #require("abc123".data(using: .utf8))
       try test(value)
@@ -607,7 +607,7 @@ struct MySendableAttachableWithDefaultByteCount: Attachable, Sendable {
   }
 }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 struct MyCodableAttachable: Codable, Attachable, Sendable {
   var string: String
 }

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable @_spi(ForToolsIntegrationOnly) import Testing
-#if SWT_TARGET_OS_APPLE && canImport(Foundation)
+#if SWT_TARGET_OS_APPLE && !SWT_NO_FOUNDATION && canImport(Foundation)
 import Foundation
 #endif
 
@@ -72,7 +72,7 @@ struct BacktraceTests {
     }
   }
 
-#if SWT_TARGET_OS_APPLE && canImport(Foundation)
+#if SWT_TARGET_OS_APPLE && !SWT_NO_FOUNDATION && canImport(Foundation)
   @available(_typedThrowsAPI, *)
   @Test("Thrown NSError captures backtrace")
   func thrownNSErrorCapturesBacktrace() async throws {
@@ -141,7 +141,7 @@ struct BacktraceTests {
     #expect(Backtrace(forFirstThrowOf: BacktracedError()) == nil)
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   @Test("Encoding/decoding")
   func encodingAndDecoding() throws {
     let original = Backtrace.current()

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -121,7 +121,7 @@ struct ClockTests {
     #expect(duration == .nanoseconds(offsetNanoseconds))
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   @available(_clockAPI, *)
   @Test("Codable")
   func codable() async throws {

--- a/Tests/TestingTests/DiscoveryTests.swift
+++ b/Tests/TestingTests/DiscoveryTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import _TestDiscovery
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 private import Foundation
 #endif
 
@@ -30,7 +30,7 @@ struct DiscoveryTests {
     #expect(String(describing: kind3).lowercased() == "0xff123456")
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   @Test func testContentKindCodableConformance() throws {
     let kind1: TestContentKind = "moof"
     let data = try JSONEncoder().encode(kind1)

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -12,10 +12,10 @@
 #if !os(Windows)
 import RegexBuilder
 #endif
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
 import Foundation
 #endif
-#if canImport(FoundationXML)
+#if !SWT_NO_FOUNDATION && canImport(FoundationXML)
 import FoundationXML
 #endif
 
@@ -370,7 +370,7 @@ struct EventRecorderTests {
   }
 #endif
 
-#if canImport(Foundation) || canImport(FoundationXML)
+#if !SWT_NO_FOUNDATION && (canImport(Foundation) || canImport(FoundationXML))
   @Test(
     "JUnitXMLRecorder outputs valid XML",
     .bug("https://github.com/swiftlang/swift-testing/issues/254")

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -14,7 +14,7 @@ private import _TestingInternals
 
 @Suite("Event Tests")
 struct EventTests {
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   @Test("Event's and Event.Kinds's Codable Conformances",
         arguments: [
           Event.Kind.expectationChecked(

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1596,7 +1596,7 @@ final class IssueTests: XCTestCase {
 }
 #endif
 
-#if canImport(Foundation) && !SWT_NO_SNAPSHOT_TYPES
+#if !SWT_NO_FOUNDATION && canImport(Foundation) && !SWT_NO_SNAPSHOT_TYPES
 import Foundation
 
 @Suite("Issue Codable Conformance Tests")

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -580,4 +580,13 @@ struct MiscellaneousTests {
     }
     #expect(duration < .seconds(1))
   }
+
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
+  @Test("JSON string escaping")
+  func escapeJSONStrings() throws {
+    let value1 = "abc\t123äßç"
+    let value2 = try JSON.encodeAndDecode(value1)
+    #expect(value1 == value2)
+  }
+#endif
 }

--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -13,7 +13,7 @@
 
 @Suite("Runner.Plan.Snapshot tests")
 struct Runner_Plan_SnapshotTests {
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   @Test("Codable")
   func codable() async throws {
     let suite = try #require(await test(for: Runner_Plan_SnapshotFixtures.self))

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -195,7 +195,7 @@ struct SwiftPMTests {
     #expect(fileContents.contains(UInt8(ascii: ">")))
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   @Test("--configuration-path argument", arguments: [
     "--configuration-path", "--experimental-configuration-path",
   ])

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -37,7 +37,7 @@ struct Test_Case_Argument_IDTests {
     #expect(testCase.arguments.count == 1)
     let argument = try #require(testCase.arguments.first)
     let argumentID = try #require(argument.id)
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
     let decodedArgument = try argumentID.bytes.withUnsafeBufferPointer { argumentID in
       try JSON.decode(MyCustomTestArgument.self, from: .init(argumentID))
     }

--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -13,7 +13,6 @@
 
 @Suite("Test.Snapshot tests")
 struct Test_SnapshotTests {
-#if canImport(Foundation)
   @Test("Codable")
   func codable() throws {
     let test = try #require(Test.current)
@@ -27,7 +26,6 @@ struct Test_SnapshotTests {
     // FIXME: Compare traits as well, once they are included.
     #expect(decoded.parameters == snapshot.parameters)
   }
-#endif
 
   @Test("isParameterized property")
   func isParameterized() async throws {

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -343,9 +343,26 @@ extension JSON {
   /// - Returns: A copy of `value` after encoding and decoding.
   ///
   /// - Throws: Any error encountered encoding or decoding `value`.
+  @_disfavoredOverload
   static func encodeAndDecode<T>(_ value: T) throws -> T where T: Codable {
     try JSON.withEncoding(of: value) { data in
-      try JSON.decode(T.self, from: data)
+      try FileHandle.stdout.write(data)
+      return try JSON.decode(T.self, from: data)
+    }
+  }
+
+  /// Round-trip a value through JSON encoding/decoding.
+  ///
+  /// - Parameters:
+  ///   - value: The value to round-trip.
+  ///
+  /// - Returns: A copy of `value` after encoding and decoding.
+  ///
+  /// - Throws: Any error encountered encoding or decoding `value`.
+  static func encodeAndDecode<T>(_ value: T) throws -> T where T: JSON.Serializable & Codable {
+    try JSON.withEncoding(of: value) { data in
+      try FileHandle.stdout.write(data)
+      return try JSON.decode(T.self, from: data)
     }
   }
 }

--- a/Tests/TestingTests/Traits/BugTests.swift
+++ b/Tests/TestingTests/Traits/BugTests.swift
@@ -84,7 +84,7 @@ struct BugTests {
     #expect(traits.count == 3)
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   @Test("Encoding/decoding")
   func encodingAndDecoding() throws {
     let original = Bug.bug(id: 12345, "Lorem ipsum")

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -98,7 +98,7 @@ struct TagListTests {
     #expect(Tag(userProvidedStringValue: ".red") == .red)
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION && canImport(Foundation)
   @Test("Encoding/decoding tags")
   func encodeAndDecodeTags() throws {
     let array: [Tag] = [.red, .orange, Tag("abc123"), Tag(".abc123")]

--- a/Tests/TestingTests/_Testing_Foundation/FoundationTests.swift
+++ b/Tests/TestingTests/_Testing_Foundation/FoundationTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_UTC_CLOCK
+#if !SWT_NO_FOUNDATION && canImport(Foundation) && !SWT_NO_UTC_CLOCK
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import _Testing_Foundation
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 import Foundation


### PR DESCRIPTION
This PR replaces most of our uses of `JSONEncoder` with a home-grown implementation. Types conform to the internal `JSON.Serializable` protocol and emit strings, numbers, dictionaries, arrays, etc. Unlike with `Codable`, there is no synthesized implementation here.

Pros:

- Less reliance on Foundation (ideally we drop the dependency entirely at some point);
- No need to use existentials to encode a value (allowing us to eventually support Embedded Swift); and
- The potential for more inlining as all the encoding work is done in-module.

Cons:

- Don't Repeat Yourself;
- This implementation doesn't come with a decoder (which is harder to write);
- The implementation of `JSON.Serializable` cannot be supplied by the compiler;
- More code means more technical debt and a higher maintenance burden;
- The implementation is less configurable/customizable than Foundation's; and
- The implementation is not a full `Encoder` conformance, so it cannot be used to reimplement `CustomTestArgumentEncodable`.

Resolves rdar://146964016.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
