### PR TITLE
Enable experimental 'AllowUnsafeAttribute' feature to continue supporting 6.1 development snapshot toolchains

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -277,6 +277,17 @@ extension Array where Element == PackageDescription.SwiftSetting {
       // proposal via Swift Evolution.
       .enableExperimentalFeature("SymbolLinkageMarkers"),
 
+      // This setting is no longer needed when building with a 6.2 or later
+      // toolchain now that SE-0458 has been accepted and implemented, but it is
+      // needed in order to preserve support for building with 6.1 development
+      // snapshot toolchains. (Production 6.1 toolchains can build the testing
+      // library even without this setting since this experimental feature is
+      // _suppressible_.) This setting can be removed once the minimum supported
+      // toolchain for building the testing library is ≥ 6.2. It is not needed
+      // in the CMake settings since that is expected to build using a
+      // new-enough toolchain.
+      .enableExperimentalFeature("AllowUnsafeAttribute"),
+
       // When building as a package, the macro plugin always builds as an
       // executable rather than a library.
       .define("SWT_NO_LIBRARY_MACRO_PLUGINS"),


### PR DESCRIPTION
This fixes a build failure when attempting to build the `main` branch using a 6.1 development snapshot toolchain. This failure was introduced by #1069, which added usage of the new `@unsafe` attribute, and the failure was revealed when we set up the 6.1 CI jobs in #1083.

Here are some relevant related Swift PRs which give context around these changes:

- https://github.com/swiftlang/swift/pull/75413
- https://github.com/swiftlang/swift/pull/79645

See the code comment for more details.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
