### PR TITLE
Add signal handler for `SIGABRT_COMPAT` on Windows.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -214,7 +214,7 @@ extension ExitTest {
     // exit code that is unlikely to be encountered "in the wild" and which
     // encodes the caught signal. Corresponding code in the parent process looks
     // for these special exit codes and translates them back to signals.
-    for sig in [SIGINT, SIGILL, SIGFPE, SIGSEGV, SIGTERM, SIGBREAK, SIGABRT] {
+    for sig in [SIGINT, SIGILL, SIGFPE, SIGSEGV, SIGTERM, SIGBREAK, SIGABRT, SIGABRT_COMPAT] {
       _ = signal(sig) { sig in
         _Exit(STATUS_SIGNAL_CAUGHT_BITS | sig)
       }


### PR DESCRIPTION
The special-case signal handling implemented for Windows doesn't currently set a handler for `SIGABRT_COMPAT` (which is a synonym of `SIGABRT` with a different value.) This PR adds it to the list of signals we install handlers for.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
