### PR TITLE
Remove experimental status for evaluate() and add metadata

### DIFF
--- a/Sources/Testing/Traits/ConditionTrait.swift
+++ b/Sources/Testing/Traits/ConditionTrait.swift
@@ -69,7 +69,10 @@ public struct ConditionTrait: TestTrait, SuiteTrait {
   ///
   /// The evaluation is performed each time this function is called, and is not
   /// cached.
-  @_spi(Experimental)
+  /// 
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.2)
+  /// }
   public func evaluate() async throws -> Bool {
     switch kind {
     case let .conditional(condition):

--- a/Tests/TestingTests/Traits/ConditionTraitTests.swift
+++ b/Tests/TestingTests/Traits/ConditionTraitTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable @_spi(Experimental) import Testing
+@testable import Testing
 
 @Suite("Condition Trait Tests", .tags(.traitRelated))
 struct ConditionTraitTests {


### PR DESCRIPTION
Remove experimental status for ConditionTrait.evaluate() and add metadata

### Motivation:

Now that the proposal has been accepted, the experimental tag can be removed.

### Modifications:

* Removed the `@_spi(Experimental)` attribute from `ConditionTrait.evaluate()`
* Added metadata to the doc comment marking it as part of Swift 6.2

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
