### PR TITLE
Improve type inference for exit test value captures.

### DIFF
--- a/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
@@ -36,6 +36,13 @@ extension TypeSyntaxProtocol {
       .contains(.keyword(.some))
   }
 
+  /// Whether or not this type is `any T` or a type derived from such a type.
+  var isAny: Bool {
+    tokens(viewMode: .fixedUp).lazy
+      .map(\.tokenKind)
+      .contains(.keyword(.any))
+  }
+
   /// Check whether or not this type is named with the specified name and
   /// module.
   ///

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -461,6 +461,10 @@ struct ConditionMacroTests {
             "Type of captured value 'a' is ambiguous",
           "#expectExitTest(processExitsWith: x) { [a = b] in }":
             "Type of captured value 'a' is ambiguous",
+          "#expectExitTest(processExitsWith: x) { [a = b as any T] in }":
+            "Type of captured value 'a' is ambiguous",
+          "#expectExitTest(processExitsWith: x) { [a = b as some T] in }":
+            "Type of captured value 'a' is ambiguous",
           "struct S<T> { func f() { #expectExitTest(processExitsWith: x) { [a] in } } }":
             "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within generic structure 'S'",
         ]


### PR DESCRIPTION
This PR refactors the (new) type inference logic for exit test capture lists to use a syntax visitor, which allows for the types of more complex expressions to be inferred.

For example, previously the type of this capture would not be inferred:

```swift
[x = try await f() as Int]
```

Even though the type (`Int`) is clearly present, because the `AsExprSyntax` is nested in an `AwaitExprSyntax` and then a `TryExprSyntax`.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
