### PR TITLE
Revert "Work around a macOS CI failure (#1100)"

### DIFF
--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -491,7 +491,6 @@ final class IssueTests: XCTestCase {
     }.run(configuration: .init())
   }
 
-#if !SWT_TARGET_OS_APPLE || SWT_FIXED_149299786
   func testErrorCheckingWithExpect() async throws {
     let expectationFailed = expectation(description: "Expectation failed")
     expectationFailed.isInverted = true
@@ -611,7 +610,6 @@ final class IssueTests: XCTestCase {
 
     await fulfillment(of: [expectationFailed], timeout: 0.0)
   }
-#endif
 
   func testErrorCheckingWithExpect_mismatchedErrorDescription() async throws {
     let expectationFailed = expectation(description: "Expectation failed")


### PR DESCRIPTION
Revert the workaround added in #1100, since the Swift compiler issue has been resolved and newer `main` development snapshot toolchains have become available with the fix.

This reverts commit a82d0a89dd2eb86d18056f03396055528ce56508.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
