### PR TITLE
Acknowledge unsafe API usages in code expanded from testing library macros

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -127,8 +127,17 @@ let package = Package(
         "Testing",
         "_Testing_CoreGraphics",
         "_Testing_Foundation",
+        "MemorySafeTestingTests",
       ],
       swiftSettings: .packageSettings
+    ),
+    .target(
+      name: "MemorySafeTestingTests",
+      dependencies: [
+        "Testing",
+      ],
+      path: "Tests/_MemorySafeTestingTests",
+      swiftSettings: .packageSettings + .strictMemorySafety
     ),
 
     .macro(
@@ -354,6 +363,14 @@ extension Array where Element == PackageDescription.SwiftSetting {
     }
 
     return result
+  }
+
+  /// Settings necessary to enable Strict Memory Safety, introduced in
+  /// [SE-0458: Opt-in Strict Memory Safety Checking](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0458-strict-memory-safety.md#swiftpm-integration).
+  static var strictMemorySafety: Self {
+    // FIXME: Adopt official `.strictMemorySafety()` condition once the minimum
+    // supported toolchain is 6.2.
+    [.unsafeFlags(["-strict-memory-safety"])]
   }
 }
 

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -499,7 +499,7 @@ extension ExitTestConditionMacro {
       recordDecl = """
       enum \(legacyEnumName): Testing.__TestContentRecordContainer {
         nonisolated static var __testContentRecord: Testing.__TestContentRecord {
-          \(enumName).testContentRecord
+          unsafe \(enumName).testContentRecord
         }
       }
       """
@@ -510,7 +510,7 @@ extension ExitTestConditionMacro {
         @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
         enum \(enumName) {
           private nonisolated static let accessor: Testing.__TestContentRecordAccessor = { outValue, type, hint, _ in
-            Testing.ExitTest.__store(
+            unsafe Testing.ExitTest.__store(
               \(idExpr),
               \(bodyThunkName),
               into: outValue,

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -150,7 +150,7 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
       """
       @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")
       private nonisolated static let \(accessorName): Testing.__TestContentRecordAccessor = { outValue, type, _, _ in
-        Testing.Test.__store(\(generatorName), into: outValue, asTypeAt: type)
+        unsafe Testing.Test.__store(\(generatorName), into: outValue, asTypeAt: type)
       }
       """
     )
@@ -174,7 +174,7 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
       enum \(enumName): Testing.__TestContentRecordContainer {
         nonisolated static var __testContentRecord: Testing.__TestContentRecord {
-          \(testContentRecordName)
+          unsafe \(testContentRecordName)
         }
       }
       """

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -68,7 +68,7 @@ func makeTestContentRecordDecl(named name: TokenSyntax, in typeName: TypeSyntax?
   private nonisolated \(staticKeyword(for: typeName)) let \(name): Testing.__TestContentRecord = (
     \(kindExpr), \(kind.commentRepresentation)
     0,
-    \(accessorName),
+    unsafe \(accessorName),
     \(contextExpr),
     0
   )

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -475,7 +475,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
       """
       @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")
       private \(staticKeyword(for: typeName)) nonisolated let \(accessorName): Testing.__TestContentRecordAccessor = { outValue, type, _, _ in
-        Testing.Test.__store(\(generatorName), into: outValue, asTypeAt: type)
+        unsafe Testing.Test.__store(\(generatorName), into: outValue, asTypeAt: type)
       }
       """
     )
@@ -499,7 +499,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
       enum \(enumName): Testing.__TestContentRecordContainer {
         nonisolated static var __testContentRecord: Testing.__TestContentRecord {
-          \(testContentRecordName)
+          unsafe \(testContentRecordName)
         }
       }
       """

--- a/Tests/_MemorySafeTestingTests/MemorySafeTestDecls.swift
+++ b/Tests/_MemorySafeTestingTests/MemorySafeTestDecls.swift
@@ -1,0 +1,27 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable import Testing
+
+#if !hasFeature(StrictMemorySafety)
+#error("This file requires strict memory safety to be enabled")
+#endif
+
+@Test(.hidden)
+func exampleTestFunction() {}
+
+@Suite(.hidden)
+struct ExampleSuite {
+  @Test func example() {}
+}
+
+func exampleExitTest() async {
+  await #expect(processExitsWith: .success) {}
+}


### PR DESCRIPTION
Acknowledge unsafe API usages from various testing library macros such as `@Test`, `@Suite`, and `#expect(processExitsWith:)` which are revealed in modules which enable the new opt-in strict memory safety feature in Swift 6.2.

### Motivation:

This fix allows clients of the testing library to enable [SE-0458: Opt-in Strict Memory Safety Checking](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0458-strict-memory-safety.md) if they wish and avoid diagnostics from the testing library macros in their modules. These warnings generally looked like this, before this fix:

```
⚠️ @__swiftmacro_22MemorySafeTestingTests19exampleTestFunction33_F2EA1AA3013574E5644E5A4339F05086LL0F0fMp_.swift:23:14: warning: expression uses unsafe constructs but is not marked with 'unsafe'
  Testing.Test.__store($s22MemorySafeTestingTests19exampleTestFunction33_F2EA1AA3013574E5644E5A4339F05086LL0F0fMp_25generator1e3470c498e8fe35fMu_, into: outValue, asTypeAt: type)
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Modifications:

- Add test file to reproduce the new diagnostics. It's in a new module which opts-in to strict memory safety, and marked as a dependency of `TestingTests`.
- Add `unsafe` keyword in the appropriate places in our macros to acknowledge the existing unsafe usages.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Fixes: rdar://151238560
