### PR TITLE
Declare Xcode 26 availability for all Swift 6.2 APIs

### DIFF
--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
@@ -20,6 +20,7 @@ public import Foundation
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 extension Attachable where Self: Encodable & NSSecureCoding {
   @_documentation(visibility: private)

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable.swift
@@ -56,6 +56,7 @@ func withUnsafeBytes<E, R>(encoding attachableValue: borrowing E, for attachment
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 extension Attachable where Self: Encodable {
   /// Encode this value into a buffer using either [`PropertyListEncoder`](https://developer.apple.com/documentation/foundation/propertylistencoder)
@@ -92,6 +93,7 @@ extension Attachable where Self: Encodable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<Self>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     try _Testing_Foundation.withUnsafeBytes(encoding: self, for: attachment, body)

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+NSSecureCoding.swift
@@ -18,6 +18,7 @@ public import Foundation
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 extension Attachable where Self: NSSecureCoding {
   /// Encode this object using [`NSKeyedArchiver`](https://developer.apple.com/documentation/foundation/nskeyedarchiver)
@@ -52,6 +53,7 @@ extension Attachable where Self: NSSecureCoding {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<Self>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     let format = try EncodingFormat(for: attachment)

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
@@ -53,6 +53,7 @@ extension Attachment where AttachableValue == _AttachableURLWrapper {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public init(
     contentsOf url: URL,

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Data+Attachable.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Data+Attachable.swift
@@ -14,10 +14,12 @@ public import Foundation
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 extension Data: Attachable {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<Self>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     try withUnsafeBytes(body)

--- a/Sources/Testing/Attachments/Attachable.swift
+++ b/Sources/Testing/Attachments/Attachable.swift
@@ -29,6 +29,7 @@
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 public protocol Attachable: ~Copyable {
   /// An estimate of the number of bytes of memory needed to store this value as
@@ -48,6 +49,7 @@ public protocol Attachable: ~Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   var estimatedAttachmentByteCount: Int? { get }
 
@@ -74,6 +76,7 @@ public protocol Attachable: ~Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   borrowing func withUnsafeBytes<R>(for attachment: borrowing Attachment<Self>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R
 
@@ -94,6 +97,7 @@ public protocol Attachable: ~Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   borrowing func preferredName(for attachment: borrowing Attachment<Self>, basedOn suggestedName: String) -> String
 }

--- a/Sources/Testing/Attachments/AttachableWrapper.swift
+++ b/Sources/Testing/Attachments/AttachableWrapper.swift
@@ -24,12 +24,14 @@
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 public protocol AttachableWrapper<Wrapped>: Attachable, ~Copyable {
   /// The type of the underlying value represented by this type.
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   associatedtype Wrapped
 
@@ -37,6 +39,7 @@ public protocol AttachableWrapper<Wrapped>: Attachable, ~Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   var wrappedValue: Wrapped { get }
 }

--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -21,6 +21,7 @@ private import _TestingInternals
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 public struct Attachment<AttachableValue>: ~Copyable where AttachableValue: Attachable & ~Copyable {
   /// Storage for ``attachableValue-7dyjv``.
@@ -57,6 +58,7 @@ public struct Attachment<AttachableValue>: ~Copyable where AttachableValue: Atta
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public var preferredName: String {
     let suggestedName = if let _preferredName, !_preferredName.isEmpty {
@@ -100,6 +102,7 @@ extension Attachment where AttachableValue: ~Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public init(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #_sourceLocation) {
     self._attachableValue = attachableValue
@@ -194,6 +197,7 @@ extension Attachment where AttachableValue: ~Copyable {
 extension Attachment: CustomStringConvertible {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public var description: String {
     #""\#(preferredName)": \#(String(describingForTest: attachableValue))"#
@@ -207,6 +211,7 @@ extension Attachment where AttachableValue: ~Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   @_disfavoredOverload public var attachableValue: AttachableValue {
     _read {
@@ -229,6 +234,7 @@ extension Attachment where AttachableValue: AttachableWrapper & ~Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public var attachableValue: AttachableValue.Wrapped {
     _read {
@@ -259,6 +265,7 @@ extension Attachment where AttachableValue: Sendable & Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   @_documentation(visibility: private)
   public static func record(_ attachment: consuming Self, sourceLocation: SourceLocation = #_sourceLocation) {
@@ -291,6 +298,7 @@ extension Attachment where AttachableValue: Sendable & Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   @_documentation(visibility: private)
   public static func record(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #_sourceLocation) {
@@ -318,6 +326,7 @@ extension Attachment where AttachableValue: ~Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public static func record(_ attachment: consuming Self, sourceLocation: SourceLocation = #_sourceLocation) {
     do {
@@ -361,6 +370,7 @@ extension Attachment where AttachableValue: ~Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public static func record(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #_sourceLocation) {
     record(Self(attachableValue, named: preferredName, sourceLocation: sourceLocation), sourceLocation: sourceLocation)
@@ -389,6 +399,7 @@ extension Attachment where AttachableValue: ~Copyable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   @inlinable public borrowing func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     try attachableValue.withUnsafeBytes(for: self, body)

--- a/Sources/Testing/ExitTests/ExitStatus.swift
+++ b/Sources/Testing/ExitTests/ExitStatus.swift
@@ -21,6 +21,7 @@ private import _TestingInternals
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 #if SWT_NO_PROCESS_SPAWNING
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
@@ -55,6 +56,7 @@ public enum ExitStatus: Sendable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   case exitCode(_ exitCode: CInt)
 
@@ -81,6 +83,7 @@ public enum ExitStatus: Sendable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   case signal(_ signal: CInt)
 }

--- a/Sources/Testing/ExitTests/ExitTest.Condition.swift
+++ b/Sources/Testing/ExitTests/ExitTest.Condition.swift
@@ -35,6 +35,7 @@ extension ExitTest {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public struct Condition: Sendable {
     /// An enumeration describing the possible conditions for an exit test.
@@ -66,6 +67,7 @@ extension ExitTest.Condition {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public static var success: Self {
     Self(_kind: .success)
@@ -78,6 +80,7 @@ extension ExitTest.Condition {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public static var failure: Self {
     Self(_kind: .failure)
@@ -91,6 +94,7 @@ extension ExitTest.Condition {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public init(_ exitStatus: ExitStatus) {
     self.init(_kind: .exitStatus(exitStatus))
@@ -126,6 +130,7 @@ extension ExitTest.Condition {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public static func exitCode(_ exitCode: CInt) -> Self {
 #if !SWT_NO_EXIT_TESTS
@@ -158,6 +163,7 @@ extension ExitTest.Condition {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public static func signal(_ signal: CInt) -> Self {
 #if !SWT_NO_EXIT_TESTS

--- a/Sources/Testing/ExitTests/ExitTest.Result.swift
+++ b/Sources/Testing/ExitTests/ExitTest.Result.swift
@@ -21,12 +21,14 @@ extension ExitTest {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public struct Result: Sendable {
     /// The exit status reported by the process hosting the exit test.
     ///
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.2)
+    ///   @Available(Xcode, introduced: 26.0)
     /// }
     public var exitStatus: ExitStatus
 
@@ -57,6 +59,7 @@ extension ExitTest {
     ///
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.2)
+    ///   @Available(Xcode, introduced: 26.0)
     /// }
     public var standardOutputContent: [UInt8] = []
 
@@ -87,6 +90,7 @@ extension ExitTest {
     ///
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.2)
+    ///   @Available(Xcode, introduced: 26.0)
     /// }
     public var standardErrorContent: [UInt8] = []
 

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -32,6 +32,7 @@ private import _TestingInternals
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
@@ -170,6 +171,7 @@ extension ExitTest {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public static var current: ExitTest? {
     _read {

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -513,6 +513,7 @@ public macro require<R>(
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 @freestanding(expression)
 @discardableResult
@@ -559,6 +560,7 @@ public macro expect(
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 @freestanding(expression)
 @discardableResult

--- a/Sources/Testing/Testing.docc/exit-testing.md
+++ b/Sources/Testing/Testing.docc/exit-testing.md
@@ -12,6 +12,7 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 @Metadata {
   @Available(Swift, introduced: 6.2)
+  @Available(Xcode, introduced: 26.0)
 }
 
 Use exit tests to test functionality that might cause a test process to exit.

--- a/Sources/Testing/Traits/ConditionTrait.swift
+++ b/Sources/Testing/Traits/ConditionTrait.swift
@@ -72,6 +72,7 @@ public struct ConditionTrait: TestTrait, SuiteTrait {
   /// 
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public func evaluate() async throws -> Bool {
     switch kind {


### PR DESCRIPTION
This declares Xcode 26.0 API availability for all Swift 6.2 declarations.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Fixes rdar://151629765