### PR TITLE
Set CMP0157 to OLD for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,15 @@
 cmake_minimum_required(VERSION 3.19.6...3.29)
 
 if(POLICY CMP0157)
-  cmake_policy(SET CMP0157 NEW)
+  if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows AND CMAKE_SYSTEM_NAME STREQUAL Android)
+    # CMP0157 causes swift-testing to fail to compile when targetting
+    # Android on Windows due to swift-driver not being present during the
+    # toolchain build. Disable it for now.
+    cmake_policy(SET CMP0157 OLD)
+  else()
+    # New Swift build model: improved incremental build performance and LSP support
+    cmake_policy(SET CMP0157 NEW)
+  endif()
 endif()
 
 project(SwiftTesting


### PR DESCRIPTION
Set CMP0157 to OLD for Android

There is no early swift-driver build for the Windows toolchain. As a result, swift-collections fails to build properly when CMP0157 is set to NEW due to object files not being generated.

This sets CMP0157 to OLD when targetting Android until the early swift-driver is available on Windows.

This is similar to https://github.com/swiftlang/swift-corelibs-foundation/pull/5180
