### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 #
 
-* @stmontgomery @grynspan @briancroom @SeanROlszewski @suzannaratcliff
+* @stmontgomery @grynspan @briancroom @suzannaratcliff


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file to remove @SeanROlszewski as a code owner. We sincerely thank him for his valuable contributions and past collaboration!

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
