### PR TITLE
🍒 [6.1.2] Fully-qualify reference to Swift's `Actor` protocol in macro expansion code for synchronous test functions

### DIFF
--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -333,7 +333,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
         }
         FunctionParameterSyntax(
           firstName: .wildcardToken(),
-          type: "isolated (any Actor)?" as TypeSyntax,
+          type: "isolated (any _Concurrency.Actor)?" as TypeSyntax,
           defaultValue: InitializerClauseSyntax(value: "Testing.__defaultSynchronousIsolationContext" as ExprSyntax)
         )
       }

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -137,6 +137,11 @@ struct SendableTests: Sendable {
 @Suite("Named Sendable test type", .hidden)
 struct NamedSendableTests: Sendable {}
 
+// This is meant to help detect unqualified usages of the `Actor` protocol from
+// Swift's `_Concurrency` module in macro expansion code, since it's possible
+// for another module to declare a type with that name.
+private class Actor {}
+
 #if !SWT_NO_GLOBAL_ACTORS
 @Suite(.hidden)
 @MainActor


### PR DESCRIPTION
  - **Explanation**: This fixes a compilation error in code expanded from the `@Test` macro when it's attached to a synchronous (i.e. non-`async`) test function in a context where there is a concrete type named `Actor`.
  - **Scope**: Affects tests in code which also has a custom type named `Actor`.
  - **Issues**: n/a
  - **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1067
  - **Risk**: Low
  - **Testing**: Modified tests to detect this.
  - **Reviewers**: @grynspan 
