### PR TITLE
Ensure the .whenEmbedded() build setting condition evaluates to false when building for non-Embedded without a fallback condition

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -239,8 +239,9 @@ extension BuildSettingCondition {
       if let nonEmbeddedCondition = nonEmbeddedCondition() {
         nonEmbeddedCondition
       } else {
-        // The caller did not supply a fallback.
-        .when(platforms: [])
+        // The caller did not supply a fallback. Specify a non-existent platform
+        // to ensure this condition never matches.
+        .when(platforms: [.custom("DoesNotExist")])
       }
     } else {
       // Enable unconditionally because the target is Embedded Swift.


### PR DESCRIPTION
This fixes an unintended side effect from #1043 where the `SWT_NO_LEGACY_TEST_DISCOVERY` compilation conditional was being applied when building for non-Embedded.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
