### PR TITLE
Include total number of suites in "run ended" console message

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -542,6 +542,7 @@ extension Event.HumanReadableOutputRecorder {
 
     case .runEnded:
       let testCount = context.testCount
+      let suiteCount = context.suiteCount
       let issues = _issueCounts(in: context.testData)
       let runStartInstant = context.runStartInstant ?? instant
       let duration = runStartInstant.descriptionOfDuration(to: instant)
@@ -550,14 +551,14 @@ extension Event.HumanReadableOutputRecorder {
         [
           Message(
             symbol: .fail,
-            stringValue: "Test run with \(testCount.counting("test")) failed after \(duration)\(issues.description)."
+            stringValue: "Test run with \(testCount.counting("test")) in \(suiteCount.counting("suite")) failed after \(duration)\(issues.description)."
           )
         ]
       } else {
         [
           Message(
             symbol: .pass(knownIssueCount: issues.knownIssueCount),
-            stringValue: "Test run with \(testCount.counting("test")) passed after \(duration)\(issues.description)."
+            stringValue: "Test run with \(testCount.counting("test")) in \(suiteCount.counting("suite")) passed after \(duration)\(issues.description)."
           )
         ]
       }


### PR DESCRIPTION
This enhances the console output message shown when a test run finishes by including the total number of suites which ran or skipped, after the total number of test functions. Example:

```
✔ Test run with 456 tests in 62 suites passed after 3.389 seconds.
```

The data was already being collected to support this, in a property named `suiteCount`, but it was not being used anywhere. So this PR adopts that property to augment the current "test run ended" message.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
