### PR TITLE
Disable inheritance of file descriptors created by Swift Testing by default.

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -462,7 +462,7 @@ extension Attachment where AttachableValue: ~Copyable {
       // file exists at this path (note "x" in the mode string), an error will
       // be thrown and we'll try again by adding a suffix.
       let preferredPath = appendPathComponent(preferredName, to: directoryPath)
-      file = try FileHandle(atPath: preferredPath, mode: "wxb")
+      file = try FileHandle(atPath: preferredPath, mode: "wxeb")
       result = preferredPath
     } catch {
       // Split the extension(s) off the preferred name. The first component in
@@ -478,7 +478,7 @@ extension Attachment where AttachableValue: ~Copyable {
         // Propagate any error *except* EEXIST, which would indicate that the
         // name was already in use (so we should try again with a new suffix.)
         do {
-          file = try FileHandle(atPath: preferredPath, mode: "wxb")
+          file = try FileHandle(atPath: preferredPath, mode: "wxeb")
           result = preferredPath
           break
         } catch let error as CError where error.rawValue == swt_EEXIST() {

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -779,17 +779,21 @@ extension ExitTest {
             _ = setvbuf(stderr, nil, _IONBF, Int(BUFSIZ))
           }
         }
+        try stdoutWriteEnd?.setInherited(true)
+        try stderrWriteEnd?.setInherited(true)
 
         // Create a "back channel" pipe to handle events from the child process.
         var backChannelReadEnd: FileHandle!
         var backChannelWriteEnd: FileHandle!
         try FileHandle.makePipe(readEnd: &backChannelReadEnd, writeEnd: &backChannelWriteEnd)
+        try backChannelWriteEnd.setInherited(true)
 
         // Create another pipe to send captured values (and possibly other state
         // in the future) to the child process.
         var capturedValuesReadEnd: FileHandle!
         var capturedValuesWriteEnd: FileHandle!
         try FileHandle.makePipe(readEnd: &capturedValuesReadEnd, writeEnd: &capturedValuesWriteEnd)
+        try capturedValuesReadEnd.setInherited(true)
 
         // Let the child process know how to find the back channel and
         // captured values channel by setting a known environment variable to

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -656,7 +656,7 @@ extension FileHandle {
       }
     }
 #elseif os(Windows)
-    return withUnsafeWindowsHANDLE { handle in
+    return try withUnsafeWindowsHANDLE { handle in
       guard let handle else {
         throw SystemError(description: "Cannot set whether a file handle is inherited unless it is backed by a Windows file handle. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
       }

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -171,7 +171,6 @@ static int swt_setfdflags(int fd, int flags) {
 }
 #endif
 
-
 SWT_ASSUME_NONNULL_END
 
 #endif

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -151,6 +151,25 @@ static int swt_EEXIST(void) {
   return EEXIST;
 }
 
+#if __has_include(<fcntl.h>) || __has_include(<sys/fcntl.h>)
+/// Call `fcntl(F_GETFD)`.
+///
+/// This function is provided because `fcntl()` is a variadic function and
+/// cannot be imported directly into Swift.
+static int swt_getfdflags(int fd) {
+  return fcntl(fd, F_GETFD);
+}
+
+/// Call `fcntl(F_SETFD)`.
+///
+/// This function is provided because `fcntl()` is a variadic function and
+/// cannot be imported directly into Swift.
+static int swt_setfdflags(int fd, int flags) {
+  return fcntl(fd, F_SETFD, flags);
+}
+#endif
+
+
 SWT_ASSUME_NONNULL_END
 
 #endif

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -151,7 +151,7 @@ static int swt_EEXIST(void) {
   return EEXIST;
 }
 
-#if __has_include(<fcntl.h>) || __has_include(<sys/fcntl.h>)
+#if defined(F_GETFD)
 /// Call `fcntl(F_GETFD)`.
 ///
 /// This function is provided because `fcntl()` is a variadic function and
@@ -159,7 +159,9 @@ static int swt_EEXIST(void) {
 static int swt_getfdflags(int fd) {
   return fcntl(fd, F_GETFD);
 }
+#endif
 
+#if defined(F_SETFD)
 /// Call `fcntl(F_SETFD)`.
 ///
 /// This function is provided because `fcntl()` is a variadic function and


### PR DESCRIPTION
This PR makes file descriptors created by Swift Testing `FD_CLOEXEC` by default (on Windows, `~HANDLE_FLAG_INHERIT`.) We then clear `FD_CLOEXEC` for specific file descriptors that should be inherited. On Darwin, this is effectively ignored because we use `POSIX_SPAWN_CLOEXEC_DEFAULT`, and on Windows we use `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` which has [much the same effect](https://devblogs.microsoft.com/oldnewthing/20111216-00/?p=8873). (On non-Darwin POSIX platforms, there's no reliable way to ensure only one child process inherits a particular file descriptor.)

This change is speculative. No additional unit tests are added because existing test coverage _should be_ sufficient; the reported issue is on a platform (Ubuntu 20.04) where we don't have any CI jobs.

Resolves #1140.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
