### PR TITLE
Add isFailure to Issue

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -42,7 +42,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
 
     // Set up the event handler.
     configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
-      if case let .issueRecorded(issue) = event.kind, !issue.isKnown, issue.severity >= .error {
+      if case let .issueRecorded(issue) = event.kind, issue.isFailure {
         exitCode.withLock { exitCode in
           exitCode = EXIT_FAILURE
         }

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -108,7 +108,8 @@ public struct Issue: Sendable {
   /// considered a failure.
   ///
   /// The value of this property is `true` for issues which have a severity level of
-  /// ``Issue/Severity/error``` or greater and are not known issues via ``withKnownIssue(_:...)``.
+  /// ``Issue/Severity/error``` or greater and are not known issues via
+  /// ``withKnownIssue(_:isIntermittent:sourceLocation:_:when:matching:)``.
   /// Otherwise, the value of this property is `false.`
   ///
   /// Use this property to determine if an issue should be considered a failure, instead of

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -103,6 +103,12 @@ public struct Issue: Sendable {
   /// The severity of this issue.
   @_spi(Experimental)
   public var severity: Severity
+  
+  /// If the issues is a failing issue.
+  @_spi(Experimental)
+  public var isFailure: Bool {
+    return !self.isKnown && self.severity >= .error
+  }
 
   /// Any comments provided by the developer and associated with this issue.
   ///

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -108,7 +108,7 @@ public struct Issue: Sendable {
   /// considered a failure.
   ///
   /// The value of this property is `true` for issues which have a severity level of
-  /// ``Issue/Severity/error``` or greater and are not known issues via
+  /// ``Issue/Severity/error`` or greater and are not known issues via
   /// ``withKnownIssue(_:isIntermittent:sourceLocation:_:when:matching:)``.
   /// Otherwise, the value of this property is `false.`
   ///

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -104,7 +104,15 @@ public struct Issue: Sendable {
   @_spi(Experimental)
   public var severity: Severity
   
-  /// If the issues is a failing issue.
+  /// Whether or not this issue should cause the test it's associated with to be
+  /// considered a failure.
+  ///
+  /// The value of this property is `true` for issues which have a severity level of
+  /// ``Issue/Severity/error``` or greater and are not known issues via ``withKnownIssue(_:...)``.
+  /// Otherwise, the value of this property is `false.`
+  ///
+  /// Use this property to determine if an issue should be considered a failure, instead of
+  /// directly comparing the value of the ``severity`` property.
   @_spi(Experimental)
   public var isFailure: Bool {
     return !self.isKnown && self.severity >= .error

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1011,6 +1011,7 @@ final class IssueTests: XCTestCase {
       }
       XCTAssertFalse(issue.isKnown)
       XCTAssertEqual(issue.severity, .error)
+      XCTAssertTrue(issue.isFailure)
       guard case .unconditional = issue.kind else {
         XCTFail("Unexpected issue kind \(issue.kind)")
         return
@@ -1031,6 +1032,7 @@ final class IssueTests: XCTestCase {
       }
       XCTAssertFalse(issue.isKnown)
       XCTAssertEqual(issue.severity, .warning)
+      XCTAssertFalse(issue.isFailure)
       guard case .unconditional = issue.kind else {
         XCTFail("Unexpected issue kind \(issue.kind)")
         return

--- a/Tests/TestingTests/KnownIssueTests.swift
+++ b/Tests/TestingTests/KnownIssueTests.swift
@@ -10,7 +10,7 @@
 
 #if canImport(XCTest)
 import XCTest
-@testable @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 final class KnownIssueTests: XCTestCase {
   func testIssueIsKnownPropertyIsSetCorrectly() async {
@@ -26,6 +26,7 @@ final class KnownIssueTests: XCTestCase {
       issueRecorded.fulfill()
 
       XCTAssertTrue(issue.isKnown)
+      XCTAssertFalse(issue.isFailure)
     }
 
     await Test {


### PR DESCRIPTION
Add `isFailure` var to `Issue`

### Motivation:

This adds a variable to `Issue` in order to inspect if an issue isFailing.  This will be nice when inspecting an issue after it is recorded.

### Modifications:

- Add `isFailure` variable
- Update existing code to use `isFailure` 

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
