### PR TITLE
Update outdated Suite macro documentation

### DIFF
--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -53,9 +53,8 @@ public typealias __XCTestCompatibleSelector = Never
 /// - Parameters:
 ///   - traits: Zero or more traits to apply to this test suite.
 ///
-/// A test suite is a type that contains one or more test functions. Any
-/// copyable type (that is, any type that is not marked `~Copyable`) may be a
-/// test suite.
+/// A test suite is a type that contains one or more test functions. 
+/// Any type may be a test suite.
 ///
 /// The use of the `@Suite` attribute is optional; types are recognized as test
 /// suites even if they do not have the `@Suite` attribute applied to them.
@@ -81,9 +80,8 @@ public macro Suite(
 ///     from the associated type's name.
 ///   - traits: Zero or more traits to apply to this test suite.
 ///
-/// A test suite is a type that contains one or more test functions. Any
-/// copyable type (that is, any type that is not marked `~Copyable`) may be a
-/// test suite.
+/// A test suite is a type that contains one or more test functions.
+/// Any type may be a test suite.
 ///
 /// The use of the `@Suite` attribute is optional; types are recognized as test
 /// suites even if they do not have the `@Suite` attribute applied to them.


### PR DESCRIPTION
Remove the doc stating that the `@Suite` macro only works on `Copyable` types.

### Motivation:

When reading through the docs, I was quite confused seeing it stated that `~Copyable` types aren't supported by the `@Suite` macro, whereas it does work when doing so. I had a look at it looks like that restriction has been lifted by #619, but the docs weren't updated. 

### Modifications:

Updated the docs

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
