### PR TITLE
Remove the 'triage-needed' label from New Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -9,7 +9,7 @@
 name: 🪲 Report a bug
 description: >
   Report a deviation from expected or documented behavior.
-labels: [bug, triage-needed]
+labels: [bug]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-change-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-change-request.yml
@@ -9,7 +9,7 @@
 name: 🌟 Request a change
 description: >
   Request a feature, API, improvement, or other change.
-labels: [enhancement, triage-needed]
+labels: [enhancement]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This removes the `triage-needed` label from the GitHub New Issue templates in this repository which have it.

I added this while revamping these templates in #962, but more recently we added a `triaged` label which is works the opposite way—it's applied after an issue has been triaged—so we don't need the older label anymore.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
