### PR TITLE
Work around a macOS CI failure

### DIFF
--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -491,6 +491,7 @@ final class IssueTests: XCTestCase {
     }.run(configuration: .init())
   }
 
+#if !SWT_TARGET_OS_APPLE || SWT_FIXED_149299786
   func testErrorCheckingWithExpect() async throws {
     let expectationFailed = expectation(description: "Expectation failed")
     expectationFailed.isInverted = true
@@ -610,6 +611,7 @@ final class IssueTests: XCTestCase {
 
     await fulfillment(of: [expectationFailed], timeout: 0.0)
   }
+#endif
 
   func testErrorCheckingWithExpect_mismatchedErrorDescription() async throws {
     let expectationFailed = expectation(description: "Expectation failed")


### PR DESCRIPTION
This works around a macOS CI failure. A revert in the Swift compiler (in https://github.com/swiftlang/swift/pull/80830) is expected to resolve it, but the release of a newer `main` development snapshot toolchain is blocked for unrelated reasons.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
