### PR TITLE
[6.2] Fix a miscompile when a test function has a raw identifier parameter label.

### DIFF
--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -160,6 +160,8 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
       for (label, parameter) in parametersWithLabels {
         if parameter.firstName.tokenKind == .wildcard {
           LabeledExprSyntax(expression: label)
+        } else if let rawIdentifier = parameter.firstName.rawIdentifier {
+          LabeledExprSyntax(label: "`\(rawIdentifier)`", expression: label)
         } else {
           LabeledExprSyntax(label: parameter.firstName.textWithoutBackticks, expression: label)
         }

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -315,6 +315,11 @@ struct MiscellaneousTests {
     let displayName = try #require(suite.displayName)
     #expect(displayName == "Suite With De Facto Display Name")
   }
+
+  @Test(arguments: [0])
+  func `Test with raw identifier and raw identifier parameter labels can compile`(`argument name` i: Int) {
+    #expect(i == 0)
+  }
 #endif
 
   @Test("Free functions are runnable")


### PR DESCRIPTION
- **Explanation**: Fixes parsing of function names to preserve backticks for raw parameter labels.
- **Scope**: `@Test` macro and parameterized tests.
- **Issues**: #1167
- **Original PRs**: #1168
- **Risk**: No obvious risk.
- **Testing**: Standard CI jobs should verify the fix.
- **Reviewers**: @briancroom @stmontgomery @hamishknight