### PR TITLE
Use a consistent definition for unreachable code in macro expansions.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -384,7 +384,7 @@ extension ExitTest {
     asTypeAt typeAddress: UnsafeRawPointer,
     withHintAt hintAddress: UnsafeRawPointer? = nil
   ) -> CBool {
-    fatalError("Unimplemented")
+    swt_unreachable()
   }
 }
 

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -13,6 +13,8 @@ public import SwiftSyntax
 import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 
+private import MachO.dyld
+
 #if !hasFeature(SymbolLinkageMarkers) && SWT_NO_LEGACY_TEST_DISCOVERY
 #error("Platform-specific misconfiguration: either SymbolLinkageMarkers or legacy test discovery is required to expand #expect(processExitsWith:)")
 #endif
@@ -454,9 +456,9 @@ extension ExitTestConditionMacro {
     // early if found.
     guard _diagnoseIssues(with: macro, body: bodyArgumentExpr, in: context) else {
       if Self.isThrowing {
-        return #"{ () async throws -> Testing.ExitTest.Result in Swift.fatalError("Unreachable") }()"#
+        return #"{ () async throws -> Testing.ExitTest.Result in \#(ExprSyntax.unreachable) }()"#
       } else {
-        return #"{ () async -> Testing.ExitTest.Result in Swift.fatalError("Unreachable") }()"#
+        return #"{ () async -> Testing.ExitTest.Result in \#(ExprSyntax.unreachable) }()"#
       }
     }
 

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -13,8 +13,6 @@ public import SwiftSyntax
 import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 
-private import MachO.dyld
-
 #if !hasFeature(SymbolLinkageMarkers) && SWT_NO_LEGACY_TEST_DISCOVERY
 #error("Platform-specific misconfiguration: either SymbolLinkageMarkers or legacy test discovery is required to expand #expect(processExitsWith:)")
 #endif

--- a/Sources/TestingMacros/ExitTestCapturedValueMacro.swift
+++ b/Sources/TestingMacros/ExitTestCapturedValueMacro.swift
@@ -50,7 +50,7 @@ public struct ExitTestBadCapturedValueMacro: ExpressionMacro, Sendable {
     // Diagnose that the type of 'expr' is invalid.
     context.diagnose(.capturedValueMustBeSendableAndCodable(expr, name: nameExpr))
 
-    return #"Swift.fatalError("Unsupported")"#
+    return .unreachable
   }
 }
 

--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -178,3 +178,15 @@ extension FunctionParameterSyntax {
     return baseType.trimmedDescription
   }
 }
+
+// MARK: -
+
+extension ExprSyntax {
+  /// An expression representing an unreachable code path.
+  ///
+  /// Use this expression when a macro will emit an error diagnostic but the
+  /// compiler still requires us to produce a valid expression.
+  static var unreachable: Self {
+    #"Swift.fatalError("Unreachable")"#
+  }
+}

--- a/Sources/TestingMacros/Support/ClosureCaptureListParsing.swift
+++ b/Sources/TestingMacros/Support/ClosureCaptureListParsing.swift
@@ -41,7 +41,7 @@ struct CapturedValueInfo {
 
   init(_ capture: ClosureCaptureSyntax, in context: some MacroExpansionContext) {
     self.capture = capture
-    self.expression = #"Swift.fatalError("Unsupported")"#
+    self.expression = .unreachable
     self.type = "Swift.Never"
 
     // We don't support capture specifiers at this time.

--- a/Sources/TestingMacros/TagMacro.swift
+++ b/Sources/TestingMacros/TagMacro.swift
@@ -22,7 +22,7 @@ public struct TagMacro: PeerMacro, AccessorMacro, Sendable {
   /// This property is used rather than simply returning the empty array in
   /// order to suppress a compiler diagnostic about not producing any accessors.
   private static var _fallbackAccessorDecls: [AccessorDeclSyntax] {
-    [#"get { Swift.fatalError("Unreachable") }"#]
+    [#"get { \#(ExprSyntax.unreachable) }"#]
   }
 
   public static func expansion(


### PR DESCRIPTION
This PR defines a single `ExprSyntax` instance we can use for unreachable code paths in macro expansions (where the compiler/swift-syntax requires us to produce an expression but we know we're going to emit an error anyway.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
