### PR TITLE
Add `CustomStringConvertible` conformance to `ExitTest.Condition` and `StatusAtExit`.

### DIFF
--- a/Sources/Testing/ExitTests/StatusAtExit.swift
+++ b/Sources/Testing/ExitTests/StatusAtExit.swift
@@ -71,3 +71,19 @@ public enum StatusAtExit: Sendable {
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 extension StatusAtExit: Equatable {}
+
+// MARK: - CustomStringConvertible
+@_spi(Experimental)
+#if SWT_NO_PROCESS_SPAWNING
+@available(*, unavailable, message: "Exit tests are not available on this platform.")
+#endif
+extension StatusAtExit: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case let .exitCode(exitCode):
+      ".exitCode(\(exitCode))"
+    case let .signal(signal):
+      ".signal(\(signal))"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `CustomStringConvertible` conformance to these data/value types so that they are presented reasonably in expectation failure messages or when printed.

Strictly speaking, API changes should go through a review, but there's not really anything to review here, so with the consent of the Testing Workgroup we can amend the exit tests proposal to retroactively include these conformances.

See also: https://github.com/swiftlang/swift-evolution/pull/2789

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
