### PR TITLE
Add runtime issue kind and record issue with a kind

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -62,6 +62,7 @@ extension Issue {
   ///
   /// - Parameters:
   ///   - comment: A comment describing the expectation.
+  ///   - kind: The kind of issue.
   ///   - sourceLocation: The source location to which the issue should be
   ///     attributed.
   ///
@@ -72,15 +73,17 @@ extension Issue {
   /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
   @discardableResult public static func record(
     _ comment: Comment? = nil,
+    kind: Kind = .unconditional,
     sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
-    record(comment, severity: .error, sourceLocation: sourceLocation)
+    record(comment, kind: kind, severity: .error, sourceLocation: sourceLocation)
   }
 
   /// Record an issue when a running test fails unexpectedly.
   ///
   /// - Parameters:
   ///   - comment: A comment describing the expectation.
+  ///   - kind: The kind of issue.
   ///   - severity: The severity of the issue.
   ///   - sourceLocation: The source location to which the issue should be
   ///     attributed.
@@ -93,11 +96,12 @@ extension Issue {
   @_spi(Experimental)
   @discardableResult public static func record(
     _ comment: Comment? = nil,
+    kind: Kind = .unconditional,
     severity: Severity,
     sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
     let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
-    let issue = Issue(kind: .unconditional, severity: severity, comments: Array(comment), sourceContext: sourceContext)
+    let issue = Issue(kind: kind, severity: severity, comments: Array(comment), sourceContext: sourceContext)
     return issue.record()
   }
 }

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -73,6 +73,10 @@ public struct Issue: Sendable {
     /// An issue due to a failure in the underlying system, not due to a failure
     /// within the tests being run.
     case system
+    
+    /// An issue which occurred during runtime, either by the system or by using a test author recording it using
+    /// ``Issue/record(_:kind:)``.
+    case runtime
   }
 
   /// The kind of issue this value represents.
@@ -263,6 +267,8 @@ extension Issue.Kind: CustomStringConvertible {
       return "An API was misused"
     case .system:
       return "A system failure occurred"
+    case .runtime:
+      return "A runtime issue occurred"
     }
   }
 }
@@ -416,6 +422,10 @@ extension Issue.Kind {
     /// An issue due to a failure in the underlying system, not due to a failure
     /// within the tests being run.
     case system
+    
+    /// An issue which occurred during runtime, either by the system or by using a test author recording it using
+    /// ``Issue/record(_:kind:)``.
+    case runtime
 
     /// Initialize an instance of this type by snapshotting the specified issue
     /// kind.
@@ -440,6 +450,8 @@ extension Issue.Kind {
           .apiMisused
       case .system:
           .system
+      case .runtime:
+          .runtime
       }
     }
 
@@ -453,6 +465,7 @@ extension Issue.Kind {
       case knownIssueNotRecorded
       case apiMisused
       case system
+      case runtime
 
       /// The keys used to encode ``Issue.Kind.expectationFailed``.
       enum _ExpectationFailedKeys: CodingKey {
@@ -531,6 +544,8 @@ extension Issue.Kind {
         try container.encode(true, forKey: .apiMisused)
       case .system:
         try container.encode(true, forKey: .system)
+      case .runtime:
+        try container.encode(true, forKey: .runtime)
       }
     }
   }
@@ -585,6 +600,8 @@ extension Issue.Kind.Snapshot: CustomStringConvertible {
       "An API was misused"
     case .system:
       "A system failure occurred"
+    case .runtime:
+      "A runtime issue occurred"
     }
   }
 }


### PR DESCRIPTION
Add runtime issue kind and record issue with a kind

### Motivation:

Runtime issues are reports of programming errors at runtime.  These are different than test failures because those are pointing out issues in your project while runtime issues point out errors in how/what you code. 

This will allow anyone to report a runtime issue during a test.
### Modifications:

- Added support for specifying a kind when recording an issue
- Added a runtime issue type for users to report runtime issues

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
