### PR TITLE
Merge 'main' branch to 'release/6.2'

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -131,11 +131,11 @@ extension Attachment where AttachableValue == AnyAttachable {
 /// events of kind ``Event/Kind/valueAttached(_:)``. Test tools authors who use
 /// `@_spi(ForToolsIntegrationOnly)` will see instances of this type when
 /// handling those events.
-//
-// @Comment {
-//   Swift's type system requires that this type be at least as visible as
-//   `Event.Kind.valueAttached(_:)`, otherwise it would be declared private.
-// }
+///
+/// @Comment {
+///   Swift's type system requires that this type be at least as visible as
+///   `Event.Kind.valueAttached(_:)`, otherwise it would be declared private.
+/// }
 @_spi(ForToolsIntegrationOnly)
 public struct AnyAttachable: AttachableWrapper, Copyable, Sendable {
 #if !SWT_NO_LAZY_ATTACHMENTS

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -514,11 +514,12 @@ public macro require<R>(
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
 /// }
+@freestanding(expression)
+@discardableResult
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
-@discardableResult
-@freestanding(expression) public macro expect(
+public macro expect(
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,
@@ -559,11 +560,12 @@ public macro require<R>(
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
 /// }
+@freestanding(expression)
+@discardableResult
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
-@discardableResult
-@freestanding(expression) public macro require(
+public macro require(
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -49,12 +49,12 @@ public struct Issue: Sendable {
     ///
     /// - Parameters:
     ///   - timeLimitComponents: The time limit reached by the test.
-    //
-    // @Comment {
-    //   - Bug: The associated value of this enumeration case should be an
-    //     instance of `Duration`, but the testing library's deployment target
-    //     predates the introduction of that type.
-    // }
+    ///
+    /// @Comment {
+    ///   - Bug: The associated value of this enumeration case should be an
+    ///     instance of `Duration`, but the testing library's deployment target
+    ///     predates the introduction of that type.
+    /// }
     indirect case timeLimitExceeded(timeLimitComponents: (seconds: Int64, attoseconds: Int64))
 
     /// A known issue was expected, but was not recorded.
@@ -434,12 +434,12 @@ extension Issue.Kind {
     ///
     /// - Parameters:
     ///   - timeLimitComponents: The time limit reached by the test.
-    //
-    // @Comment {
-    //   - Bug: The associated value of this enumeration case should be an
-    //     instance of `Duration`, but the testing library's deployment target
-    //     predates the introduction of that type.
-    // }
+    ///
+    /// @Comment {
+    ///   - Bug: The associated value of this enumeration case should be an
+    ///     instance of `Duration`, but the testing library's deployment target
+    ///     predates the introduction of that type.
+    /// }
     indirect case timeLimitExceeded(timeLimitComponents: (seconds: Int64, attoseconds: Int64))
 
     /// A known issue was expected, but was not recorded.

--- a/Sources/Testing/Parameterization/Test.Case.Generator.swift
+++ b/Sources/Testing/Parameterization/Test.Case.Generator.swift
@@ -13,11 +13,11 @@ extension Test.Case {
   /// a known collection of argument values.
   ///
   /// Instances of this type can be iterated over multiple times.
-  //
-  // @Comment {
-  //   - Bug: The testing library should support variadic generics.
-  //     ([103416861](rdar://103416861))
-  // }
+  ///
+  /// @Comment {
+  ///   - Bug: The testing library should support variadic generics.
+  ///     ([103416861](rdar://103416861))
+  /// }
   struct Generator<S>: Sendable where S: Sequence & Sendable, S.Element: Sendable {
     /// The underlying sequence of argument values.
     ///
@@ -146,11 +146,11 @@ extension Test.Case {
     ///
     /// This initializer overload is specialized for sequences of 2-tuples to
     /// efficiently de-structure their elements when appropriate.
-    //
-    // @Comment {
-    //   - Bug: The testing library should support variadic generics.
-    //     ([103416861](rdar://103416861))
-    // }
+    ///
+    /// @Comment {
+    ///   - Bug: The testing library should support variadic generics.
+    ///     ([103416861](rdar://103416861))
+    /// }
     private init<E1, E2>(
       sequence: S,
       parameters: [Test.Parameter],
@@ -184,11 +184,11 @@ extension Test.Case {
     ///
     /// This initializer overload is specialized for collections of 2-tuples to
     /// efficiently de-structure their elements when appropriate.
-    //
-    // @Comment {
-    //   - Bug: The testing library should support variadic generics.
-    //     ([103416861](rdar://103416861))
-    // }
+    ///
+    /// @Comment {
+    ///   - Bug: The testing library should support variadic generics.
+    ///     ([103416861](rdar://103416861))
+    /// }
     init<E1, E2>(
       arguments collection: S,
       parameters: [Test.Parameter],

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -156,7 +156,7 @@ extension Runner {
     in sequence: some Sequence<E>,
     _ body: @Sendable @escaping (E) async throws -> Void
   ) async throws where E: Sendable {
-    try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+    try await withThrowingTaskGroup { taskGroup in
       for element in sequence {
         // Each element gets its own subtask to run in.
         _ = taskGroup.addTaskUnlessCancelled {
@@ -430,7 +430,7 @@ extension Runner {
           Event.post(.iterationEnded(iterationIndex), for: (nil, nil), configuration: runner.configuration)
         }
 
-        await withTaskGroup(of: Void.self) { [runner] taskGroup in
+        await withTaskGroup { [runner] taskGroup in
           _ = taskGroup.addTaskUnlessCancelled {
             try? await _runStep(atRootOf: runner.plan.stepGraph)
           }

--- a/Sources/Testing/Support/CartesianProduct.swift
+++ b/Sources/Testing/Support/CartesianProduct.swift
@@ -17,11 +17,11 @@
 /// `[(1, "a"), (1, "b"), (1, "c"), (2, "a"), (2, "b"), ... (3, "c")]`.
 ///
 /// This type is not part of the public interface of the testing library.
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
+///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
 struct CartesianProduct<C1, C2>: LazySequenceProtocol where C1: Collection, C2: Collection {
   fileprivate var collection1: C1
   fileprivate var collection2: C2
@@ -63,11 +63,11 @@ extension CartesianProduct: Sendable where C1: Sendable, C2: Sendable {}
 /// while `collection2` is iterated `collection1.count` times.
 ///
 /// For more information on Cartesian products, see ``CartesianProduct``.
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
+///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
 func cartesianProduct<C1, C2>(_ collection1: C1, _ collection2: C2) -> CartesianProduct<C1, C2> where C1: Collection, C2: Collection {
   CartesianProduct(collection1: collection1, collection2: collection2)
 }

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -84,7 +84,7 @@ extension Test {
       // a task group and collate their results.
       if useNewMode {
         let generators = Generator.allTestContentRecords().lazy.compactMap { $0.load() }
-        await withTaskGroup(of: Self.self) { taskGroup in
+        await withTaskGroup { taskGroup in
           for generator in generators {
             taskGroup.addTask { await generator.rawValue() }
           }
@@ -96,7 +96,7 @@ extension Test {
       // Perform legacy test discovery if needed.
       if useLegacyMode && result.isEmpty {
         let generators = Generator.allTypeMetadataBasedTestContentRecords().lazy.compactMap { $0.load() }
-        await withTaskGroup(of: Self.self) { taskGroup in
+        await withTaskGroup { taskGroup in
           for generator in generators {
             taskGroup.addTask { await generator.rawValue() }
           }

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -220,14 +220,14 @@ public macro Test<C>(
 /// During testing, the associated test function is called once for each element
 /// in `collection`.
 ///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
+///
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
 @attached(peer) public macro Test<C>(
   _ displayName: _const String? = nil,
   _ traits: any TestTrait...,
@@ -273,14 +273,14 @@ extension Test {
 /// During testing, the associated test function is called once for each pair of
 /// elements in `collection1` and `collection2`.
 ///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
+///
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
 @attached(peer)
 @_documentation(visibility: private)
 public macro Test<C1, C2>(
@@ -301,14 +301,14 @@ public macro Test<C1, C2>(
 /// During testing, the associated test function is called once for each pair of
 /// elements in `collection1` and `collection2`.
 ///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
+///
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
 @attached(peer) public macro Test<C1, C2>(
   _ displayName: _const String? = nil,
   _ traits: any TestTrait...,
@@ -327,14 +327,14 @@ public macro Test<C1, C2>(
 /// During testing, the associated test function is called once for each element
 /// in `zippedCollections`.
 ///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
+///
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
 @attached(peer)
 @_documentation(visibility: private)
 public macro Test<C1, C2>(
@@ -355,14 +355,14 @@ public macro Test<C1, C2>(
 /// During testing, the associated test function is called once for each element
 /// in `zippedCollections`.
 ///
+/// @Comment {
+///   - Bug: The testing library should support variadic generics.
+///     ([103416861](rdar://103416861))
+/// }
+///
 /// ## See Also
 ///
 /// - <doc:DefiningTests>
-//
-// @Comment {
-//   - Bug: The testing library should support variadic generics.
-//     ([103416861](rdar://103416861))
-// }
 @attached(peer) public macro Test<C1, C2>(
   _ displayName: _const String? = nil,
   _ traits: any TestTrait...,

--- a/Sources/Testing/Traits/ConditionTrait.swift
+++ b/Sources/Testing/Traits/ConditionTrait.swift
@@ -115,12 +115,12 @@ extension Trait where Self == ConditionTrait {
   ///
   /// - Returns: An instance of ``ConditionTrait`` that evaluates the
   ///   closure you provide.
-  //
-  // @Comment {
-  //   - Bug: `condition` cannot be `async` without making this function
-  //     `async` even though `condition` is not evaluated locally.
-  //     ([103037177](rdar://103037177))
-  // }
+  ///
+  /// @Comment {
+  ///   - Bug: `condition` cannot be `async` without making this function
+  ///     `async` even though `condition` is not evaluated locally.
+  ///     ([103037177](rdar://103037177))
+  /// }
   public static func enabled(
     if condition: @autoclosure @escaping @Sendable () throws -> Bool,
     _ comment: Comment? = nil,
@@ -174,12 +174,12 @@ extension Trait where Self == ConditionTrait {
   ///
   /// - Returns: An instance of ``ConditionTrait`` that evaluates the
   ///   closure you provide.
-  //
-  // @Comment {
-  //   - Bug: `condition` cannot be `async` without making this function
-  //     `async` even though `condition` is not evaluated locally.
-  //     ([103037177](rdar://103037177))
-  // }
+  ///
+  /// @Comment {
+  ///   - Bug: `condition` cannot be `async` without making this function
+  ///     `async` even though `condition` is not evaluated locally.
+  ///     ([103037177](rdar://103037177))
+  /// }
   public static func disabled(
     if condition: @autoclosure @escaping @Sendable () throws -> Bool,
     _ comment: Comment? = nil,

--- a/Sources/Testing/Traits/TimeLimitTrait.swift
+++ b/Sources/Testing/Traits/TimeLimitTrait.swift
@@ -264,7 +264,7 @@ func withTimeLimit(
   _ body: @escaping @Sendable () async throws -> Void,
   timeoutHandler: @escaping @Sendable () -> Void
 ) async throws {
-  try await withThrowingTaskGroup(of: Void.self) { group in
+  try await withThrowingTaskGroup { group in
     group.addTask {
       // If sleep() returns instead of throwing a CancellationError, that means
       // the timeout was reached before this task could be cancelled, so call

--- a/Tests/TestingTests/ConfirmationTests.swift
+++ b/Tests/TestingTests/ConfirmationTests.swift
@@ -10,6 +10,10 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
+#if canImport(Foundation)
+private import Foundation
+#endif
+
 @Suite("Confirmation Tests")
 struct ConfirmationTests {
   @Test("Successful confirmations")

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -12,6 +12,10 @@
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import _TestDiscovery
 private import _TestingInternals
 
+#if canImport(Foundation)
+private import Foundation
+#endif
+
 @Test(/* name unspecified */ .hidden)
 @Sendable func freeSyncFunction() {}
 @Sendable func freeAsyncFunction() async {}

--- a/Tests/TestingTests/Support/CartesianProductTests.swift
+++ b/Tests/TestingTests/Support/CartesianProductTests.swift
@@ -96,7 +96,7 @@ struct CartesianProductTests {
     // Test that the product can be iterated multiple times concurrently.
     let (_, _, product) = computeCartesianProduct()
     let expectedSum = product.reduce(into: 0) { $0 &+= $1.1 }
-    await withTaskGroup(of: Int.self) { taskGroup in
+    await withTaskGroup { taskGroup in
       for _ in 0 ..< 10 {
         taskGroup.addTask {
           product.reduce(into: 0) { $0 &+= $1.1 }

--- a/Tests/TestingTests/Support/LockTests.swift
+++ b/Tests/TestingTests/Support/LockTests.swift
@@ -36,7 +36,7 @@ struct LockTests {
   @Test("No lock")
   func noLock() async {
     let lock = LockedWith<Never, Int>(rawValue: 0)
-    await withTaskGroup(of: Void.self) { taskGroup in
+    await withTaskGroup { taskGroup in
       for _ in 0 ..< 100_000 {
         taskGroup.addTask {
           lock.increment()

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -11,6 +11,10 @@
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
 
+#if canImport(Foundation)
+private import Foundation
+#endif
+
 private func configurationForEntryPoint(withArguments args: [String]) throws -> Configuration {
   let args = try parseCommandLineArguments(from: args)
   return try configurationForEntryPoint(from: args)

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -162,11 +162,11 @@ extension Test {
   ///   - testFunction: The function to call when running this test. During
   ///     testing, this function is called once for each element in
   ///     `collection`.
-  //
-  // @Comment {
-  //   - Bug: The testing library should support variadic generics.
-  //     ([103416861](rdar://103416861))
-  // }
+  ///
+  /// @Comment {
+  ///   - Bug: The testing library should support variadic generics.
+  ///     ([103416861](rdar://103416861))
+  /// }
   init<C>(
     _ traits: any TestTrait...,
     arguments collection: C,
@@ -191,11 +191,11 @@ extension Test {
   ///   - testFunction: The function to call when running this test. During
   ///     testing, this function is called once for each pair of elements in
   ///     `collection1` and `collection2`.
-  //
-  // @Comment {
-  //   - Bug: The testing library should support variadic generics.
-  //     ([103416861](rdar://103416861))
-  // }
+  ///
+  /// @Comment {
+  ///   - Bug: The testing library should support variadic generics.
+  ///     ([103416861](rdar://103416861))
+  /// }
   init<C1, C2>(
     _ traits: any TestTrait...,
     arguments collection1: C1, _ collection2: C2,

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -11,6 +11,10 @@
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
 
+#if canImport(Foundation)
+private import Foundation
+#endif
+
 @Suite("Tag/Tag List Tests", .tags(.traitRelated))
 struct TagListTests {
   @Test(".tags() factory method with one tag")

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -10,6 +10,10 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
+#if canImport(Foundation)
+private import Foundation
+#endif
+
 @Suite("TimeLimitTrait Tests", .tags(.traitRelated))
 struct TimeLimitTraitTests {
   @available(_clockAPI, *)
@@ -181,7 +185,7 @@ struct TimeLimitTraitTests {
   @Test("Cancelled tests can exit early (cancellation checking works)")
   func cancelledTestExitsEarly() async throws {
     let timeAwaited = await Test.Clock().measure {
-      await withTaskGroup(of: Void.self) { taskGroup in
+      await withTaskGroup { taskGroup in
         taskGroup.addTask {
           await Test {
             try await Test.Clock.sleep(for: .seconds(60) * 60)


### PR DESCRIPTION
This merges the `main` branch into the `release/6.2` branch.

> Note: The Swift Testing project will be periodically performing "backwards" merges like this for a period which extends beyond the date when the 6.2 branches were cut, since nearly all contributions are intended to be included in the 6.2 release.

Once this PR has been merged, I will adjust the milestones on the PRs included in this merge to be 6.2 wherever appropriate.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
