### PR TITLE
Lower the "ambiguous display name" diagnostic to a warning for some names.

### DIFF
--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -144,8 +144,9 @@ struct AttributeInfo {
        let rawIdentifier = namedDecl.name.rawIdentifier {
       if let displayName, let displayNameArgument {
         context.diagnose(.declaration(namedDecl, hasExtraneousDisplayName: displayName, fromArgument: displayNameArgument, using: attribute))
+      } else {
+        displayName = StringLiteralExprSyntax(content: rawIdentifier)
       }
-      displayName = StringLiteralExprSyntax(content: rawIdentifier)
     }
 
     // Remove leading "Self." expressions from the arguments of the attribute.


### PR DESCRIPTION
This PR modifies the behaviour of this compile-time macro diagnostic:

> 🛑 "Attribute 'Test' specifies display name 'foo' for function with implicit display name 'bar'

If `bar` (in the above context) is _not_ considered a raw identifier by the language, we emit a warning instead of an error. This will allow us to adjust display-name-from-backticked-name inference (see #1174) without introducing a source-breaking change for a declaration such as:

```swift
@Test("subscript([K]) operator")
func `subscript`()
```

(The above is a real-world test function in our own package that would be impacted.)

Note that we don't actually have a code path that triggers this warning yet. #1174, if approved and merged, would introduce such a code path. Here's an example of what that would look like:

<img width="774" alt="Screenshot showing the warning diagnostic presented for func subscript()" src="https://github.com/user-attachments/assets/ee8ff23c-8cbb-4335-af36-24a54deac6cc" />

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
