### PR TITLE
Adjust a timing-sensitive TimeLimitTrait test to avoid flakiness in CI

### DIFF
--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -184,13 +184,17 @@ struct TimeLimitTraitTests {
       await withTaskGroup(of: Void.self) { taskGroup in
         taskGroup.addTask {
           await Test {
-            try await Test.Clock.sleep(for: .seconds(60))
+            try await Test.Clock.sleep(for: .seconds(60) * 60)
           }.run()
         }
         taskGroup.cancelAll()
       }
     }
-    #expect(timeAwaited < .seconds(5)) // less than the 60 second sleep
+
+    // Expect that the time awaited is significantly less than the duration of
+    // the sleep above. To avoid flakiness in CI, allow for a somewhat long
+    // wait, but still much less than the full sleep duration.
+    #expect(timeAwaited < .seconds(60))
   }
 
   @available(_clockAPI, *)


### PR DESCRIPTION
This adjusts the `TimeLimitTraitTests.cancelledTestExitsEarly()` test function to make it less sensitive to running on resource-constrained CI systems.

### Motivation:

Recently on a few PRs I have seen flaky results from this test which are unrelated to my work. They typically show up as console output such as:

```
✘ Test "Cancelled tests can exit early (cancellation checking works)" recorded an issue
  at TimeLimitTraitTests.swift:193:5: Expectation failed:
  (timeAwaited → 5.108262525 seconds) < (.seconds(5) → 5.0 seconds)
```

This indicates the test is just a little too sensitive to specific timing.

### Modifications:

- Lengthen the "full" sleep duration the test would run if it wasn't cancelled, which it is.
- Extend the much shorter duration it allows for waiting, to avoid false positives when running on resource-constrained CI systems.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
