### PR TITLE
Enable Library Evolution for package-based builds of the _TestDiscovery target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -171,7 +171,7 @@ let package = Package(
       dependencies: ["_TestingInternals",],
       exclude: ["CMakeLists.txt"],
       cxxSettings: .packageSettings,
-      swiftSettings: .packageSettings
+      swiftSettings: .packageSettings + .enableLibraryEvolution()
     ),
 
     // Cross-import overlays (not supported by Swift Package Manager)


### PR DESCRIPTION
This enables Library Evolution (LE) for the `_TestDiscovery` target in Swift package-based builds. The CMake-based build is already configured to enable LE for this target, so this is just matching behavior.

(Note that we already enable LE for several other targets which vend public API as of #951.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
