### PR TITLE
Have `DiscoverableAsTestContent` enumeration produce `some Sequence` instead of `AnySequence`.

### DIFF
--- a/Sources/Testing/Test+Discovery+Legacy.swift
+++ b/Sources/Testing/Test+Discovery+Legacy.swift
@@ -24,14 +24,14 @@ public protocol __TestContentRecordContainer {
   nonisolated static var __testContentRecord: __TestContentRecord { get }
 }
 
-extension DiscoverableAsTestContent where Self: ~Copyable {
+extension DiscoverableAsTestContent {
   /// Get all test content of this type known to Swift and found in the current
   /// process using the legacy discovery mechanism.
   ///
   /// - Returns: A sequence of instances of ``TestContentRecord``. Only test
   ///   content records matching this ``TestContent`` type's requirements are
   ///   included in the sequence.
-  static func allTypeMetadataBasedTestContentRecords() -> AnySequence<TestContentRecord<Self>> {
+  static func allTypeMetadataBasedTestContentRecords() -> some Sequence<TestContentRecord<Self>> {
     return allTypeMetadataBasedTestContentRecords { type, buffer in
       guard let type = type as? any __TestContentRecordContainer.Type else {
         return false

--- a/Sources/_TestDiscovery/DiscoverableAsTestContent.swift
+++ b/Sources/_TestDiscovery/DiscoverableAsTestContent.swift
@@ -16,7 +16,7 @@
 /// because they may be discovered within any isolation context or within
 /// multiple isolation contexts running concurrently.
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
-public protocol DiscoverableAsTestContent: Sendable, ~Copyable {
+public protocol DiscoverableAsTestContent: Sendable {
   /// The value of the `kind` field in test content records associated with this
   /// type.
   ///
@@ -49,7 +49,7 @@ public protocol DiscoverableAsTestContent: Sendable, ~Copyable {
 }
 
 #if !SWT_NO_LEGACY_TEST_DISCOVERY
-extension DiscoverableAsTestContent where Self: ~Copyable {
+extension DiscoverableAsTestContent {
   public static var _testContentTypeNameHint: String {
     "__🟡$"
   }

--- a/Sources/_TestDiscovery/TestContentRecord.swift
+++ b/Sources/_TestDiscovery/TestContentRecord.swift
@@ -44,7 +44,7 @@ private typealias _TestContentRecord = (
   reserved2: UInt
 )
 
-extension DiscoverableAsTestContent where Self: ~Copyable {
+extension DiscoverableAsTestContent {
   /// Check that the layout of this structure in memory matches its expected
   /// layout in the test content section.
   ///
@@ -64,7 +64,7 @@ extension DiscoverableAsTestContent where Self: ~Copyable {
 /// ``DiscoverableAsTestContent/allTestContentRecords()`` on a type that
 /// conforms to ``DiscoverableAsTestContent``.
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
-public struct TestContentRecord<T> where T: DiscoverableAsTestContent & ~Copyable {
+public struct TestContentRecord<T> where T: DiscoverableAsTestContent {
   /// The base address of the image containing this instance, if known.
   ///
   /// The type of this pointer is platform-dependent:
@@ -229,24 +229,19 @@ extension TestContentRecord: CustomStringConvertible {
 
 // MARK: - Enumeration of test content records
 
-extension DiscoverableAsTestContent where Self: ~Copyable {
+extension DiscoverableAsTestContent {
   /// Get all test content of this type known to Swift and found in the current
   /// process.
   ///
   /// - Returns: A sequence of instances of ``TestContentRecord``. Only test
   ///   content records matching this ``TestContent`` type's requirements are
   ///   included in the sequence.
-  ///
-  /// @Comment {
-  ///   - Bug: This function returns an instance of `AnySequence` instead of an
-  ///     opaque type due to a compiler crash. ([143080508](rdar://143080508))
-  /// }
-  public static func allTestContentRecords() -> AnySequence<TestContentRecord<Self>> {
+  public static func allTestContentRecords() -> some Sequence<TestContentRecord<Self>> {
     validateMemoryLayout()
 
     let kind = testContentKind.rawValue
 
-    let result = SectionBounds.all(.testContent).lazy.flatMap { sb in
+    return SectionBounds.all(.testContent).lazy.flatMap { sb in
       sb.buffer.withMemoryRebound(to: _TestContentRecord.self) { records in
         (0 ..< records.count).lazy
           .map { (records.baseAddress! + $0) as UnsafePointer<_TestContentRecord> }
@@ -254,7 +249,6 @@ extension DiscoverableAsTestContent where Self: ~Copyable {
           .map { TestContentRecord<Self>(imageAddress: sb.imageAddress, recordAddress: $0) }
       }
     }
-    return AnySequence(result)
   }
 }
 
@@ -263,7 +257,7 @@ extension DiscoverableAsTestContent where Self: ~Copyable {
 
 private import _TestingInternals
 
-extension DiscoverableAsTestContent where Self: ~Copyable {
+extension DiscoverableAsTestContent {
   /// Get all test content of this type known to Swift and found in the current
   /// process using the legacy discovery mechanism.
   ///
@@ -277,15 +271,10 @@ extension DiscoverableAsTestContent where Self: ~Copyable {
   /// - Returns: A sequence of instances of ``TestContentRecord``. Only test
   ///   content records matching this ``TestContent`` type's requirements are
   ///   included in the sequence.
-  ///
-  /// @Comment {
-  ///   - Bug: This function returns an instance of `AnySequence` instead of an
-  ///     opaque type due to a compiler crash. ([143080508](rdar://143080508))
-  /// }
   @available(swift, deprecated: 100000.0, message: "Do not adopt this functionality in new code. It will be removed in a future release.")
   public static func allTypeMetadataBasedTestContentRecords(
     loadingWith loader: @escaping @Sendable (Any.Type, UnsafeMutableRawBufferPointer) -> Bool
-  ) -> AnySequence<TestContentRecord<Self>> {
+  ) -> some Sequence<TestContentRecord<Self>> {
     validateMemoryLayout()
 
     let typeNameHint = _testContentTypeNameHint
@@ -300,7 +289,7 @@ extension DiscoverableAsTestContent where Self: ~Copyable {
       }
     }
 
-    let result = SectionBounds.all(.typeMetadata).lazy.flatMap { sb in
+    return SectionBounds.all(.typeMetadata).lazy.flatMap { sb in
       stride(from: 0, to: sb.buffer.count, by: SWTTypeMetadataRecordByteCount).lazy
         .map { sb.buffer.baseAddress! + $0 }
         .compactMap { swt_getType(fromTypeMetadataRecord: $0, ifNameContains: typeNameHint) }
@@ -309,7 +298,6 @@ extension DiscoverableAsTestContent where Self: ~Copyable {
         .filter { $0.kind == kind }
         .map { TestContentRecord<Self>(imageAddress: sb.imageAddress, record: $0) }
     }
-    return AnySequence(result)
   }
 }
 #endif


### PR DESCRIPTION
This PR changes how `DiscoverableAsTestContent` enumeration works so that we can return `some Sequence` instead of `AnySequence`. We do so by removing the `~Copyable` constraint on the protocol, which subsequently causes the compiler to get confused and crash trying to represent `some Sequence<TestContentRecord<T>>` where `T: DiscoverableAsTestContent`.

The only supported/allowed consumers of the `DiscoverableAsTestContent` protocol are Swift Testing and the experimental Playgrounds package, neither of which uses (or needs to use) a move-only type here. Earlier, `ExitTest` conformed to `DiscoverableAsTestContent`, but this was changed and is no longer necessary.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
