### PR TITLE
Fix some typos in documentation.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.Result.swift
+++ b/Sources/Testing/ExitTests/ExitTest.Result.swift
@@ -43,9 +43,9 @@ extension ExitTest {
     ///
     /// When checking the value of this property, keep in mind that the standard
     /// output stream is globally accessible, and any code running in an exit
-    /// test may write to it including including the operating system and any
-    /// third-party dependencies you have declared in your package. Rather than
-    /// comparing the value of this property with [`==`](https://developer.apple.com/documentation/swift/array/==(_:_:)),
+    /// test may write to it including the operating system and any third-party
+    /// dependencies you have declared in your package. Rather than comparing
+    /// the value of this property with [`==`](https://developer.apple.com/documentation/swift/array/==(_:_:)),
     /// use [`contains(_:)`](https://developer.apple.com/documentation/swift/collection/contains(_:))
     /// to check if expected output is present.
     ///
@@ -73,10 +73,10 @@ extension ExitTest {
     /// instead.
     ///
     /// When checking the value of this property, keep in mind that the standard
-    /// error stream is globally accessible, and any code running in an exit
-    /// test may write to it including including the operating system and any
-    /// third-party dependencies you have declared in your package. Rather than
-    /// comparing the value of this property with [`==`](https://developer.apple.com/documentation/swift/array/==(_:_:)),
+    /// output stream is globally accessible, and any code running in an exit
+    /// test may write to it including the operating system and any third-party
+    /// dependencies you have declared in your package. Rather than comparing
+    /// the value of this property with [`==`](https://developer.apple.com/documentation/swift/array/==(_:_:)),
     /// use [`contains(_:)`](https://developer.apple.com/documentation/swift/collection/contains(_:))
     /// to check if expected output is present.
     ///

--- a/Sources/Testing/Testing.docc/exit-testing.md
+++ b/Sources/Testing/Testing.docc/exit-testing.md
@@ -153,4 +153,4 @@ extension Customer {
 
 The testing library always sets ``ExitTest/Result/exitStatus`` to the actual
 exit status of the child process (as reported by the system) even if you do not
-pass it.
+observe `\.exitStatus`.

--- a/Sources/_TestDiscovery/TestContentRecord.swift
+++ b/Sources/_TestDiscovery/TestContentRecord.swift
@@ -71,8 +71,8 @@ public struct TestContentRecord<T> where T: DiscoverableAsTestContent {
   ///
   /// | Platform | Pointer Type |
   /// |-|-|
-  /// | macOS, iOS, watchOS, tvOS, visionOS | `UnsafePointer<mach_header64>` |
-  /// | Linux, FreeBSD, Android | `UnsafePointer<ElfW_Ehdr>` |
+  /// | macOS, iOS, watchOS, tvOS, visionOS | `UnsafePointer<mach_header_64>` |
+  /// | Linux, FreeBSD, Android | `UnsafePointer<ElfW(Ehdr)>` |
   /// | OpenBSD | `UnsafePointer<Elf_Ehdr>` |
   /// | Windows | `HMODULE` |
   ///


### PR DESCRIPTION
This PR fixes some typos/minor errors in our documentation.

Resolves #1118.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
