### PR TITLE
Merge 'main' branch to 'release/6.2'

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 #
 
-* @stmontgomery @grynspan @briancroom @SeanROlszewski @suzannaratcliff
+* @stmontgomery @grynspan @briancroom @suzannaratcliff

--- a/Documentation/ABI/TestContent.md
+++ b/Documentation/ABI/TestContent.md
@@ -100,9 +100,10 @@ record's kind is a 32-bit unsigned value. The following kinds are defined:
 | `0x00000000` | &ndash; | Reserved (**do not use**) |
 | `0x74657374` | `'test'` | Test or suite declaration |
 | `0x65786974` | `'exit'` | Exit test |
+| `0x706c6179` | `'play'` | [Playground](https://github.com/apple/swift-play-experimental) |
 
-<!-- When adding cases to this enumeration, be sure to also update the
-corresponding enumeration in TestContentGeneration.swift. -->
+<!-- The kind values listed in this table should be a superset of the cases in
+the `TestContentKind` enumeration. -->
 
 If a test content record's `kind` field equals `0x00000000`, the values of all
 other fields in that record are undefined.

--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -323,7 +323,7 @@ extension Event.ConsoleOutputRecorder {
         // text instead of just the symbol. Details may be multi-line messages,
         // so split the message on newlines and indent all lines to align them
         // to the indentation provided by the symbol.
-        var lines = message.stringValue.split(whereSeparator: \.isNewline)
+        var lines = message.stringValue.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
         lines = CollectionOfOne(lines[0]) + lines.dropFirst().map { line in
           "\(padding) \(line)"
         }

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -157,8 +157,17 @@ extension ConditionMacro {
         expandedFunctionName = conditionArgument.expandedFunctionName
       }
 
-      // Capture any comments as well (either in source or as a macro argument.)
+      // Capture any comments as well -- either in source, preceding the
+      // expression macro or one of its lexical context nodes, or as an argument
+      // to the macro.
       let commentsArrayExpr = ArrayExprSyntax {
+        // Lexical context is ordered innermost-to-outermost, so reverse it to
+        // maintain the expected order.
+        for lexicalSyntaxNode in context.lexicalContext.trailingEffectExpressions.reversed() {
+          for commentTraitExpr in createCommentTraitExprs(for: lexicalSyntaxNode) {
+            ArrayElementSyntax(expression: commentTraitExpr)
+          }
+        }
         for commentTraitExpr in createCommentTraitExprs(for: macro) {
           ArrayElementSyntax(expression: commentTraitExpr)
         }

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -240,6 +240,59 @@ struct ConditionMacroTests {
       // Capture me
       Testing.__checkValue(try x(), expression: .__fromSyntaxNode("try x()"), comments: [.__line("// Capture me")], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()
       """,
+
+      """
+      // Capture me
+      try #expect(x)
+      """:
+      """
+      // Capture me
+      try Testing.__checkValue(x, expression: .__fromSyntaxNode("x"), comments: [.__line("// Capture me")], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()
+      """,
+
+      """
+      // Capture me
+      await #expect(x)
+      """:
+      """
+      // Capture me
+      await Testing.__checkValue(x, expression: .__fromSyntaxNode("x"), comments: [.__line("// Capture me")], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()
+      """,
+
+      """
+      // Ignore me
+
+      // Comment for try
+      try
+      // Comment for await
+      await
+      // Comment for expect
+      #expect(x)
+      """:
+      """
+      // Comment for try
+      try
+      // Comment for await
+      await
+      // Comment for expect
+      Testing.__checkValue(x, expression: .__fromSyntaxNode("x"), comments: [.__line("// Comment for try"), .__line("// Comment for await"), .__line("// Comment for expect")], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()
+      """,
+
+      """
+      // Ignore me
+      func example() {
+        // Capture me
+        #expect(x())
+      }
+      """:
+      """
+      func example() {
+        // Capture me
+        Testing.__checkFunctionCall((), calling: { _ in
+          x()
+        }, expression: .__fromFunctionCall(nil, "x"), comments: [.__line("// Capture me")], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()
+      }
+      """,
     ]
   )
   func commentCapture(input: String, expectedOutput: String) throws {

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -257,6 +257,30 @@ struct EventRecorderTests {
   }
 #endif
 
+  @Test(
+    "Uncommonly-formatted comments",
+    .bug("rdar://149482060"),
+    arguments: [
+      "", // Empty string
+      "\n\n\n", // Only newlines
+      "\nFoo\n\nBar\n\n\nBaz\n", // Newlines interspersed with non-empty strings
+    ]
+  )
+  func uncommonComments(text: String) async throws {
+    let stream = Stream()
+
+    var configuration = Configuration()
+    configuration.eventHandlingOptions.isWarningIssueRecordedEventEnabled = true
+    let eventRecorder = Event.ConsoleOutputRecorder(writingUsing: stream.write)
+    configuration.eventHandler = { event, context in
+      eventRecorder.record(event, in: context)
+    }
+
+    await Test {
+      Issue.record(Comment(rawValue: text) /* empty */)
+    }.run(configuration: configuration)
+  }
+
   @available(_regexAPI, *)
   @Test("Issue counts are omitted on a successful test")
   func issueCountOmittedForPassingTest() async throws {


### PR DESCRIPTION
This merges the `main` branch into the `release/6.2` branch.

> Note: The Swift Testing project will be periodically performing "backwards" merges like this for a period which extends beyond the date when the 6.2 branches were cut, since nearly all contributions are intended to be included in the 6.2 release.

Once this PR has been merged, I will adjust the milestones on the PRs included in this merge to be 6.2 wherever appropriate.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
