### PR TITLE
Emit a diagnostic if an exit test's body closure includes a capture list.

### DIFF
--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -764,3 +764,51 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   var severity: DiagnosticSeverity
   var fixIts: [FixIt] = []
 }
+
+// MARK: - Captured values
+
+extension DiagnosticMessage {
+  /// Create a diagnostic message stating that a capture clause cannot be used
+  /// in an exit test.
+  ///
+  /// - Parameters:
+  ///   - captureClause: The invalid capture clause.
+  ///   - closure: The closure containing `captureClause`.
+  ///   - exitTestMacro: The containing exit test macro invocation.
+  ///
+  /// - Returns: A diagnostic message.
+  static func captureClauseUnsupported(_ captureClause: ClosureCaptureClauseSyntax, in closure: ClosureExprSyntax, inExitTest exitTestMacro: some FreestandingMacroExpansionSyntax) -> Self {
+    let changes: [FixIt.Change]
+    if let signature = closure.signature,
+       Array(signature.with(\.capture, nil).tokens(viewMode: .sourceAccurate)).count == 1 {
+      // The only remaining token in the signature is `in`, so remove the whole
+      // signature tree instead of just the capture clause.
+      changes = [
+        .replaceTrailingTrivia(token: closure.leftBrace, newTrivia: ""),
+        .replace(
+          oldNode: Syntax(signature),
+          newNode: Syntax("" as ExprSyntax)
+        )
+      ]
+    } else {
+      changes = [
+        .replace(
+          oldNode: Syntax(captureClause),
+          newNode: Syntax("" as ExprSyntax)
+        )
+      ]
+    }
+
+    return Self(
+      syntax: Syntax(captureClause),
+      message: "Cannot specify a capture clause in closure passed to \(_macroName(exitTestMacro))",
+      severity: .error,
+      fixIts: [
+        FixIt(
+          message: MacroExpansionFixItMessage("Remove '\(captureClause.trimmed)'"),
+          changes: changes
+        ),
+      ]
+    )
+  }
+}

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -383,6 +383,23 @@ struct ConditionMacroTests {
     #expect(diagnostic.message.contains("is redundant"))
   }
 
+  @Test(
+    "Capture list on an exit test produces a diagnostic",
+    arguments: [
+      "#expectExitTest(exitsWith: x) { [a] in }":
+        "Cannot specify a capture clause in closure passed to '#expectExitTest(exitsWith:_:)'"
+    ]
+  )
+  func exitTestCaptureListProducesDiagnostic(input: String, expectedMessage: String) throws {
+    let (_, diagnostics) = try parse(input)
+
+    #expect(diagnostics.count > 0)
+    for diagnostic in diagnostics {
+      #expect(diagnostic.diagMessage.severity == .error)
+      #expect(diagnostic.message == expectedMessage)
+    }
+  }
+
   @Test("Macro expansion is performed within a test function")
   func macroExpansionInTestFunction() throws {
     let input = ##"""


### PR DESCRIPTION
This PR adds a custom diagnostic for `#expect(exitsWith:)` if the passed closure visibly closes over any state (via a capture list). For example:

```swift
await #expect(exitsWith: .failure) { [x] in
  // ...
}
```

Produces:

>  🛑 Cannot specify a capture clause in closure passed to '#expect(exitsWith:_:)'

With a fix-it to remove the capture list.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
