### PR TITLE
Add a kind to Issue.record to record various kinds a of issues

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -76,7 +76,6 @@ extension Issue {
   ///   - severity: The severity of the issue.
   ///   - sourceLocation: The source location to which the issue should be
   ///     attributed.
-  ///   - kind: The kind of the issue.
   ///
   /// - Returns: The issue that was recorded.
   ///
@@ -87,13 +86,40 @@ extension Issue {
   @discardableResult public static func record(
     _ comment: Comment? = nil,
     severity: Severity,
-    sourceLocation: SourceLocation = #_sourceLocation,
-    kind: Kind = .unconditional
+    sourceLocation: SourceLocation = #_sourceLocation
+  ) -> Self {
+    let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
+    let issue = Issue(kind: .unconditional, severity: severity, comments: Array(comment), sourceContext: sourceContext)
+    return issue.record()
+  }
+  
+  /// Record an issue when a running test fails unexpectedly.
+  ///
+  /// - Parameters:
+  ///   - comment: A comment describing the expectation.
+  ///   - severity: The severity of the issue.
+  ///   - sourceLocation: The source location to which the issue should be
+  ///     attributed.
+  ///   - kind: The kind of the issue.
+  ///
+  /// - Returns: The issue that was recorded.
+  ///
+  /// Use this function if, while running a test, an issue occurs that cannot be
+  /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
+  /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
+  @_spi(Experimental)
+  @_spi(ForToolsIntegrationOnly)
+  @discardableResult public static func record(
+    kind: Kind = .unconditional,
+    comment: Comment? = nil,
+    severity: Severity = .error,
+    sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
     let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
     let issue = Issue(kind: kind, severity: severity, comments: Array(comment), sourceContext: sourceContext)
     return issue.record()
   }
+
 }
 
 // MARK: - Recording issues for errors

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -76,6 +76,7 @@ extension Issue {
   ///   - severity: The severity of the issue.
   ///   - sourceLocation: The source location to which the issue should be
   ///     attributed.
+  ///   - kind: The kind of the issue.
   ///
   /// - Returns: The issue that was recorded.
   ///
@@ -86,10 +87,11 @@ extension Issue {
   @discardableResult public static func record(
     _ comment: Comment? = nil,
     severity: Severity,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #_sourceLocation,
+    kind: Kind = .unconditional
   ) -> Self {
     let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
-    let issue = Issue(kind: .unconditional, severity: severity, comments: Array(comment), sourceContext: sourceContext)
+    let issue = Issue(kind: kind, severity: severity, comments: Array(comment), sourceContext: sourceContext)
     return issue.record()
   }
 }

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -999,7 +999,7 @@ final class IssueTests: XCTestCase {
       
     }
     await Test {
-      Issue.record("My comment", severity: .error, kind: .apiMisused)
+      Issue.record(kind: .apiMisused, comment: "My comment")
     }.run(configuration: configuration)
     
     await fulfillment(of: [apiMisused], timeout: 0.0)

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -985,6 +985,25 @@ final class IssueTests: XCTestCase {
 
     await fulfillment(of: [errorCaught, apiMisused, expectationFailed], timeout: 0.0)
   }
+  
+  func testIssueRecordKinds() async throws {
+    var configuration = Configuration()
+    let apiMisused = expectation(description: "API misused")
+    configuration.eventHandler = { event, _ in
+      guard case let .issueRecorded(issue) = event.kind else {
+        return
+      }
+      if case .apiMisused = issue.kind {
+        apiMisused.fulfill()
+      }
+      
+    }
+    await Test {
+      Issue.record("My comment", severity: .error, kind: .apiMisused)
+    }.run(configuration: configuration)
+    
+    await fulfillment(of: [apiMisused], timeout: 0.0)
+  }
 
   @__testing(semantics: "nomacrowarnings")
   func testErrorCheckingWithRequire_ResultValueIsNever_VariousSyntaxes() throws {
@@ -1764,6 +1783,7 @@ struct IssueCodingTests {
       }.run(configuration: configuration)
     }
   }
+  
 }
 #endif
 

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1783,7 +1783,6 @@ struct IssueCodingTests {
       }.run(configuration: configuration)
     }
   }
-  
 }
 #endif
 


### PR DESCRIPTION
Add a kind to Issue.record to record various kinds a of issues

### Motivation:

I would like to be able to specify what kind of issue I am recording when I record an issue.

### Modifications:

Add an optional parameter to `Issue.record` that takes in an issue `Kind`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.