### PR TITLE
Fully-qualify reference to Swift's `Actor` protocol in macro expansion code for synchronous test functions

### DIFF
--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -328,7 +328,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
         }
         FunctionParameterSyntax(
           firstName: .wildcardToken(),
-          type: "isolated (any Actor)?" as TypeSyntax,
+          type: "isolated (any _Concurrency.Actor)?" as TypeSyntax,
           defaultValue: InitializerClauseSyntax(value: "Testing.__defaultSynchronousIsolationContext" as ExprSyntax)
         )
       }

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -139,6 +139,11 @@ struct SendableTests: Sendable {
 @Suite("Named Sendable test type", .hidden)
 struct NamedSendableTests: Sendable {}
 
+// This is meant to help detect unqualified usages of the `Actor` protocol from
+// Swift's `_Concurrency` module in macro expansion code, since it's possible
+// for another module to declare a type with that name.
+private class Actor {}
+
 #if !SWT_NO_GLOBAL_ACTORS
 @Suite(.hidden)
 @MainActor


### PR DESCRIPTION
This fixes a compilation error in code expanded from the `@Test` macro when it's attached to a synchronous (i.e. non-`async`) test function in a context where there is a concrete type named `Actor`. For example, the following code reproduces the error:

```swift
// In MyApp
public class Actor {}

// In test code
import Testing
import MyApp

// ❌ 'any' has no effect on concrete type 'Actor'
//  - 'isolated' parameter type 'Actor?' does not conform to 'Actor' or 'DistributedActor'
@Test func example() /* No 'async' */ {}
```

The macro code includes an unqualified reference to a type by that name, but it's intended to refer to the protocol in Swift's `_Concurrency` module. The fix is to ensure the macro's reference to this protocol is fully-qualified with a module name.

This was first reported on the Swift Forums in https://forums.swift.org/t/error-isolated-parameter-type-actor-does-not-conform-to-actor-or-distributedactor/79190. This bug was introduced in #747, which first landed in Swift 6.1 and Xcode 16.3.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
