### PR TITLE
Introduce a severity level when recording issues

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -74,9 +74,31 @@ extension Issue {
     _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
-    let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
-    let issue = Issue(kind: .unconditional, comments: Array(comment), sourceContext: sourceContext)
-    return issue.record()
+    return Self.record(comment, sourceLocation: sourceLocation, severity: .error)
+  }
+
+  /// Record an issue when a running test fails unexpectedly.
+  ///
+  /// - Parameters:
+  ///   - comment: A comment describing the expectation.
+  ///   - sourceLocation: The source location to which the issue should be
+  ///     attributed.
+  ///   - severity: The severity of the issue.
+  ///
+  /// - Returns: The issue that was recorded.
+  ///
+  /// Use this function if, while running a test, an issue occurs that cannot be
+  /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
+  /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
+  @_spi(Experimental)
+  @discardableResult public static func record(
+    _ comment: Comment? = nil,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    severity: Severity
+  ) -> Self {
+      let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
+      let issue = Issue(kind: .unconditional, severity: severity, comments: Array(comment), sourceContext: sourceContext)
+      return issue.record()
   }
 }
 
@@ -102,10 +124,7 @@ extension Issue {
     _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
-    let backtrace = Backtrace(forFirstThrowOf: error) ?? Backtrace.current()
-    let sourceContext = SourceContext(backtrace: backtrace, sourceLocation: sourceLocation)
-    let issue = Issue(kind: .errorCaught(error), comments: Array(comment), sourceContext: sourceContext)
-    return issue.record()
+    return Self.record(error, comment, sourceLocation: sourceLocation, severity: .error)
   }
   
   /// Record a new issue when a running test unexpectedly catches an error.
@@ -128,7 +147,7 @@ extension Issue {
     _ error: any Error,
     _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation,
-    severity: Severity = .error,
+    severity: Severity
   ) -> Self {
     let backtrace = Backtrace(forFirstThrowOf: error) ?? Backtrace.current()
     let sourceContext = SourceContext(backtrace: backtrace, sourceLocation: sourceLocation)

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -74,7 +74,7 @@ extension Issue {
     _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
-    return Self.record(comment, sourceLocation: sourceLocation, severity: .error)
+    record(comment, sourceLocation: sourceLocation, severity: .error)
   }
 
   /// Record an issue when a running test fails unexpectedly.
@@ -124,7 +124,7 @@ extension Issue {
     _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
-    return Self.record(error, comment, sourceLocation: sourceLocation, severity: .error)
+    record(error, comment, sourceLocation: sourceLocation, severity: .error)
   }
   
   /// Record a new issue when a running test unexpectedly catches an error.

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -74,16 +74,16 @@ extension Issue {
     _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
-    record(comment, sourceLocation: sourceLocation, severity: .error)
+    record(comment, severity: .error, sourceLocation: sourceLocation)
   }
 
   /// Record an issue when a running test fails unexpectedly.
   ///
   /// - Parameters:
   ///   - comment: A comment describing the expectation.
+  ///   - severity: The severity of the issue.
   ///   - sourceLocation: The source location to which the issue should be
   ///     attributed.
-  ///   - severity: The severity of the issue.
   ///
   /// - Returns: The issue that was recorded.
   ///
@@ -93,12 +93,12 @@ extension Issue {
   @_spi(Experimental)
   @discardableResult public static func record(
     _ comment: Comment? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation,
-    severity: Severity
+    severity: Severity,
+    sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
-      let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
-      let issue = Issue(kind: .unconditional, severity: severity, comments: Array(comment), sourceContext: sourceContext)
-      return issue.record()
+    let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
+    let issue = Issue(kind: .unconditional, severity: severity, comments: Array(comment), sourceContext: sourceContext)
+    return issue.record()
   }
 }
 
@@ -124,7 +124,7 @@ extension Issue {
     _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
-    record(error, comment, sourceLocation: sourceLocation, severity: .error)
+    record(error, comment, severity: .error, sourceLocation: sourceLocation)
   }
   
   /// Record a new issue when a running test unexpectedly catches an error.
@@ -132,9 +132,9 @@ extension Issue {
   /// - Parameters:
   ///   - error: The error that caused the issue.
   ///   - comment: A comment describing the expectation.
+  ///   - severity: The severity of the issue.
   ///   - sourceLocation: The source location to which the issue should be
   ///     attributed.
-  ///   - severity: The severity of the issue.
   ///
   /// - Returns: The issue that was recorded.
   ///
@@ -146,8 +146,8 @@ extension Issue {
   @discardableResult public static func record(
     _ error: any Error,
     _ comment: Comment? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation,
-    severity: Severity
+    severity: Severity,
+    sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
     let backtrace = Backtrace(forFirstThrowOf: error) ?? Backtrace.current()
     let sourceContext = SourceContext(backtrace: backtrace, sourceLocation: sourceLocation)

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -107,6 +107,34 @@ extension Issue {
     let issue = Issue(kind: .errorCaught(error), comments: Array(comment), sourceContext: sourceContext)
     return issue.record()
   }
+  
+  /// Record a new issue when a running test unexpectedly catches an error.
+  ///
+  /// - Parameters:
+  ///   - error: The error that caused the issue.
+  ///   - comment: A comment describing the expectation.
+  ///   - sourceLocation: The source location to which the issue should be
+  ///     attributed.
+  ///   - severity: The severity of the issue.
+  ///
+  /// - Returns: The issue that was recorded.
+  ///
+  /// This function can be used if an unexpected error is caught while running a
+  /// test and it should be treated as a test failure. If an error is thrown
+  /// from a test function, it is automatically recorded as an issue and this
+  /// function does not need to be used.
+  @_spi(Experimental)
+  @discardableResult public static func record(
+    _ error: any Error,
+    _ comment: Comment? = nil,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    severity: Severity = .error,
+  ) -> Self {
+    let backtrace = Backtrace(forFirstThrowOf: error) ?? Backtrace.current()
+    let sourceContext = SourceContext(backtrace: backtrace, sourceLocation: sourceLocation)
+    let issue = Issue(kind: .errorCaught(error), severity: severity, comments: Array(comment), sourceContext: sourceContext)
+    return issue.record()
+  }
 
   /// Catch any error thrown from a closure and record it as an issue instead of
   /// allowing it to propagate to the caller.

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1010,7 +1010,7 @@ final class IssueTests: XCTestCase {
         return
       }
       XCTAssertFalse(issue.isKnown)
-      XCTAssertTrue(issue.severity == .error)
+      XCTAssertEqual(issue.severity, .error)
       guard case .unconditional = issue.kind else {
         XCTFail("Unexpected issue kind \(issue.kind)")
         return
@@ -1030,7 +1030,7 @@ final class IssueTests: XCTestCase {
         return
       }
       XCTAssertFalse(issue.isKnown)
-      XCTAssertTrue(issue.severity == .warning)
+      XCTAssertEqual(issue.severity, .warning)
       guard case .unconditional = issue.kind else {
         XCTFail("Unexpected issue kind \(issue.kind)")
         return
@@ -1068,7 +1068,7 @@ final class IssueTests: XCTestCase {
         return
       }
       XCTAssertFalse(issue.isKnown)
-      XCTAssertTrue(issue.severity == .error)
+      XCTAssertEqual(issue.severity, .error)
       guard case let .errorCaught(error) = issue.kind else {
         XCTFail("Unexpected issue kind \(issue.kind)")
         return
@@ -1089,7 +1089,7 @@ final class IssueTests: XCTestCase {
         return
       }
       XCTAssertFalse(issue.isKnown)
-      XCTAssertTrue(issue.severity == .warning)
+      XCTAssertEqual(issue.severity, .warning)
       guard case let .errorCaught(error) = issue.kind else {
         XCTFail("Unexpected issue kind \(issue.kind)")
         return


### PR DESCRIPTION
Introduce a severity level when recording issues

### Motivation:

In order to create issues that don't fail a test this introduces a parameter to specify the severity of the issue.  This is in support of work added here for an issue severity: https://github.com/swiftlang/swift-testing/pull/931

This is experimental.

Example usage:
`Issue.record("My comment", severity: .warning)`

### Modifications:

I modified the `Issue.record` method signature to take in a severity level so that users can create issues that are not failing. 

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
- [x] Add tests
