### PR TITLE
Fix crash in ConsoleOutputRecorder when an issue has a comment with an empty string

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -323,7 +323,7 @@ extension Event.ConsoleOutputRecorder {
         // text instead of just the symbol. Details may be multi-line messages,
         // so split the message on newlines and indent all lines to align them
         // to the indentation provided by the symbol.
-        var lines = message.stringValue.split(whereSeparator: \.isNewline)
+        var lines = message.stringValue.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
         lines = CollectionOfOne(lines[0]) + lines.dropFirst().map { line in
           "\(padding) \(line)"
         }

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -257,6 +257,30 @@ struct EventRecorderTests {
   }
 #endif
 
+  @Test(
+    "Uncommonly-formatted comments",
+    .bug("rdar://149482060"),
+    arguments: [
+      "", // Empty string
+      "\n\n\n", // Only newlines
+      "\nFoo\n\nBar\n\n\nBaz\n", // Newlines interspersed with non-empty strings
+    ]
+  )
+  func uncommonComments(text: String) async throws {
+    let stream = Stream()
+
+    var configuration = Configuration()
+    configuration.eventHandlingOptions.isWarningIssueRecordedEventEnabled = true
+    let eventRecorder = Event.ConsoleOutputRecorder(writingUsing: stream.write)
+    configuration.eventHandler = { event, context in
+      eventRecorder.record(event, in: context)
+    }
+
+    await Test {
+      Issue.record(Comment(rawValue: text) /* empty */)
+    }.run(configuration: configuration)
+  }
+
   @available(_regexAPI, *)
   @Test("Issue counts are omitted on a successful test")
   func issueCountOmittedForPassingTest() async throws {


### PR DESCRIPTION
This fixes a crash which can occur when recording an issue with a comment whose string is empty. It also adds some test coverage of this scenario and other "uncommon" comment examples.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Fixes rdar://149482060
