### PR TITLE
Merge 'main' branch to 'release/6.2'

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -127,8 +127,23 @@ let package = Package(
         "Testing",
         "_Testing_CoreGraphics",
         "_Testing_Foundation",
+        "MemorySafeTestingTests",
       ],
-      swiftSettings: .packageSettings
+      swiftSettings: .packageSettings + .disableMandatoryOptimizationsSettings
+    ),
+
+    // Use a plain `.target` instead of a `.testTarget` to avoid the unnecessary
+    // overhead of having a separate test target for this module. Conceptually,
+    // the content in this module is no different than content which would
+    // typically be placed in the `TestingTests` target, except this content
+    // needs the (module-wide) strict memory safety feature to be enabled.
+    .target(
+      name: "MemorySafeTestingTests",
+      dependencies: [
+        "Testing",
+      ],
+      path: "Tests/_MemorySafeTestingTests",
+      swiftSettings: .packageSettings + .strictMemorySafety
     ),
 
     .macro(
@@ -219,7 +234,7 @@ package.targets.append(contentsOf: [
       "Testing",
       "TestingMacros",
     ],
-    swiftSettings: .packageSettings
+    swiftSettings: .packageSettings + .disableMandatoryOptimizationsSettings
   )
 ])
 #endif
@@ -275,7 +290,10 @@ extension Array where Element == PackageDescription.SwiftSetting {
       // This setting is enabled in the package, but not in the toolchain build
       // (via CMake). Enabling it is dependent on acceptance of the @section
       // proposal via Swift Evolution.
-      .enableExperimentalFeature("SymbolLinkageMarkers"),
+      //
+      // FIXME: Re-enable this once a CI blocker is resolved:
+      // https://github.com/swiftlang/swift-testing/issues/1138.
+//      .enableExperimentalFeature("SymbolLinkageMarkers"),
 
       // This setting is no longer needed when building with a 6.2 or later
       // toolchain now that SE-0458 has been accepted and implemented, but it is
@@ -354,6 +372,32 @@ extension Array where Element == PackageDescription.SwiftSetting {
     }
 
     return result
+  }
+
+  /// Settings necessary to enable Strict Memory Safety, introduced in
+  /// [SE-0458: Opt-in Strict Memory Safety Checking](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0458-strict-memory-safety.md#swiftpm-integration).
+  static var strictMemorySafety: Self {
+#if compiler(>=6.2)
+    // FIXME: Adopt official `.strictMemorySafety()` condition once the minimum
+    // supported toolchain is 6.2.
+    [.unsafeFlags(["-strict-memory-safety"])]
+#else
+    []
+#endif
+  }
+
+  /// Settings which disable Swift's mandatory optimizations pass.
+  ///
+  /// This is intended only to work around a build failure caused by a Swift
+  /// compiler regression which is expected to be resolved in
+  /// [swiftlang/swift#82034](https://github.com/swiftlang/swift/pull/82034).
+  ///
+  /// @Comment {
+  ///   - Bug: This should be removed once the CI issue is resolved.
+  ///     [swiftlang/swift-testin#1138](https://github.com/swiftlang/swift-testing/issues/1138).
+  /// }
+  static var disableMandatoryOptimizationsSettings: Self {
+    [.unsafeFlags(["-Xllvm", "-sil-disable-pass=mandatory-performance-optimizations"])]
   }
 }
 

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -327,6 +327,9 @@ extension ExitTest {
   ///
   /// - Warning: This function is used to implement the
   ///   `#expect(processExitsWith:)` macro. Do not use it directly.
+#if compiler(>=6.2)
+  @safe
+#endif
   public static func __store<each T>(
     _ id: (UInt64, UInt64, UInt64, UInt64),
     _ body: @escaping @Sendable (repeat each T) async throws -> Void,

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -39,6 +39,9 @@ extension Test {
   ///
   /// - Warning: This function is used to implement the `@Test` macro. Do not
   ///   use it directly.
+#if compiler(>=6.2)
+  @safe
+#endif
   public static func __store(
     _ generator: @escaping @Sendable () async -> Test,
     into outValue: UnsafeMutableRawPointer,

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -217,8 +217,10 @@ public macro Test<C>(
 ///   - collection: A collection of values to pass to the associated test
 ///     function.
 ///
-/// During testing, the associated test function is called once for each element
-/// in `collection`.
+/// You can prefix the expression you pass to `collection` with `try` or `await`.
+/// The testing library evaluates the expression lazily only if it determines
+/// that the associated test will run. During testing, the testing library calls
+/// the associated test function once for each element in `collection`.
 ///
 /// @Comment {
 ///   - Bug: The testing library should support variadic generics.
@@ -270,7 +272,10 @@ extension Test {
 ///   - collection1: A collection of values to pass to `testFunction`.
 ///   - collection2: A second collection of values to pass to `testFunction`.
 ///
-/// During testing, the associated test function is called once for each pair of
+/// You can prefix the expressions you pass to `collection1` or `collection2`
+/// with `try` or `await`. The testing library evaluates the expressions lazily
+/// only if it determines that the associated test will run. During testing, the
+/// testing library calls the associated test function once for each pair of
 /// elements in `collection1` and `collection2`.
 ///
 /// @Comment {
@@ -298,7 +303,10 @@ public macro Test<C1, C2>(
 ///   - collection1: A collection of values to pass to `testFunction`.
 ///   - collection2: A second collection of values to pass to `testFunction`.
 ///
-/// During testing, the associated test function is called once for each pair of
+/// You can prefix the expressions you pass to `collection1` or `collection2`
+/// with `try` or `await`. The testing library evaluates the expressions lazily
+/// only if it determines that the associated test will run. During testing, the
+/// testing library calls the associated test function once for each pair of
 /// elements in `collection1` and `collection2`.
 ///
 /// @Comment {
@@ -324,8 +332,11 @@ public macro Test<C1, C2>(
 ///   - zippedCollections: Two zipped collections of values to pass to
 ///     `testFunction`.
 ///
-/// During testing, the associated test function is called once for each element
-/// in `zippedCollections`.
+/// You can prefix the expression you pass to `zippedCollections` with `try` or
+/// `await`. The testing library evaluates the expression lazily only if it
+/// determines that the associated test will run. During testing, the testing
+/// library calls the associated test function once for each element in
+/// `zippedCollections`.
 ///
 /// @Comment {
 ///   - Bug: The testing library should support variadic generics.
@@ -352,8 +363,11 @@ public macro Test<C1, C2>(
 ///   - zippedCollections: Two zipped collections of values to pass to
 ///     `testFunction`.
 ///
-/// During testing, the associated test function is called once for each element
-/// in `zippedCollections`.
+/// You can prefix the expression you pass to `zippedCollections` with `try` or
+/// `await`. The testing library evaluates the expression lazily only if it
+/// determines that the associated test will run. During testing, the testing
+/// library calls the associated test function once for each element in
+/// `zippedCollections`.
 ///
 /// @Comment {
 ///   - Bug: The testing library should support variadic generics.

--- a/Sources/Testing/Testing.docc/ParameterizedTesting.md
+++ b/Sources/Testing/Testing.docc/ParameterizedTesting.md
@@ -101,6 +101,37 @@ func makeLargeOrder(count: Int) async throws {
 - Note: Very large ranges such as `0 ..< .max` may take an excessive amount of
   time to test, or may never complete due to resource constraints.
 
+### Pass the same arguments to multiple test functions
+
+If you want to pass the same collection of arguments to two or more
+parameterized test functions, you can extract the arguments to a separate
+function or property and pass it to each `@Test` attribute. For example:
+
+```swift
+extension Food {
+  static var bestSelling: [Food] {
+    get async throws { /* ... */ }
+  }
+}
+
+@Test(arguments: try await Food.bestSelling)
+func `Order entree`(food: Food) {
+  let foodTruck = FoodTruck()
+  #expect(foodTruck.order(food))
+}
+
+@Test(arguments: try await Food.bestSelling)
+func `Package leftovers`(food: Food) throws {
+  let foodTruck = FoodTruck()
+  let container = try #require(foodTruck.container(fitting: food))
+  try container.add(food)
+}
+```
+
+> Tip: You can prefix expressions passed to `arguments:` with `try` or `await`.
+> The testing library evaluates them lazily only if it determines that the
+> associated test will run.
+
 ### Test with more than one collection
 
 It's possible to test more than one collection. Consider the following test

--- a/Sources/Testing/Testing.docc/Traits.md
+++ b/Sources/Testing/Testing.docc/Traits.md
@@ -51,7 +51,7 @@ types that customize the behavior of your tests.
 <!--
 ### Handling issues
 
-- ``Trait/transformIssues(_:)``
+- ``Trait/compactMapIssues(_:)``
 - ``Trait/filterIssues(_:)``
 -->
 

--- a/Sources/Testing/Traits/IssueHandlingTrait.swift
+++ b/Sources/Testing/Traits/IssueHandlingTrait.swift
@@ -15,14 +15,14 @@
 /// modifying one or more of its properties, and returning the copy. You can
 /// observe recorded issues by returning them unmodified. Or you can suppress an
 /// issue by either filtering it using ``Trait/filterIssues(_:)`` or returning
-/// `nil` from the closure passed to ``Trait/transformIssues(_:)``.
+/// `nil` from the closure passed to ``Trait/compactMapIssues(_:)``.
 ///
 /// When an instance of this trait is applied to a suite, it is recursively
 /// inherited by all child suites and tests.
 ///
 /// To add this trait to a test, use one of the following functions:
 ///
-/// - ``Trait/transformIssues(_:)``
+/// - ``Trait/compactMapIssues(_:)``
 /// - ``Trait/filterIssues(_:)``
 @_spi(Experimental)
 public struct IssueHandlingTrait: TestTrait, SuiteTrait {
@@ -96,8 +96,14 @@ extension IssueHandlingTrait: TestScoping {
         return
       }
 
+      // Ignore system issues, as they are not expected to be caused by users.
+      if case .system = issue.kind {
+        oldConfiguration.eventHandler(event, context)
+        return
+      }
+
       // Use the original configuration's event handler when invoking the
-      // transformer to avoid infinite recursion if the transformer itself
+      // handler closure to avoid infinite recursion if the handler itself
       // records new issues. This means only issue handling traits whose scope
       // is outside this one will be allowed to handle such issues.
       let newIssue = Configuration.withCurrent(oldConfiguration) {
@@ -105,6 +111,11 @@ extension IssueHandlingTrait: TestScoping {
       }
 
       if let newIssue {
+        // Prohibit assigning the issue's kind to system.
+        if case .system = newIssue.kind {
+          preconditionFailure("Issue returned by issue handling closure cannot have kind 'system': \(newIssue)")
+        }
+
         var event = event
         event.kind = .issueRecorded(newIssue)
         oldConfiguration.eventHandler(event, context)
@@ -120,31 +131,35 @@ extension Trait where Self == IssueHandlingTrait {
   /// Constructs an trait that transforms issues recorded by a test.
   ///
   /// - Parameters:
-  ///   - transformer: The closure called for each issue recorded by the test
+  ///   - transform: A closure called for each issue recorded by the test
   ///     this trait is applied to. It is passed a recorded issue, and returns
   ///     an optional issue to replace the passed-in one.
   ///
   /// - Returns: An instance of ``IssueHandlingTrait`` that transforms issues.
   ///
-  /// The `transformer` closure is called synchronously each time an issue is
+  /// The `transform` closure is called synchronously each time an issue is
   /// recorded by the test this trait is applied to. The closure is passed the
   /// recorded issue, and if it returns a non-`nil` value, that will be recorded
   /// instead of the original. Otherwise, if the closure returns `nil`, the
   /// issue is suppressed and will not be included in the results.
   ///
-  /// The `transformer` closure may be called more than once if the test records
+  /// The `transform` closure may be called more than once if the test records
   /// multiple issues. If more than one instance of this trait is applied to a
-  /// test (including via inheritance from a containing suite), the `transformer`
+  /// test (including via inheritance from a containing suite), the `transform`
   /// closure for each instance will be called in right-to-left, innermost-to-
   /// outermost order, unless `nil` is returned, which will skip invoking the
   /// remaining traits' closures.
   ///
-  /// Within `transformer`, you may access the current test or test case (if any)
+  /// Within `transform`, you may access the current test or test case (if any)
   /// using ``Test/current`` ``Test/Case/current``, respectively. You may also
   /// record new issues, although they will only be handled by issue handling
   /// traits which precede this trait or were inherited from a containing suite.
-  public static func transformIssues(_ transformer: @escaping @Sendable (Issue) -> Issue?) -> Self {
-    Self(handler: transformer)
+  ///
+  /// - Note: `transform` will never be passed an issue for which the value of
+  ///   ``Issue/kind`` is ``Issue/Kind/system``, and may not return such an
+  ///   issue.
+  public static func compactMapIssues(_ transform: @escaping @Sendable (Issue) -> Issue?) -> Self {
+    Self(handler: transform)
   }
 
   /// Constructs a trait that filters issues recorded by a test.
@@ -174,6 +189,9 @@ extension Trait where Self == IssueHandlingTrait {
   /// using ``Test/current`` ``Test/Case/current``, respectively. You may also
   /// record new issues, although they will only be handled by issue handling
   /// traits which precede this trait or were inherited from a containing suite.
+  ///
+  /// - Note: `isIncluded` will never be passed an issue for which the value of
+  ///   ``Issue/kind`` is ``Issue/Kind/system``.
   public static func filterIssues(_ isIncluded: @escaping @Sendable (Issue) -> Bool) -> Self {
     Self { issue in
       isIncluded(issue) ? issue : nil

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -496,10 +496,11 @@ extension ExitTestConditionMacro {
       var recordDecl: DeclSyntax?
 #if !SWT_NO_LEGACY_TEST_DISCOVERY
       let legacyEnumName = context.makeUniqueName("__🟡$")
+      let unsafeKeyword: TokenSyntax? = isUnsafeKeywordSupported ? .keyword(.unsafe, trailingTrivia: .space) : nil
       recordDecl = """
       enum \(legacyEnumName): Testing.__TestContentRecordContainer {
         nonisolated static var __testContentRecord: Testing.__TestContentRecord {
-          \(enumName).testContentRecord
+          \(unsafeKeyword)\(enumName).testContentRecord
         }
       }
       """

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -169,12 +169,13 @@ public struct SuiteDeclarationMacro: MemberMacro, PeerMacro, Sendable {
 #if !SWT_NO_LEGACY_TEST_DISCOVERY
     // Emit a type that contains a reference to the test content record.
     let enumName = context.makeUniqueName("__🟡$")
+    let unsafeKeyword: TokenSyntax? = isUnsafeKeywordSupported ? .keyword(.unsafe, trailingTrivia: .space) : nil
     result.append(
       """
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
       enum \(enumName): Testing.__TestContentRecordContainer {
         nonisolated static var __testContentRecord: Testing.__TestContentRecord {
-          \(testContentRecordName)
+          \(unsafeKeyword)\(testContentRecordName)
         }
       }
       """

--- a/Sources/TestingMacros/Support/EffectfulExpressionHandling.swift
+++ b/Sources/TestingMacros/Support/EffectfulExpressionHandling.swift
@@ -86,6 +86,17 @@ extension BidirectionalCollection<Syntax> {
 
 // MARK: - Inserting effect keywords/thunks
 
+/// Whether or not the `unsafe` expression keyword is supported.
+var isUnsafeKeywordSupported: Bool {
+  // The 'unsafe' keyword was introduced in 6.2 as part of SE-0458. Older
+  // toolchains are not aware of it.
+#if compiler(>=6.2)
+  true
+#else
+  false
+#endif
+}
+
 /// Make a function call expression to an effectful thunk function provided by
 /// the testing library.
 ///
@@ -127,12 +138,7 @@ func applyEffectfulKeywords(_ effectfulKeywords: Set<Keyword>, to expr: some Exp
   let needAwait = effectfulKeywords.contains(.await) && !expr.is(AwaitExprSyntax.self)
   let needTry = effectfulKeywords.contains(.try) && !expr.is(TryExprSyntax.self)
 
-  // The 'unsafe' keyword was introduced in 6.2 as part of SE-0458. Older
-  // toolchains are not aware of it, so avoid emitting expressions involving
-  // that keyword when the macro has been built using an older toolchain.
-#if compiler(>=6.2)
-  let needUnsafe = effectfulKeywords.contains(.unsafe) && !expr.is(UnsafeExprSyntax.self)
-#endif
+  let needUnsafe = isUnsafeKeywordSupported && effectfulKeywords.contains(.unsafe) && !expr.is(UnsafeExprSyntax.self)
 
   // First, add thunk function calls.
   if needAwait {
@@ -141,11 +147,9 @@ func applyEffectfulKeywords(_ effectfulKeywords: Set<Keyword>, to expr: some Exp
   if needTry {
     expr = _makeCallToEffectfulThunk(.identifier("__requiringTry"), passing: expr)
   }
-#if compiler(>=6.2)
   if needUnsafe {
     expr = _makeCallToEffectfulThunk(.identifier("__requiringUnsafe"), passing: expr)
   }
-#endif
 
   // Then add keyword expressions. (We do this separately so we end up writing
   // `try await __r(__r(self))` instead of `try __r(await __r(self))` which is
@@ -153,7 +157,7 @@ func applyEffectfulKeywords(_ effectfulKeywords: Set<Keyword>, to expr: some Exp
   if needAwait {
     expr = ExprSyntax(
       AwaitExprSyntax(
-        awaitKeyword: .keyword(.await).with(\.trailingTrivia, .space),
+        awaitKeyword: .keyword(.await, trailingTrivia: .space),
         expression: expr
       )
     )
@@ -161,21 +165,19 @@ func applyEffectfulKeywords(_ effectfulKeywords: Set<Keyword>, to expr: some Exp
   if needTry {
     expr = ExprSyntax(
       TryExprSyntax(
-        tryKeyword: .keyword(.try).with(\.trailingTrivia, .space),
+        tryKeyword: .keyword(.try, trailingTrivia: .space),
         expression: expr
       )
     )
   }
-#if compiler(>=6.2)
   if needUnsafe {
     expr = ExprSyntax(
       UnsafeExprSyntax(
-        unsafeKeyword: .keyword(.unsafe).with(\.trailingTrivia, .space),
+        unsafeKeyword: .keyword(.unsafe, trailingTrivia: .space),
         expression: expr
       )
     )
   }
-#endif
 
   expr.leadingTrivia = originalExpr.leadingTrivia
   expr.trailingTrivia = originalExpr.trailingTrivia

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -63,12 +63,13 @@ func makeTestContentRecordDecl(named name: TokenSyntax, in typeName: TypeSyntax?
     IntegerLiteralExprSyntax(context, radix: .binary)
   }
 
+  let unsafeKeyword: TokenSyntax? = isUnsafeKeywordSupported ? .keyword(.unsafe, trailingTrivia: .space) : nil
   var result: DeclSyntax = """
   @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")
   private nonisolated \(staticKeyword(for: typeName)) let \(name): Testing.__TestContentRecord = (
     \(kindExpr), \(kind.commentRepresentation)
     0,
-    \(accessorName),
+    \(unsafeKeyword)\(accessorName),
     \(contextExpr),
     0
   )

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -494,12 +494,13 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
 #if !SWT_NO_LEGACY_TEST_DISCOVERY
     // Emit a type that contains a reference to the test content record.
     let enumName = context.makeUniqueName(thunking: functionDecl, withPrefix: "__🟡$")
+    let unsafeKeyword: TokenSyntax? = isUnsafeKeywordSupported ? .keyword(.unsafe, trailingTrivia: .space) : nil
     result.append(
       """
       @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
       enum \(enumName): Testing.__TestContentRecordContainer {
         nonisolated static var __testContentRecord: Testing.__TestContentRecord {
-          \(testContentRecordName)
+          \(unsafeKeyword)\(testContentRecordName)
         }
       }
       """

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -491,7 +491,6 @@ final class IssueTests: XCTestCase {
     }.run(configuration: .init())
   }
 
-#if !SWT_TARGET_OS_APPLE || SWT_FIXED_149299786
   func testErrorCheckingWithExpect() async throws {
     let expectationFailed = expectation(description: "Expectation failed")
     expectationFailed.isInverted = true
@@ -611,7 +610,6 @@ final class IssueTests: XCTestCase {
 
     await fulfillment(of: [expectationFailed], timeout: 0.0)
   }
-#endif
 
   func testErrorCheckingWithExpect_mismatchedErrorDescription() async throws {
     let expectationFailed = expectation(description: "Expectation failed")

--- a/Tests/TestingTests/Traits/IssueHandlingTraitTests.swift
+++ b/Tests/TestingTests/Traits/IssueHandlingTraitTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("IssueHandlingTrait Tests")
 struct IssueHandlingTraitTests {
@@ -23,7 +23,7 @@ struct IssueHandlingTraitTests {
       #expect(issue.comments == ["Foo", "Bar"])
     }
 
-    let handler = IssueHandlingTrait.transformIssues { issue in
+    let handler = IssueHandlingTrait.compactMapIssues { issue in
       var issue = issue
       issue.comments.append("Bar")
       return issue
@@ -34,8 +34,8 @@ struct IssueHandlingTraitTests {
     }.run(configuration: configuration)
   }
 
-  @Test("Suppressing an issue by returning `nil` from the transform closure")
-  func suppressIssueUsingTransformer() async throws {
+  @Test("Suppressing an issue by returning `nil` from the closure passed to compactMapIssues()")
+  func suppressIssueUsingCompactMapIssues() async throws {
     var configuration = Configuration()
     configuration.eventHandler = { event, context in
       if case .issueRecorded = event.kind {
@@ -43,7 +43,7 @@ struct IssueHandlingTraitTests {
       }
     }
 
-    let handler = IssueHandlingTrait.transformIssues { _ in
+    let handler = IssueHandlingTrait.compactMapIssues { _ in
       // Return nil to suppress the issue.
       nil
     }
@@ -81,10 +81,10 @@ struct IssueHandlingTraitTests {
 
     struct MyError: Error {}
 
-    try await confirmation("Transformer closure is called") { transformerCalled in
-      let transformer: @Sendable (Issue) -> Issue? = { issue in
+    try await confirmation("Issue handler closure is called") { issueHandlerCalled in
+      let transform: @Sendable (Issue) -> Issue? = { issue in
         defer {
-          transformerCalled()
+          issueHandlerCalled()
         }
 
         #expect(Test.Case.current == nil)
@@ -96,7 +96,7 @@ struct IssueHandlingTraitTests {
 
       let test = Test(
         .enabled(if: try { throw MyError() }()),
-        .transformIssues(transformer)
+        .compactMapIssues(transform)
       ) {}
 
       // Use a detached task to intentionally clear task local values for the
@@ -108,12 +108,12 @@ struct IssueHandlingTraitTests {
   }
 #endif
 
-  @Test("Accessing the current Test and Test.Case from a transformer closure")
+  @Test("Accessing the current Test and Test.Case from an issue handler closure")
   func currentTestAndCase() async throws {
-    await confirmation("Transformer closure is called") { transformerCalled in
-      let handler = IssueHandlingTrait.transformIssues { issue in
+    await confirmation("Issue handler closure is called") { issueHandlerCalled in
+      let handler = IssueHandlingTrait.compactMapIssues { issue in
         defer {
-          transformerCalled()
+          issueHandlerCalled()
         }
         #expect(Test.current?.name == "fixture()")
         #expect(Test.Case.current != nil)
@@ -140,12 +140,12 @@ struct IssueHandlingTraitTests {
       #expect(issue.comments == ["Foo", "Bar", "Baz"])
     }
 
-    let outerHandler = IssueHandlingTrait.transformIssues { issue in
+    let outerHandler = IssueHandlingTrait.compactMapIssues { issue in
       var issue = issue
       issue.comments.append("Baz")
       return issue
     }
-    let innerHandler = IssueHandlingTrait.transformIssues { issue in
+    let innerHandler = IssueHandlingTrait.compactMapIssues { issue in
       var issue = issue
       issue.comments.append("Bar")
       return issue
@@ -156,7 +156,7 @@ struct IssueHandlingTraitTests {
     }.run(configuration: configuration)
   }
 
-  @Test("Secondary issue recorded from a transformer closure")
+  @Test("Secondary issue recorded from an issue handler closure")
   func issueRecordedFromClosure() async throws {
     await confirmation("Original issue recorded") { originalIssueRecorded in
       await confirmation("Secondary issue recorded") { secondaryIssueRecorded in
@@ -175,14 +175,14 @@ struct IssueHandlingTraitTests {
           }
         }
 
-        let handler1 = IssueHandlingTrait.transformIssues { issue in
+        let handler1 = IssueHandlingTrait.compactMapIssues { issue in
           return issue
         }
-        let handler2 = IssueHandlingTrait.transformIssues { issue in
+        let handler2 = IssueHandlingTrait.compactMapIssues { issue in
           Issue.record("Something else")
           return issue
         }
-        let handler3 = IssueHandlingTrait.transformIssues { issue in
+        let handler3 = IssueHandlingTrait.compactMapIssues { issue in
           // The "Something else" issue should not be passed to this closure.
           #expect(issue.comments.contains("Foo"))
           return issue
@@ -194,4 +194,40 @@ struct IssueHandlingTraitTests {
       }
     }
   }
+
+  @Test("System issues are not passed to issue handler closures")
+  func ignoresSystemIssues() async throws {
+    var configuration = Configuration()
+    configuration.eventHandler = { event, context in
+      if case let .issueRecorded(issue) = event.kind, case .unconditional = issue.kind {
+        issue.record()
+      }
+    }
+
+    let handler = IssueHandlingTrait.compactMapIssues { issue in
+      if case .system = issue.kind {
+        Issue.record("Unexpectedly received a system issue")
+      }
+      return nil
+    }
+
+    await Test(handler) {
+      Issue(kind: .system).record()
+    }.run(configuration: configuration)
+  }
+
+#if !SWT_NO_EXIT_TESTS
+  @Test("Disallow assigning kind to .system")
+  func disallowAssigningSystemKind() async throws {
+    await #expect(processExitsWith: .failure) {
+      await Test(.compactMapIssues { issue in
+        var issue = issue
+        issue.kind = .system
+        return issue
+      }) {
+        Issue.record("A non-system issue")
+      }.run()
+    }
+  }
+#endif
 }

--- a/Tests/_MemorySafeTestingTests/MemorySafeTestDecls.swift
+++ b/Tests/_MemorySafeTestingTests/MemorySafeTestDecls.swift
@@ -1,0 +1,31 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if compiler(>=6.2)
+
+@testable import Testing
+
+#if !hasFeature(StrictMemorySafety)
+#error("This file requires strict memory safety to be enabled")
+#endif
+
+@Test(.hidden)
+func exampleTestFunction() {}
+
+@Suite(.hidden)
+struct ExampleSuite {
+  @Test func example() {}
+}
+
+func exampleExitTest() async {
+  await #expect(processExitsWith: .success) {}
+}
+
+#endif


### PR DESCRIPTION
This merges the `main` branch into the `release/6.2` branch.

> Note: The Swift Testing project will be periodically performing "backwards" merges like this for a period which extends beyond the date when the 6.2 branches were cut, since nearly all contributions are intended to be included in the 6.2 release.

Once this PR has been merged, I will adjust the milestones on the PRs included in this merge to be 6.2 wherever appropriate.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
