### PR TITLE
Add support for the `--attachments-path` CLI argument.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -285,8 +285,8 @@ public struct __CommandLineArguments_v0: Sendable {
   /// The value of the `--repeat-until` argument.
   public var repeatUntil: String?
 
-  /// The value of the `--experimental-attachments-path` argument.
-  public var experimentalAttachmentsPath: String?
+  /// The value of the `--attachments-path` argument.
+  public var attachmentsPath: String?
 
   /// Whether or not the experimental warning issue severity feature should be
   /// enabled.
@@ -314,7 +314,7 @@ extension __CommandLineArguments_v0: Codable {
     case skip
     case repetitions
     case repeatUntil
-    case experimentalAttachmentsPath
+    case attachmentsPath
   }
 }
 
@@ -396,8 +396,9 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   }
 
   // Attachment output
-  if let attachmentsPathIndex = args.firstIndex(of: "--experimental-attachments-path"), !isLastArgument(at: attachmentsPathIndex) {
-    result.experimentalAttachmentsPath = args[args.index(after: attachmentsPathIndex)]
+  if let attachmentsPathIndex = args.firstIndex(of: "--attachments-path") ?? args.firstIndex(of: "--experimental-attachments-path"),
+     !isLastArgument(at: attachmentsPathIndex) {
+    result.attachmentsPath = args[args.index(after: attachmentsPathIndex)]
   }
 #endif
 
@@ -509,9 +510,9 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
   }
 
   // Attachment output.
-  if let attachmentsPath = args.experimentalAttachmentsPath {
+  if let attachmentsPath = args.attachmentsPath {
     guard fileExists(atPath: attachmentsPath) else {
-      throw _EntryPointError.invalidArgument("--experimental-attachments-path", value: attachmentsPath)
+      throw _EntryPointError.invalidArgument("---attachments-path", value: attachmentsPath)
     }
     configuration.attachmentsPath = attachmentsPath
   }

--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -30,9 +30,9 @@ public struct Attachment<AttachableValue>: ~Copyable where AttachableValue: Atta
   ///
   /// If a developer sets the ``Configuration/attachmentsPath`` property of the
   /// current configuration before running tests, or if a developer passes
-  /// `--experimental-attachments-path` on the command line, then attachments
-  /// will be automatically written to disk when they are attached and the value
-  /// of this property will describe the path where they were written.
+  /// `--attachments-path` on the command line, then attachments will be
+  /// automatically written to disk when they are attached and the value of this
+  /// property will describe the path where they were written.
   ///
   /// If no destination path is set, or if an error occurred while writing this
   /// attachment to disk, the value of this property is `nil`.
@@ -412,9 +412,9 @@ extension Attachment where AttachableValue: ~Copyable {
   /// The attachment is written to a file _within_ `directoryPath`, whose name
   /// is derived from the value of the ``Attachment/preferredName`` property.
   ///
-  /// If you pass `--experimental-attachments-path` to `swift test`, the testing
-  /// library automatically uses this function to persist attachments to the
-  /// directory you specify.
+  /// If you pass `--attachments-path` to `swift test`, the testing library
+  /// automatically uses this function to persist attachments to the directory
+  /// you specify.
   ///
   /// This function does not get or set the value of the attachment's
   /// ``fileSystemPath`` property. The caller is responsible for setting the


### PR DESCRIPTION
This PR adds support for the `--attachments-path` CLI argument on `swift test` as approved in [ST-0009](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0009-attachments.md). We will maintain support for the older `--experimental-attachments-path` version through Swift 6.2.

Resolves rdar://147753783.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
