### PR TITLE
Fix build failure when building with pre-6.2 toolchain due to unrecognized `unsafe` keyword

### DIFF
--- a/Sources/TestingMacros/Support/EffectfulExpressionHandling.swift
+++ b/Sources/TestingMacros/Support/EffectfulExpressionHandling.swift
@@ -111,7 +111,13 @@ func applyEffectfulKeywords(_ effectfulKeywords: Set<Keyword>, to expr: some Exp
 
   let needAwait = effectfulKeywords.contains(.await) && !expr.is(AwaitExprSyntax.self)
   let needTry = effectfulKeywords.contains(.try) && !expr.is(TryExprSyntax.self)
+
+  // The 'unsafe' keyword was introduced in 6.2 as part of SE-0458. Older
+  // toolchains are not aware of it, so avoid emitting expressions involving
+  // that keyword when the macro has been built using an older toolchain.
+#if compiler(>=6.2)
   let needUnsafe = effectfulKeywords.contains(.unsafe) && !expr.is(UnsafeExprSyntax.self)
+#endif
 
   // First, add thunk function calls.
   if needAwait {
@@ -120,9 +126,11 @@ func applyEffectfulKeywords(_ effectfulKeywords: Set<Keyword>, to expr: some Exp
   if needTry {
     expr = _makeCallToEffectfulThunk(.identifier("__requiringTry"), passing: expr)
   }
+#if compiler(>=6.2)
   if needUnsafe {
     expr = _makeCallToEffectfulThunk(.identifier("__requiringUnsafe"), passing: expr)
   }
+#endif
 
   // Then add keyword expressions. (We do this separately so we end up writing
   // `try await __r(__r(self))` instead of `try __r(await __r(self))` which is
@@ -143,6 +151,7 @@ func applyEffectfulKeywords(_ effectfulKeywords: Set<Keyword>, to expr: some Exp
       )
     )
   }
+#if compiler(>=6.2)
   if needUnsafe {
     expr = ExprSyntax(
       UnsafeExprSyntax(
@@ -151,6 +160,7 @@ func applyEffectfulKeywords(_ effectfulKeywords: Set<Keyword>, to expr: some Exp
       )
     )
   }
+#endif
 
   expr.leadingTrivia = originalExpr.leadingTrivia
   expr.trailingTrivia = originalExpr.trailingTrivia


### PR DESCRIPTION
This fixes another bit of fallout from #1069 when building this project's test targets with a 6.1 (or any pre-6.2) toolchain.

The `unsafe` keyword was introduced in 6.2 as part of [SE-0458: Opt-in Strict Memory Safety Checking](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0458-strict-memory-safety.md). Older toolchains are not aware of it, so the fix is to avoid emitting expressions involving that keyword when the macro plugin has been built using an older toolchain.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
