### PR TITLE
Work around compiler bug affecting macro decls with #if-guarded availability when building w/legacy driver

### DIFF
--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -514,11 +514,12 @@ public macro require<R>(
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
 /// }
+@freestanding(expression)
+@discardableResult
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
-@discardableResult
-@freestanding(expression) public macro expect(
+public macro expect(
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,
@@ -559,11 +560,12 @@ public macro require<R>(
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
 /// }
+@freestanding(expression)
+@discardableResult
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
-@discardableResult
-@freestanding(expression) public macro require(
+public macro require(
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,


### PR DESCRIPTION
This works around a Swift compiler bug which causes a failure validating the generated .swiftinterface of the `Testing` module due to it having macro declarations with `#if`-conditionalized `@available(...)` attributes _before_ any other `@`-attributes.

The PR which recently landed to enable the Exit Tests feature (#324) revealed this compiler bug — specifically, that PR removed `@_spi` attributes which until then _preceded_ `#if SWT_NO_EXIT_TESTS`. The workaround is to move other attributes on the affected macro declarations up before the `#if`.

The compiler bug is being fixed in https://github.com/swiftlang/swift/pull/81346. It only appears to happen when building with the legacy driver, and Android uses that driver still. An example CI failure log can be found here:

> https://github.com/thebrowsercompany/swift-build/actions/runs/14823859186/job/41615678071#step:32:72

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
