### PR TITLE
Work around a compiler regression affecting exit test value capturing.

### DIFF
--- a/Sources/TestingMacros/Support/ClosureCaptureListParsing.swift
+++ b/Sources/TestingMacros/Support/ClosureCaptureListParsing.swift
@@ -36,7 +36,11 @@ struct CapturedValueInfo {
 
   /// The expression to assign to the captured value with type-checking applied.
   var typeCheckedExpression: ExprSyntax {
+#if SWT_FIXED_154221449
     #"#__capturedValue(\#(expression.trimmed), \#(literal: name.trimmedDescription), (\#(type.trimmed)).self)"#
+#else
+    expression.trimmed
+#endif
   }
 
   init(_ capture: ClosureCaptureSyntax, in context: some MacroExpansionContext) {


### PR DESCRIPTION
This PR works around a compiler regression as of Swift acbdfef4f4d71b1 that causes our helper macro `#__capturedValue()` to be incorrectly expanded (wrong overload is selected.) The workaround is to disable our use of this macro, which does not affect correct functioning of our code but which does degrade the quality of our diagnostics.

Works around rdar://154221449.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
