### PR TITLE
Miscellaneous bookkeeping/cleanup of `_TestDiscovery`.

### DIFF
--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -30,12 +30,10 @@ enum TestContentKind: UInt32 {
   /// This kind value as a comment (`/* 'abcd' */`) if it looks like it might be
   /// a [FourCC](https://en.wikipedia.org/wiki/FourCC) value, or `nil` if not.
   var commentRepresentation: Trivia {
-    switch self {
-    case .testDeclaration:
-      .blockComment("/* 'test' */")
-    case .exitTest:
-      .blockComment("/* 'exit' */")
+    let stringValue = withUnsafeBytes(of: self.rawValue.bigEndian) { bytes in
+      String(decoding: bytes, as: Unicode.ASCII.self)
     }
+    return .blockComment("/* '\(stringValue)' */")
   }
 }
 

--- a/Sources/_TestDiscovery/DiscoverableAsTestContent.swift
+++ b/Sources/_TestDiscovery/DiscoverableAsTestContent.swift
@@ -48,8 +48,10 @@ public protocol DiscoverableAsTestContent: Sendable, ~Copyable {
 #endif
 }
 
+#if !SWT_NO_LEGACY_TEST_DISCOVERY
 extension DiscoverableAsTestContent where Self: ~Copyable {
   public static var _testContentTypeNameHint: String {
     "__🟡$"
   }
 }
+#endif

--- a/Sources/_TestDiscovery/SectionBounds.swift
+++ b/Sources/_TestDiscovery/SectionBounds.swift
@@ -52,11 +52,11 @@ extension SectionBounds.Kind {
   /// The Mach-O segment and section name for this instance as a pair of
   /// null-terminated UTF-8 C strings and pass them to a function.
   ///
-  /// The values of this property within this function are instances of
-  /// `StaticString` rather than `String` because the latter's inner storage is
-  /// sometimes Objective-C-backed and touching it here can cause a recursive
-  /// access to an internal libobjc lock, whereas `StaticString`'s internal
-  /// storage is immediately available.
+  /// The values of this property are instances of `StaticString` rather than
+  /// `String` because the latter's inner storage is sometimes backed by
+  /// Objective-C and touching it here can cause a recursive access to an
+  /// internal libobjc lock, whereas `StaticString`'s internal storage is
+  /// immediately available.
   fileprivate var segmentAndSectionName: (segmentName: StaticString, sectionName: StaticString) {
     switch self {
     case .testContent:

--- a/Sources/_TestDiscovery/TestContentKind.swift
+++ b/Sources/_TestDiscovery/TestContentKind.swift
@@ -60,8 +60,8 @@ extension TestContentKind: Codable {}
 
 extension TestContentKind: ExpressibleByStringLiteral, ExpressibleByIntegerLiteral {
   @inlinable public init(stringLiteral stringValue: StaticString) {
-    precondition(stringValue.utf8CodeUnitCount == MemoryLayout<UInt32>.stride, #""\#(stringValue)".utf8CodeUnitCount = \#(stringValue.utf8CodeUnitCount), expected \#(MemoryLayout<UInt32>.stride)"#)
     let rawValue = stringValue.withUTF8Buffer { stringValue in
+      precondition(stringValue.count == MemoryLayout<UInt32>.stride, #""\#(stringValue)".utf8CodeUnitCount = \#(stringValue.count), expected \#(MemoryLayout<UInt32>.stride)"#)
       let bigEndian = UnsafeRawBufferPointer(stringValue).loadUnaligned(as: UInt32.self)
       return UInt32(bigEndian: bigEndian)
     }
@@ -81,12 +81,11 @@ extension TestContentKind: CustomStringConvertible {
   /// value, or `nil` if not.
   private var _fourCCValue: String? {
     withUnsafeBytes(of: rawValue.bigEndian) { bytes in
-      if bytes.allSatisfy(Unicode.ASCII.isASCII) {
-        let characters = String(decoding: bytes, as: Unicode.ASCII.self)
-        let allAlphanumeric = characters.allSatisfy { $0.isLetter || $0.isWholeNumber }
-        if allAlphanumeric {
-          return characters
-        }
+      let allPrintableASCII = bytes.allSatisfy { byte in
+        Unicode.ASCII.isASCII(byte) && 0 != isprint(CInt(byte))
+      }
+      if allPrintableASCII {
+        return String(decoding: bytes, as: Unicode.ASCII.self)
       }
       return nil
     }

--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -26,6 +26,7 @@
 ///
 /// - Note: Avoid including headers that aren't actually used.
 
+#include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
 /// Guard against including `signal.h` on WASI. The `signal.h` header file


### PR DESCRIPTION
This PR has a few minor changes:

- The default implementation of `DiscoverableAsTestContent._testContentTypeNameHint` is not present if `SWT_NO_LEGACY_TEST_DISCOVERY` is defined;
- Fixed the precondition in `TestContentKind.init(stringLiteral:)` so it doesn't call `utf8CodeUnitCount` on single-character static strings;
- The implementation of `TestContentKind._fourCCValue` uses `isprint()` to check if the kind value looks like a FourCC rather than calling ICU-based functions;
- Fixed a type in a comment on `SectionBounds.Kind.segmentAndSectionName`; and
- Simplified the implementation of `TestContentKind.commentRepresentation` (in the macro target).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
