### PR TITLE
Adopt Source Location-Aware Unique Name Generation for `@Test` Macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -103,7 +103,7 @@ let package = Package(
   ],
 
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0-latest"),
+    .package(path: "../swift-syntax"),
   ],
 
   targets: [

--- a/Sources/TestingMacros/Support/Additions/MacroExpansionContextAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/MacroExpansionContextAdditions.swift
@@ -85,7 +85,10 @@ extension MacroExpansionContext {
       prefix = "Z"
     }
 
-    return makeUniqueName("\(prefix)\(suffix)")
+    // Get the source location of the function declaration for better uniqueness
+    let sourceLocation = location(of: functionDecl)
+
+    return makeUniqueName("\(prefix)\(suffix)", sourceLocation: sourceLocation)
   }
 }
 

--- a/Tests/TestingMacrosTests/UniqueIdentifierTests.swift
+++ b/Tests/TestingMacrosTests/UniqueIdentifierTests.swift
@@ -81,4 +81,17 @@ struct UniqueIdentifierTests {
     let uniqueName2 = try makeUniqueName("func f() { def() }")
     #expect(uniqueName1 == uniqueName2)
   }
+
+
+
+  @Test("Duplicate function names generate different identifiers")
+  func duplicateFunctionNames() throws {
+    // Test that calling makeUniqueName twice with the same base name
+    // generates different identifiers
+    let context = BasicMacroExpansionContext()
+    let name1 = context.makeUniqueName("test")
+    let name2 = context.makeUniqueName("test")
+    
+    #expect(name1.text != name2.text)
+  }
 }


### PR DESCRIPTION
This PR updates the `swift-testing` library to leverage the new source location-aware `makeUniqueName` API from `swift-syntax`. This ensures that `@Test` functions with the same name at different locations generate unique identifiers, preventing compiler crashes and redeclaration errors.

#### Motivation
With the previous approach, duplicate `@Test` function names could cause symbol conflicts and compiler crashes. By incorporating source location into the unique name, we ensure robust test discovery and execution.

#### Changes
- Updated the `makeUniqueName(thunking:)` helper to use the new source location-aware API.
- Added a test to verify that duplicate function names generate different identifiers.
- (For development) Temporarily updated `Package.swift` to use the local `swift-syntax` package.

#### Impact
- Fixes crashes and redeclaration errors caused by duplicate `@Test` function names.
- Ensures reliable test macro expansion and execution.

Resolves swiftlang/swift#82631