### PR TITLE
Support property accesses on ~Escapable types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -116,7 +116,8 @@ let package = Package(
       ],
       exclude: ["CMakeLists.txt", "Testing.swiftcrossimport"],
       cxxSettings: .packageSettings,
-      swiftSettings: .packageSettings + .enableLibraryEvolution(),
+      swiftSettings: .packageSettings + .enableLibraryEvolution()
+        + [.enableExperimentalFeature("LifetimeDependence")],
       linkerSettings: [
         .linkedLibrary("execinfo", .when(platforms: [.custom("freebsd"), .openbsd]))
       ]
@@ -130,6 +131,7 @@ let package = Package(
         "MemorySafeTestingTests",
       ],
       swiftSettings: .packageSettings + .disableMandatoryOptimizationsSettings
+        + [.enableExperimentalFeature("LifetimeDependence")]
     ),
 
     // Use a plain `.target` instead of a `.testTarget` to avoid the unnecessary

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -65,7 +65,7 @@
 /// If `optionalValue` is `nil`, an ``Issue`` is recorded for the test that is
 /// running in the current task and an instance of ``ExpectationFailedError`` is
 /// thrown.
-@freestanding(expression) public macro require<T>(
+@freestanding(expression) public macro require<T: ~Escapable>(
   _ optionalValue: T?,
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation
@@ -123,7 +123,7 @@ public macro require(
 /// diagnostic indicating that the expectation is redundant.
 @freestanding(expression)
 @_documentation(visibility: private)
-public macro require<T>(
+public macro require<T: ~Escapable>(
   _ optionalValue: T,
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation

--- a/Sources/Testing/Support/Additions/ResultAdditions.swift
+++ b/Sources/Testing/Support/Additions/ResultAdditions.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-extension Result {
+extension Result where Success: ~Escapable {
   /// Handle this instance as if it were returned from a call to `#expect()`.
   ///
   /// - Warning: This function is used to implement the `#expect()` and
@@ -19,6 +19,7 @@ extension Result {
   ///
   /// - Warning: This function is used to implement the `#expect()` and
   ///   `#require()` macros. Do not call it directly.
+  @lifetime(copy self)
   @inlinable public func __required() throws -> Success {
     try get()
   }


### PR DESCRIPTION
This adds support for having nonescapable types on the LHS of property accesses in the `#expect(...)` and `#require(...)` macros. This includes some additional changes that could lead to supporting a nonescapable result type in `#require(...)`, but that may need more lifetime support in the language.

### Motivation:

In the BinaryParsing library, I have a nonescapable `ParserSpan` type. In the tests, I need to write `#expect(span.count == 0)` instead of the more fluent `#expect(span.isEmpty)`.

### Modifications:

I've enabled lifetime annotations in the `Testing` and test targets, and then added overloads of `__checkPropertyAccess` and `__checkValue` that allow `~Escapable` parameters.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
