### PR TITLE
[6.2] Remove redundant word from console output for test case started events in verbose mode

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -521,12 +521,10 @@ extension Event.HumanReadableOutputRecorder {
         break
       }
 
-      let status = verbosity > 0 ? " started" : ""
-
       return [
         Message(
           symbol: .default,
-          stringValue: "Test case passing \(arguments.count.counting("argument")) \(testCase.labeledArguments(includingQualifiedTypeNames: verbosity > 0)) to \(testName)\(status) started."
+          stringValue: "Test case passing \(arguments.count.counting("argument")) \(testCase.labeledArguments(includingQualifiedTypeNames: verbosity > 0)) to \(testName) started."
         )
       ]
 

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -114,6 +114,10 @@ struct EventRecorderTests {
     #expect(buffer.contains(#""Animal Crackers" (aka 'WrittenTests')"#))
     #expect(buffer.contains(#""Not A Lobster" (aka 'actuallyCrab()')"#))
     do {
+      let regex = try Regex(".* Test case passing 1 argument i → 0 \\(Swift.Int\\) to multitudeOcelot\\(i:\\) started.")
+      #expect(try buffer.split(whereSeparator: \.isNewline).compactMap(regex.wholeMatch(in:)).first != nil)
+    }
+    do {
       let regex = try Regex(".* Test case passing 1 argument i → 0 \\(Swift.Int\\) to multitudeOcelot\\(i:\\) passed after .*.")
       #expect(try buffer.split(whereSeparator: \.isNewline).compactMap(regex.wholeMatch(in:)).first != nil)
     }


### PR DESCRIPTION
- **Explanation**: This is a small fix for an oversight: the word "started" is printed twice at the end of the console message for `.testCaseStarted` events in verbose mode.
- **Scope**: Affects console output in verbose mode.
- **Issues**: n/a
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1180
- **Risk**: Low
- **Testing**: New unit test added
- **Reviewers**: @grynspan 
