### PR TITLE
Revert portion of workaround landed in #1139 which disabled the mandatory perf optimization pass

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -129,7 +129,7 @@ let package = Package(
         "_Testing_Foundation",
         "MemorySafeTestingTests",
       ],
-      swiftSettings: .packageSettings + .disableMandatoryOptimizationsSettings
+      swiftSettings: .packageSettings
     ),
 
     // Use a plain `.target` instead of a `.testTarget` to avoid the unnecessary
@@ -234,7 +234,7 @@ package.targets.append(contentsOf: [
       "Testing",
       "TestingMacros",
     ],
-    swiftSettings: .packageSettings + .disableMandatoryOptimizationsSettings
+    swiftSettings: .packageSettings
   )
 ])
 #endif
@@ -305,10 +305,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       // This setting is enabled in the package, but not in the toolchain build
       // (via CMake). Enabling it is dependent on acceptance of the @section
       // proposal via Swift Evolution.
-      //
-      // FIXME: Re-enable this once a CI blocker is resolved:
-      // https://github.com/swiftlang/swift-testing/issues/1138.
-//      .enableExperimentalFeature("SymbolLinkageMarkers"),
+      .enableExperimentalFeature("SymbolLinkageMarkers"),
 
       // This setting is no longer needed when building with a 6.2 or later
       // toolchain now that SE-0458 has been accepted and implemented, but it is
@@ -396,20 +393,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
 #else
     []
 #endif
-  }
-
-  /// Settings which disable Swift's mandatory optimizations pass.
-  ///
-  /// This is intended only to work around a build failure caused by a Swift
-  /// compiler regression which is expected to be resolved in
-  /// [swiftlang/swift#82034](https://github.com/swiftlang/swift/pull/82034).
-  ///
-  /// @Comment {
-  ///   - Bug: This should be removed once the CI issue is resolved.
-  ///     [swiftlang/swift-testin#1138](https://github.com/swiftlang/swift-testing/issues/1138).
-  /// }
-  static var disableMandatoryOptimizationsSettings: Self {
-    [.unsafeFlags(["-Xllvm", "-sil-disable-pass=mandatory-performance-optimizations"])]
   }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -305,7 +305,10 @@ extension Array where Element == PackageDescription.SwiftSetting {
       // This setting is enabled in the package, but not in the toolchain build
       // (via CMake). Enabling it is dependent on acceptance of the @section
       // proposal via Swift Evolution.
-      .enableExperimentalFeature("SymbolLinkageMarkers"),
+      //
+      // FIXME: Re-enable this once a CI blocker is resolved:
+      // https://github.com/swiftlang/swift-testing/issues/1138.
+//      .enableExperimentalFeature("SymbolLinkageMarkers"),
 
       // This setting is no longer needed when building with a 6.2 or later
       // toolchain now that SE-0458 has been accepted and implemented, but it is


### PR DESCRIPTION
This reverts most of the workaround I landed in #1139. A compiler fix in https://github.com/swiftlang/swift/pull/82034 has resolved the problem that necessitated it, and our macOS CI is using a new-enough toolchain which has that fix.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
