### PR TITLE
Reserve the 'play' content kind in _TestDiscovery

### DIFF
--- a/Documentation/ABI/TestContent.md
+++ b/Documentation/ABI/TestContent.md
@@ -100,6 +100,7 @@ record's kind is a 32-bit unsigned value. The following kinds are defined:
 | `0x00000000` | &ndash; | Reserved (**do not use**) |
 | `0x74657374` | `'test'` | Test or suite declaration |
 | `0x65786974` | `'exit'` | Exit test |
+| `0x706c6179` | `'play'` | Playground |
 
 <!-- When adding cases to this enumeration, be sure to also update the
 corresponding enumeration in TestContentGeneration.swift. -->

--- a/Documentation/ABI/TestContent.md
+++ b/Documentation/ABI/TestContent.md
@@ -100,10 +100,10 @@ record's kind is a 32-bit unsigned value. The following kinds are defined:
 | `0x00000000` | &ndash; | Reserved (**do not use**) |
 | `0x74657374` | `'test'` | Test or suite declaration |
 | `0x65786974` | `'exit'` | Exit test |
-| `0x706c6179` | `'play'` | Playground |
+| `0x706c6179` | `'play'` | [Playground](https://github.com/apple/swift-play-experimental) |
 
-<!-- When adding cases to this enumeration, be sure to also update the
-corresponding enumeration in TestContentGeneration.swift. -->
+<!-- The kind values listed in this table should be a superset of the cases in
+the `TestContentKind` enumeration. -->
 
 If a test content record's `kind` field equals `0x00000000`, the values of all
 other fields in that record are undefined.

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -27,9 +27,6 @@ enum TestContentKind: UInt32 {
   /// An exit test.
   case exitTest = 0x65786974
 
-  /// A Swift playground.
-  case playground = 0x706c6179
-
   /// This kind value as a comment (`/* 'abcd' */`) if it looks like it might be
   /// a [FourCC](https://en.wikipedia.org/wiki/FourCC) value, or `nil` if not.
   var commentRepresentation: Trivia {

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -27,6 +27,9 @@ enum TestContentKind: UInt32 {
   /// An exit test.
   case exitTest = 0x65786974
 
+  /// A Swift playground.
+  case playground = 0x706c6179
+
   /// This kind value as a comment (`/* 'abcd' */`) if it looks like it might be
   /// a [FourCC](https://en.wikipedia.org/wiki/FourCC) value, or `nil` if not.
   var commentRepresentation: Trivia {


### PR DESCRIPTION
This defines the `'play'` test content kind in the `TestContentKind` enum and corresponding documentation.

### Motivation:

This is intended to "reserve" this FourCC code for eventual use by the [swift-play-experimental](https://github.com/apple/swift-play-experimental) project, which has adopted the `_TestDiscovery` library from this package.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Fixes #1089
Fixes rdar://147585572