### PR TITLE
🍒6.1: [CMake] Set CMP0157 to OLD when targeting Android with the Windows toolchain (#1009)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,14 @@
 cmake_minimum_required(VERSION 3.19.6...3.29)
 
 if(POLICY CMP0157)
-  cmake_policy(SET CMP0157 NEW)
+  if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows AND CMAKE_SYSTEM_NAME STREQUAL Android)
+    # CMP0157 causes builds to fail when targetting Android with the Windows
+    # toolchain, because the early swift-driver isn't (yet) available. Disable
+    # it for now.
+    cmake_policy(SET CMP0157 OLD)
+  else()
+    cmake_policy(SET CMP0157 NEW)
+  endif()
 endif()
 
 project(SwiftTesting


### PR DESCRIPTION
The C++ Swift Driver on Windows doesn't emit objects in the same place as the Swift Swift Driver when building for Android resulting in build failures about missing object files.

```
<unknown>:0: error: no such file or directory: 'Sources/Testing/CMakeFiles/Testing.dir/ABI/EntryPoints/ABIEntryPoint.swift.o'
<unknown>:0: error: no such file or directory: 'Sources/Testing/CMakeFiles/Testing.dir/ABI/EntryPoints/EntryPoint.swift.o'
<unknown>:0: error: no such file or directory: 'Sources/Testing/CMakeFiles/Testing.dir/ABI/EntryPoints/SwiftPMEntryPoint.swift.o'
...
```

Cherry-picking https://github.com/swiftlang/swift-testing/pull/1009 to unblock the 6.1 release: https://ci-external.swift.org/job/swift-6.1-windows-toolchain/164/

(cherry picked from commit a5dfbc2507eb7b745f164ec52bc5f6d92b9c38e3)
