### PR TITLE
IssueHandlingTrait refinements: Rename to 'compactMapIssues' and special-case system issues

### DIFF
--- a/Sources/Testing/Testing.docc/Traits.md
+++ b/Sources/Testing/Testing.docc/Traits.md
@@ -51,7 +51,7 @@ types that customize the behavior of your tests.
 <!--
 ### Handling issues
 
-- ``Trait/transformIssues(_:)``
+- ``Trait/compactMapIssues(_:)``
 - ``Trait/filterIssues(_:)``
 -->
 

--- a/Sources/Testing/Traits/IssueHandlingTrait.swift
+++ b/Sources/Testing/Traits/IssueHandlingTrait.swift
@@ -96,6 +96,12 @@ extension IssueHandlingTrait: TestScoping {
         return
       }
 
+      // Ignore system issues, as they are not expected to be caused by users.
+      if case .system = issue.kind {
+        oldConfiguration.eventHandler(event, context)
+        return
+      }
+
       // Use the original configuration's event handler when invoking the
       // handler closure to avoid infinite recursion if the handler itself
       // records new issues. This means only issue handling traits whose scope
@@ -143,6 +149,9 @@ extension Trait where Self == IssueHandlingTrait {
   /// using ``Test/current`` ``Test/Case/current``, respectively. You may also
   /// record new issues, although they will only be handled by issue handling
   /// traits which precede this trait or were inherited from a containing suite.
+  ///
+  /// - Note: `transform` is never passed issues for which the value of
+  ///   ``Issue/kind`` is ``Issue/Kind/system``.
   public static func compactMapIssues(_ transform: @escaping @Sendable (Issue) -> Issue?) -> Self {
     Self(handler: transform)
   }
@@ -174,6 +183,9 @@ extension Trait where Self == IssueHandlingTrait {
   /// using ``Test/current`` ``Test/Case/current``, respectively. You may also
   /// record new issues, although they will only be handled by issue handling
   /// traits which precede this trait or were inherited from a containing suite.
+  ///
+  /// - Note: `isIncluded` is never passed issues for which the value of
+  ///   ``Issue/kind`` is ``Issue/Kind/system``.
   public static func filterIssues(_ isIncluded: @escaping @Sendable (Issue) -> Bool) -> Self {
     Self { issue in
       isIncluded(issue) ? issue : nil

--- a/Sources/Testing/Traits/IssueHandlingTrait.swift
+++ b/Sources/Testing/Traits/IssueHandlingTrait.swift
@@ -15,14 +15,14 @@
 /// modifying one or more of its properties, and returning the copy. You can
 /// observe recorded issues by returning them unmodified. Or you can suppress an
 /// issue by either filtering it using ``Trait/filterIssues(_:)`` or returning
-/// `nil` from the closure passed to ``Trait/transformIssues(_:)``.
+/// `nil` from the closure passed to ``Trait/compactMapIssues(_:)``.
 ///
 /// When an instance of this trait is applied to a suite, it is recursively
 /// inherited by all child suites and tests.
 ///
 /// To add this trait to a test, use one of the following functions:
 ///
-/// - ``Trait/transformIssues(_:)``
+/// - ``Trait/compactMapIssues(_:)``
 /// - ``Trait/filterIssues(_:)``
 @_spi(Experimental)
 public struct IssueHandlingTrait: TestTrait, SuiteTrait {
@@ -97,7 +97,7 @@ extension IssueHandlingTrait: TestScoping {
       }
 
       // Use the original configuration's event handler when invoking the
-      // transformer to avoid infinite recursion if the transformer itself
+      // handler closure to avoid infinite recursion if the handler itself
       // records new issues. This means only issue handling traits whose scope
       // is outside this one will be allowed to handle such issues.
       let newIssue = Configuration.withCurrent(oldConfiguration) {
@@ -120,31 +120,31 @@ extension Trait where Self == IssueHandlingTrait {
   /// Constructs an trait that transforms issues recorded by a test.
   ///
   /// - Parameters:
-  ///   - transformer: The closure called for each issue recorded by the test
+  ///   - transform: A closure called for each issue recorded by the test
   ///     this trait is applied to. It is passed a recorded issue, and returns
   ///     an optional issue to replace the passed-in one.
   ///
   /// - Returns: An instance of ``IssueHandlingTrait`` that transforms issues.
   ///
-  /// The `transformer` closure is called synchronously each time an issue is
+  /// The `transform` closure is called synchronously each time an issue is
   /// recorded by the test this trait is applied to. The closure is passed the
   /// recorded issue, and if it returns a non-`nil` value, that will be recorded
   /// instead of the original. Otherwise, if the closure returns `nil`, the
   /// issue is suppressed and will not be included in the results.
   ///
-  /// The `transformer` closure may be called more than once if the test records
+  /// The `transform` closure may be called more than once if the test records
   /// multiple issues. If more than one instance of this trait is applied to a
-  /// test (including via inheritance from a containing suite), the `transformer`
+  /// test (including via inheritance from a containing suite), the `transform`
   /// closure for each instance will be called in right-to-left, innermost-to-
   /// outermost order, unless `nil` is returned, which will skip invoking the
   /// remaining traits' closures.
   ///
-  /// Within `transformer`, you may access the current test or test case (if any)
+  /// Within `transform`, you may access the current test or test case (if any)
   /// using ``Test/current`` ``Test/Case/current``, respectively. You may also
   /// record new issues, although they will only be handled by issue handling
   /// traits which precede this trait or were inherited from a containing suite.
-  public static func transformIssues(_ transformer: @escaping @Sendable (Issue) -> Issue?) -> Self {
-    Self(handler: transformer)
+  public static func compactMapIssues(_ transform: @escaping @Sendable (Issue) -> Issue?) -> Self {
+    Self(handler: transform)
   }
 
   /// Constructs a trait that filters issues recorded by a test.

--- a/Sources/Testing/Traits/IssueHandlingTrait.swift
+++ b/Sources/Testing/Traits/IssueHandlingTrait.swift
@@ -111,6 +111,11 @@ extension IssueHandlingTrait: TestScoping {
       }
 
       if let newIssue {
+        // Prohibit assigning the issue's kind to system.
+        if case .system = newIssue.kind {
+          preconditionFailure("Issue returned by issue handling closure cannot have kind 'system': \(newIssue)")
+        }
+
         var event = event
         event.kind = .issueRecorded(newIssue)
         oldConfiguration.eventHandler(event, context)
@@ -150,8 +155,9 @@ extension Trait where Self == IssueHandlingTrait {
   /// record new issues, although they will only be handled by issue handling
   /// traits which precede this trait or were inherited from a containing suite.
   ///
-  /// - Note: `transform` is never passed issues for which the value of
-  ///   ``Issue/kind`` is ``Issue/Kind/system``.
+  /// - Note: `transform` will never be passed an issue for which the value of
+  ///   ``Issue/kind`` is ``Issue/Kind/system``, and may not return such an
+  ///   issue.
   public static func compactMapIssues(_ transform: @escaping @Sendable (Issue) -> Issue?) -> Self {
     Self(handler: transform)
   }
@@ -184,7 +190,7 @@ extension Trait where Self == IssueHandlingTrait {
   /// record new issues, although they will only be handled by issue handling
   /// traits which precede this trait or were inherited from a containing suite.
   ///
-  /// - Note: `isIncluded` is never passed issues for which the value of
+  /// - Note: `isIncluded` will never be passed an issue for which the value of
   ///   ``Issue/kind`` is ``Issue/Kind/system``.
   public static func filterIssues(_ isIncluded: @escaping @Sendable (Issue) -> Bool) -> Self {
     Self { issue in

--- a/Tests/TestingTests/Traits/IssueHandlingTraitTests.swift
+++ b/Tests/TestingTests/Traits/IssueHandlingTraitTests.swift
@@ -215,4 +215,19 @@ struct IssueHandlingTraitTests {
       Issue(kind: .system).record()
     }.run(configuration: configuration)
   }
+
+#if !SWT_NO_EXIT_TESTS
+  @Test("Disallow assigning kind to .system")
+  func disallowAssigningSystemKind() async throws {
+    await #expect(processExitsWith: .failure) {
+      await Test(.compactMapIssues { issue in
+        var issue = issue
+        issue.kind = .system
+        return issue
+      }) {
+        Issue.record("A non-system issue")
+      }.run()
+    }
+  }
+#endif
 }


### PR DESCRIPTION
Refinements to `IssueHandlingTrait` based on [pitch](https://forums.swift.org/t/pitch-issue-handling-traits/80019) feedback.

### Modifications:

- Rename the `transformIssues(_:)` function to `compactMapIssues(_:)` to align better with `filterIssues(_:)`.
- Ignore issues for which the value of `kind` is `.system`.
- Prohibit returning an issue from the closure passed to `compactMapIssues(_:)` whose `kind` is `.system`.
- Adjust documentation and tests.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
