### PR TITLE
Don't use a class to store the current exit test.

### DIFF
--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -88,7 +88,7 @@ struct LockedWith<L, T>: RawRepresentable where L: Lockable {
   /// This function can be used to synchronize access to shared data from a
   /// synchronous caller. Wherever possible, use actor isolation or other Swift
   /// concurrency tools.
-  nonmutating func withLock<R>(_ body: (inout T) throws -> R) rethrows -> R {
+  nonmutating func withLock<R>(_ body: (inout T) throws -> R) rethrows -> R where R: ~Copyable {
     try _storage.withUnsafeMutablePointers { rawValue, lock in
       L.unsafelyAcquireLock(at: lock)
       defer {
@@ -118,7 +118,7 @@ struct LockedWith<L, T>: RawRepresentable where L: Lockable {
   /// - Warning: Callers that unlock the lock _must_ lock it again before the
   ///   closure returns. If the lock is not acquired when `body` returns, the
   ///   effect is undefined.
-  nonmutating func withUnsafeUnderlyingLock<R>(_ body: (UnsafeMutablePointer<L>, T) throws -> R) rethrows -> R {
+  nonmutating func withUnsafeUnderlyingLock<R>(_ body: (UnsafeMutablePointer<L>, T) throws -> R) rethrows -> R where R: ~Copyable {
     try withLock { value in
       try _storage.withUnsafeMutablePointerToElements { lock in
         try body(lock, value)


### PR DESCRIPTION
This PR replaces the private `_CurrentContainer` class used to store the current exit test with a bare pointer. The class is prone to duplicate definitions, but we really just use it as a glorified box type for the move-only `ExitTest`, so an immortal pointer will work just as well.

Works around rdar://148837303.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
