### PR TITLE
Work around a compiler crash building `Attachment.record()`.

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -265,7 +265,7 @@ extension Attachment where AttachableValue: Sendable & Copyable {
   /// An attachment can only be attached once.
   @_documentation(visibility: private)
   public static func record(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #_sourceLocation) {
-    record(Self(attachableValue, named: preferredName), sourceLocation: sourceLocation)
+    record(Self(attachableValue, named: preferredName, sourceLocation: sourceLocation), sourceLocation: sourceLocation)
   }
 }
 #endif
@@ -326,7 +326,7 @@ extension Attachment where AttachableValue: ~Copyable {
   ///
   /// An attachment can only be attached once.
   public static func record(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #_sourceLocation) {
-    record(Self(attachableValue, named: preferredName), sourceLocation: sourceLocation)
+    record(Self(attachableValue, named: preferredName, sourceLocation: sourceLocation), sourceLocation: sourceLocation)
   }
 }
 


### PR DESCRIPTION
This PR works around a compiler crash that appeared in CI while building one of the overloads of `Attachment.record()`.

Works around rdar://147543560.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
