### PR TITLE
FreeBSD: Gate GNU-only API

### DIFF
--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -136,7 +136,7 @@ func spawnExecutable(
             // standardized in POSIX.1-2024 (see https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_spawn_file_actions_adddup2.html
             // and https://www.austingroupbugs.net/view.php?id=411).
             _ = posix_spawn_file_actions_adddup2(fileActions, fd, fd)
-#if canImport(Glibc)
+#if canImport(Glibc) && !os(FreeBSD) && !os(OpenBSD)
             if _slowPath(glibcVersion.major < 2 || (glibcVersion.major == 2 && glibcVersion.minor < 29)) {
               // This system is using an older version of glibc that does not
               // implement FD_CLOEXEC clearing in posix_spawn_file_actions_adddup2(),

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -153,7 +153,7 @@ let swiftStandardLibraryVersion: String = {
   return "unknown"
 }()
 
-#if canImport(Glibc)
+#if canImport(Glibc) && !os(FreeBSD) && !os(OpenBSD)
 /// The (runtime, not compile-time) version of glibc in use on this system.
 ///
 /// This value is not part of the public interface of the testing library.


### PR DESCRIPTION
The FreeBSD builds are currently using the GlibC modulemap to import the C runtimes. FreeBSD does not have `gnu_get_libc_version` resulting in build failures.

The use of this API was introduced in https://github.com/swiftlang/swift-testing/pull/1147