### PR TITLE
Simplify usages of withTaskGroup to infer ChildTaskResult type where possible

### DIFF
--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -156,7 +156,7 @@ extension Runner {
     in sequence: some Sequence<E>,
     _ body: @Sendable @escaping (E) async throws -> Void
   ) async throws where E: Sendable {
-    try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+    try await withThrowingTaskGroup { taskGroup in
       for element in sequence {
         // Each element gets its own subtask to run in.
         _ = taskGroup.addTaskUnlessCancelled {
@@ -430,7 +430,7 @@ extension Runner {
           Event.post(.iterationEnded(iterationIndex), for: (nil, nil), configuration: runner.configuration)
         }
 
-        await withTaskGroup(of: Void.self) { [runner] taskGroup in
+        await withTaskGroup { [runner] taskGroup in
           _ = taskGroup.addTaskUnlessCancelled {
             try? await _runStep(atRootOf: runner.plan.stepGraph)
           }

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -84,7 +84,7 @@ extension Test {
       // a task group and collate their results.
       if useNewMode {
         let generators = Generator.allTestContentRecords().lazy.compactMap { $0.load() }
-        await withTaskGroup(of: Self.self) { taskGroup in
+        await withTaskGroup { taskGroup in
           for generator in generators {
             taskGroup.addTask { await generator.rawValue() }
           }
@@ -96,7 +96,7 @@ extension Test {
       // Perform legacy test discovery if needed.
       if useLegacyMode && result.isEmpty {
         let generators = Generator.allTypeMetadataBasedTestContentRecords().lazy.compactMap { $0.load() }
-        await withTaskGroup(of: Self.self) { taskGroup in
+        await withTaskGroup { taskGroup in
           for generator in generators {
             taskGroup.addTask { await generator.rawValue() }
           }

--- a/Sources/Testing/Traits/TimeLimitTrait.swift
+++ b/Sources/Testing/Traits/TimeLimitTrait.swift
@@ -264,7 +264,7 @@ func withTimeLimit(
   _ body: @escaping @Sendable () async throws -> Void,
   timeoutHandler: @escaping @Sendable () -> Void
 ) async throws {
-  try await withThrowingTaskGroup(of: Void.self) { group in
+  try await withThrowingTaskGroup { group in
     group.addTask {
       // If sleep() returns instead of throwing a CancellationError, that means
       // the timeout was reached before this task could be cancelled, so call

--- a/Tests/TestingTests/Support/CartesianProductTests.swift
+++ b/Tests/TestingTests/Support/CartesianProductTests.swift
@@ -96,7 +96,7 @@ struct CartesianProductTests {
     // Test that the product can be iterated multiple times concurrently.
     let (_, _, product) = computeCartesianProduct()
     let expectedSum = product.reduce(into: 0) { $0 &+= $1.1 }
-    await withTaskGroup(of: Int.self) { taskGroup in
+    await withTaskGroup { taskGroup in
       for _ in 0 ..< 10 {
         taskGroup.addTask {
           product.reduce(into: 0) { $0 &+= $1.1 }

--- a/Tests/TestingTests/Support/LockTests.swift
+++ b/Tests/TestingTests/Support/LockTests.swift
@@ -36,7 +36,7 @@ struct LockTests {
   @Test("No lock")
   func noLock() async {
     let lock = LockedWith<Never, Int>(rawValue: 0)
-    await withTaskGroup(of: Void.self) { taskGroup in
+    await withTaskGroup { taskGroup in
       for _ in 0 ..< 100_000 {
         taskGroup.addTask {
           lock.increment()

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -181,7 +181,7 @@ struct TimeLimitTraitTests {
   @Test("Cancelled tests can exit early (cancellation checking works)")
   func cancelledTestExitsEarly() async throws {
     let timeAwaited = await Test.Clock().measure {
-      await withTaskGroup(of: Void.self) { taskGroup in
+      await withTaskGroup { taskGroup in
         taskGroup.addTask {
           await Test {
             try await Test.Clock.sleep(for: .seconds(60) * 60)


### PR DESCRIPTION
This adjusts usages of `withTaskGroup` and `withThrowingTaskGroup` to take advantage of [SE-0442: Allow TaskGroup's ChildTaskResult Type To Be Inferred](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0442-allow-taskgroup-childtaskresult-type-to-be-inferred.md) by inferring the child task result type.

I successfully built this PR using a Swift 6.1 toolchain. A couple usages I _did_ need to leave explicitly specified, but most I was able to simplify.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
