### PR TITLE
Highlight parallel-by-default test run in case of XCTest migration

### DIFF
--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -84,6 +84,8 @@ concurrency safety:
 For more information about suites and how to declare and customize them, see
 <doc:OrganizingTests>.
 
+> Important: While XCTest test cases running sequentially by default, the test execution happens in parallel by default in Swift Testing. See the [Run tests sequentially](#Run-tests-sequentially) section in this document for further information. 
+
 ### Convert setup and teardown functions
 
 In XCTest, code can be scheduled to run before and after a test using the


### PR DESCRIPTION
Adding highlight and link to the XCTest Migration document to help understand and mitigate the parallel-by-default test execution.

### Motivation:

Handling https://github.com/swiftlang/swift-testing/issues/863

### Modifications:

Adding the Important aside, highlighting the parallel-by-default nature of Swift Testing test execution while migrating from XCTest.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
