### PR TITLE
Qualify `@__testing(warning:)` usage in macro expansion with module name and enhance a related unit test

### DIFF
--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -86,7 +86,7 @@ func makeTestContentRecordDecl(named name: TokenSyntax, in typeName: TypeSyntax?
   #elseif os(Windows)
   @_section(".sw5test$B")
   #else
-  @__testing(warning: "Platform-specific implementation missing: test content section name unavailable")
+  @Testing.__testing(warning: "Platform-specific implementation missing: test content section name unavailable")
   #endif
   @_used
   #endif

--- a/Tests/TestingMacrosTests/PragmaMacroTests.swift
+++ b/Tests/TestingMacrosTests/PragmaMacroTests.swift
@@ -22,6 +22,7 @@ struct PragmaMacroTests {
     let node = """
     @Testing.__testing(semantics: "abc123")
     @__testing(semantics: "def456")
+    @UnrelatedModule.__testing(semantics: "xyz789")
     let x = 0
     """ as DeclSyntax
     let nodeWithAttributes = try #require(node.asProtocol((any WithAttributesSyntax).self))


### PR DESCRIPTION
A small enhancement to the `@Test` and `@Suite` macro expansion changes made in #880: qualify the `@__testing(warning:)` usage with the module name.

I also took the opportunity to enhance a unit test related to `@__testing(semantics:)`. It already correctly checks the attribute module name if present, and this test simply validates that.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
