### PR TITLE
Add missing Foundation imports to fix test build errors on iOS with MemberImportVisibility enabled

### DIFF
--- a/Tests/TestingTests/ConfirmationTests.swift
+++ b/Tests/TestingTests/ConfirmationTests.swift
@@ -10,6 +10,10 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
+#if canImport(Foundation)
+private import Foundation
+#endif
+
 @Suite("Confirmation Tests")
 struct ConfirmationTests {
   @Test("Successful confirmations")

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -12,6 +12,10 @@
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import _TestDiscovery
 private import _TestingInternals
 
+#if canImport(Foundation)
+private import Foundation
+#endif
+
 @Test(/* name unspecified */ .hidden)
 @Sendable func freeSyncFunction() {}
 @Sendable func freeAsyncFunction() async {}

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -11,6 +11,10 @@
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
 
+#if canImport(Foundation)
+private import Foundation
+#endif
+
 private func configurationForEntryPoint(withArguments args: [String]) throws -> Configuration {
   let args = try parseCommandLineArguments(from: args)
   return try configurationForEntryPoint(from: args)

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -11,6 +11,10 @@
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
 
+#if canImport(Foundation)
+private import Foundation
+#endif
+
 @Suite("Tag/Tag List Tests", .tags(.traitRelated))
 struct TagListTests {
   @Test(".tags() factory method with one tag")

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -10,6 +10,10 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
+#if canImport(Foundation)
+private import Foundation
+#endif
+
 @Suite("TimeLimitTrait Tests", .tags(.traitRelated))
 struct TimeLimitTraitTests {
   @available(_clockAPI, *)


### PR DESCRIPTION
This fixes several instances of a build error when attempting to build this package for iOS, or any non-macOS Apple platform. Here's one example

```
error: instance method 'contains' is not available due to missing import of defining module 'Foundation'
Tests/TestingTests/SwiftPMTests.swift:370:5: note: in expansion of macro 'expect' here
    #expect(testIDs.allSatisfy { $0.contains(".swift:") })
```

This general kind of build error is being emitted because we adopted [SE-0444: Member import visibility](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md) by enabling the `MemberImportVisibility` experimental feature in #1020.

In that PR, I fixed several instances of missing imports, including some for `Foundation` in test files. But these errors are from usages of `String.contains()`, and it turns out there are multiple overloads of that function, with an older one in `Foundation` and a newer one directly in the stdlib `Swift` module. The latter has newer, iOS 13.0-aligned API availability, and when building our tests for macOS this issue was not noticed previously because SwiftPM artificially raises the deployment target of macOS test targets to match the testing frameworks included in Xcode (when the testing libraries are being used from the installed copy of Xcode).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
