### PR TITLE
Restore DocC `@Comment` blocks to documentation line comments

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -131,11 +131,11 @@ extension Attachment where AttachableValue == AnyAttachable {
 /// events of kind ``Event/Kind/valueAttached(_:)``. Test tools authors who use
 /// `@_spi(ForToolsIntegrationOnly)` will see instances of this type when
 /// handling those events.
-//
-// @Comment {
-//   Swift's type system requires that this type be at least as visible as
-//   `Event.Kind.valueAttached(_:)`, otherwise it would be declared private.
-// }
+///
+/// @Comment {
+///   Swift's type system requires that this type be at least as visible as
+///   `Event.Kind.valueAttached(_:)`, otherwise it would be declared private.
+/// }
 @_spi(ForToolsIntegrationOnly)
 public struct AnyAttachable: AttachableWrapper, Copyable, Sendable {
 #if !SWT_NO_LAZY_ATTACHMENTS

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -49,12 +49,12 @@ public struct Issue: Sendable {
     ///
     /// - Parameters:
     ///   - timeLimitComponents: The time limit reached by the test.
-    //
-    // @Comment {
-    //   - Bug: The associated value of this enumeration case should be an
-    //     instance of `Duration`, but the testing library's deployment target
-    //     predates the introduction of that type.
-    // }
+    ///
+    /// @Comment {
+    ///   - Bug: The associated value of this enumeration case should be an
+    ///     instance of `Duration`, but the testing library's deployment target
+    ///     predates the introduction of that type.
+    /// }
     indirect case timeLimitExceeded(timeLimitComponents: (seconds: Int64, attoseconds: Int64))
 
     /// A known issue was expected, but was not recorded.
@@ -434,12 +434,12 @@ extension Issue.Kind {
     ///
     /// - Parameters:
     ///   - timeLimitComponents: The time limit reached by the test.
-    //
-    // @Comment {
-    //   - Bug: The associated value of this enumeration case should be an
-    //     instance of `Duration`, but the testing library's deployment target
-    //     predates the introduction of that type.
-    // }
+    ///
+    /// @Comment {
+    ///   - Bug: The associated value of this enumeration case should be an
+    ///     instance of `Duration`, but the testing library's deployment target
+    ///     predates the introduction of that type.
+    /// }
     indirect case timeLimitExceeded(timeLimitComponents: (seconds: Int64, attoseconds: Int64))
 
     /// A known issue was expected, but was not recorded.

--- a/Sources/Testing/Parameterization/Test.Case.Generator.swift
+++ b/Sources/Testing/Parameterization/Test.Case.Generator.swift
@@ -13,11 +13,11 @@ extension Test.Case {
   /// a known collection of argument values.
   ///
   /// Instances of this type can be iterated over multiple times.
-  //
-  // @Comment {
-  //   - Bug: The testing library should support variadic generics.
-  //     ([103416861](rdar://103416861))
-  // }
+  ///
+  /// @Comment {
+  ///   - Bug: The testing library should support variadic generics.
+  ///     ([103416861](rdar://103416861))
+  /// }
   struct Generator<S>: Sendable where S: Sequence & Sendable, S.Element: Sendable {
     /// The underlying sequence of argument values.
     ///
@@ -146,11 +146,11 @@ extension Test.Case {
     ///
     /// This initializer overload is specialized for sequences of 2-tuples to
     /// efficiently de-structure their elements when appropriate.
-    //
-    // @Comment {
-    //   - Bug: The testing library should support variadic generics.
-    //     ([103416861](rdar://103416861))
-    // }
+    ///
+    /// @Comment {
+    ///   - Bug: The testing library should support variadic generics.
+    ///     ([103416861](rdar://103416861))
+    /// }
     private init<E1, E2>(
       sequence: S,
       parameters: [Test.Parameter],
@@ -184,11 +184,11 @@ extension Test.Case {
     ///
     /// This initializer overload is specialized for collections of 2-tuples to
     /// efficiently de-structure their elements when appropriate.
-    //
-    // @Comment {
-    //   - Bug: The testing library should support variadic generics.
-    //     ([103416861](rdar://103416861))
-    // }
+    ///
+    /// @Comment {
+    ///   - Bug: The testing library should support variadic generics.
+    ///     ([103416861](rdar://103416861))
+    /// }
     init<E1, E2>(
       arguments collection: S,
       parameters: [Test.Parameter],

--- a/Sources/Testing/Support/CartesianProduct.swift
+++ b/Sources/Testing/Support/CartesianProduct.swift
@@ -17,11 +17,11 @@
 /// `[(1, "a"), (1, "b"), (1, "c"), (2, "a"), (2, "b"), ... (3, "c")]`.
 ///
 /// This type is not part of the public interface of the testing library.
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
+///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
 struct CartesianProduct<C1, C2>: LazySequenceProtocol where C1: Collection, C2: Collection {
   fileprivate var collection1: C1
   fileprivate var collection2: C2
@@ -63,11 +63,11 @@ extension CartesianProduct: Sendable where C1: Sendable, C2: Sendable {}
 /// while `collection2` is iterated `collection1.count` times.
 ///
 /// For more information on Cartesian products, see ``CartesianProduct``.
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
+///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
 func cartesianProduct<C1, C2>(_ collection1: C1, _ collection2: C2) -> CartesianProduct<C1, C2> where C1: Collection, C2: Collection {
   CartesianProduct(collection1: collection1, collection2: collection2)
 }

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -220,14 +220,14 @@ public macro Test<C>(
 /// During testing, the associated test function is called once for each element
 /// in `collection`.
 ///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
+///
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
 @attached(peer) public macro Test<C>(
   _ displayName: _const String? = nil,
   _ traits: any TestTrait...,
@@ -273,14 +273,14 @@ extension Test {
 /// During testing, the associated test function is called once for each pair of
 /// elements in `collection1` and `collection2`.
 ///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
+///
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
 @attached(peer)
 @_documentation(visibility: private)
 public macro Test<C1, C2>(
@@ -301,14 +301,14 @@ public macro Test<C1, C2>(
 /// During testing, the associated test function is called once for each pair of
 /// elements in `collection1` and `collection2`.
 ///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
+///
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
 @attached(peer) public macro Test<C1, C2>(
   _ displayName: _const String? = nil,
   _ traits: any TestTrait...,
@@ -327,14 +327,14 @@ public macro Test<C1, C2>(
 /// During testing, the associated test function is called once for each element
 /// in `zippedCollections`.
 ///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
+///
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
 @attached(peer)
 @_documentation(visibility: private)
 public macro Test<C1, C2>(
@@ -355,14 +355,14 @@ public macro Test<C1, C2>(
 /// During testing, the associated test function is called once for each element
 /// in `zippedCollections`.
 ///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
+///
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
 @attached(peer) public macro Test<C1, C2>(
   _ displayName: _const String? = nil,
   _ traits: any TestTrait...,

--- a/Sources/Testing/Traits/ConditionTrait.swift
+++ b/Sources/Testing/Traits/ConditionTrait.swift
@@ -115,12 +115,12 @@ extension Trait where Self == ConditionTrait {
   ///
   /// - Returns: An instance of ``ConditionTrait`` that evaluates the
   ///   closure you provide.
-  //
-  // @Comment {
-  //   - Bug: `condition` cannot be `async` without making this function
-  //     `async` even though `condition` is not evaluated locally.
-  //     ([103037177](rdar://103037177))
-  // }
+  ///
+  /// @Comment {
+  ///   - Bug: `condition` cannot be `async` without making this function
+  ///     `async` even though `condition` is not evaluated locally.
+  ///     ([103037177](rdar://103037177))
+  /// }
   public static func enabled(
     if condition: @autoclosure @escaping @Sendable () throws -> Bool,
     _ comment: Comment? = nil,
@@ -174,12 +174,12 @@ extension Trait where Self == ConditionTrait {
   ///
   /// - Returns: An instance of ``ConditionTrait`` that evaluates the
   ///   closure you provide.
-  //
-  // @Comment {
-  //   - Bug: `condition` cannot be `async` without making this function
-  //     `async` even though `condition` is not evaluated locally.
-  //     ([103037177](rdar://103037177))
-  // }
+  ///
+  /// @Comment {
+  ///   - Bug: `condition` cannot be `async` without making this function
+  ///     `async` even though `condition` is not evaluated locally.
+  ///     ([103037177](rdar://103037177))
+  /// }
   public static func disabled(
     if condition: @autoclosure @escaping @Sendable () throws -> Bool,
     _ comment: Comment? = nil,

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -162,11 +162,11 @@ extension Test {
   ///   - testFunction: The function to call when running this test. During
   ///     testing, this function is called once for each element in
   ///     `collection`.
-  //
-  // @Comment {
-  //   - Bug: The testing library should support variadic generics.
-  //     ([103416861](rdar://103416861))
-  // }
+  ///
+  /// @Comment {
+  ///   - Bug: The testing library should support variadic generics.
+  ///     ([103416861](rdar://103416861))
+  /// }
   init<C>(
     _ traits: any TestTrait...,
     arguments collection: C,
@@ -191,11 +191,11 @@ extension Test {
   ///   - testFunction: The function to call when running this test. During
   ///     testing, this function is called once for each pair of elements in
   ///     `collection1` and `collection2`.
-  //
-  // @Comment {
-  //   - Bug: The testing library should support variadic generics.
-  //     ([103416861](rdar://103416861))
-  // }
+  ///
+  /// @Comment {
+  ///   - Bug: The testing library should support variadic generics.
+  ///     ([103416861](rdar://103416861))
+  /// }
   init<C1, C2>(
     _ traits: any TestTrait...,
     arguments collection1: C1, _ collection2: C2,


### PR DESCRIPTION
This reverts a portion of the changes I made in #836 which converted triple-`///` style DocC `@Comment` blocks to double-`//` style code comments. That change was needed at the time because our documentation was still rendered using pre-Swift 6.1 toolchains, but now `@Comment` blocks are supported by DocC in documentation comments (as of https://github.com/swiftlang/swift-docc/pull/1107) so we can restore these.

I needed to move some of these comment blocks up before `## See Also` sections to avoid a DocC warning about items in lists not being links.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
