### PR TITLE
Ensure `Locked+Platform.swift` is not stripped when statically linking.

### DIFF
--- a/Sources/Testing/Support/Locked+Platform.swift
+++ b/Sources/Testing/Support/Locked+Platform.swift
@@ -94,3 +94,14 @@ typealias DefaultLock = Never
 #warning("Platform-specific implementation missing: locking unavailable")
 typealias DefaultLock = Never
 #endif
+
+#if SWT_NO_DYNAMIC_LINKING
+/// A function which, when called by another file, ensures that the file in
+/// which ``DefaultLock`` is declared is linked.
+///
+/// When static linking is used, the linker may opt to strip some or all of the
+/// symbols (including protocol conformance metadata) declared in this file.
+/// ``LockedWith`` calls this function in ``LockedWith/init(rawValue:)`` to work
+/// around that issue.
+func linkLockImplementations() {}
+#endif

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -66,6 +66,10 @@ struct LockedWith<L, T>: RawRepresentable where L: Lockable {
   private nonisolated(unsafe) var _storage: ManagedBuffer<T, L>
 
   init(rawValue: T) {
+#if SWT_NO_DYNAMIC_LINKING
+    linkLockImplementations()
+#endif
+
     _storage = _Storage.create(minimumCapacity: 1, makingHeaderWith: { _ in rawValue })
     _storage.withUnsafeMutablePointerToElements { lock in
       L.initializeLock(at: lock)


### PR DESCRIPTION
All symbols in Locked+Platform.swift are referenced _indirectly_ by the Swift compiler due to `LockedWith` being generic, which can cause symbols from that file (including protocol conformance metadata) to be stripped at link time as if it were unused. This change (hopefully) works around that issue.

Works around rdar://147250336.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
