### PR TITLE
Add a cross-import overlay with CoreImage to allow attaching `CIImage`s.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,6 +90,7 @@ let package = Package(
         targets: [
           "_Testing_AppKit",
           "_Testing_CoreGraphics",
+          "_Testing_CoreImage",
         ]
       )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -127,6 +127,7 @@ let package = Package(
         "Testing",
         "_Testing_AppKit",
         "_Testing_CoreGraphics",
+        "_Testing_CoreImage",
         "_Testing_Foundation",
         "MemorySafeTestingTests",
       ],
@@ -207,6 +208,15 @@ let package = Package(
       ],
       path: "Sources/Overlays/_Testing_CoreGraphics",
       swiftSettings: .packageSettings + .enableLibraryEvolution()
+    ),
+    .target(
+      name: "_Testing_CoreImage",
+      dependencies: [
+        "Testing",
+        "_Testing_CoreGraphics",
+      ],
+      path: "Sources/Overlays/_Testing_CoreImage",
+      swiftSettings: .packageSettings
     ),
     .target(
       name: "_Testing_Foundation",

--- a/Package.swift
+++ b/Package.swift
@@ -216,7 +216,7 @@ let package = Package(
         "_Testing_CoreGraphics",
       ],
       path: "Sources/Overlays/_Testing_CoreImage",
-      swiftSettings: .packageSettings
+      swiftSettings: .packageSettings + .enableLibraryEvolution()
     ),
     .target(
       name: "_Testing_Foundation",

--- a/Sources/Overlays/_Testing_AppKit/ReexportTesting.swift
+++ b/Sources/Overlays/_Testing_AppKit/ReexportTesting.swift
@@ -8,5 +8,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_exported public import Testing
-@_exported public import _Testing_CoreGraphics
+@_exported @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import Testing
+@_exported @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import _Testing_CoreGraphics

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
@@ -24,6 +24,7 @@ private import ImageIO
 /// be attached to a test:
 ///
 /// - [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage)
+/// - [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage)
 /// - [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage)
 ///   (macOS)
 ///

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/Attachment+AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/Attachment+AttachableAsCGImage.swift
@@ -36,6 +36,7 @@ extension Attachment {
   /// ``AttachableAsCGImage`` protocol and can be attached to a test:
   ///
   /// - [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage)
+  /// - [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage)
   /// - [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage)
   ///   (macOS)
   ///
@@ -82,6 +83,7 @@ extension Attachment {
   /// ``AttachableAsCGImage`` protocol and can be attached to a test:
   ///
   /// - [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage)
+  /// - [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage)
   /// - [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage)
   ///   (macOS)
   ///

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/_AttachableImageWrapper.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/_AttachableImageWrapper.swift
@@ -47,6 +47,7 @@ import UniformTypeIdentifiers
 /// to the ``AttachableAsCGImage`` protocol and can be attached to a test:
 ///
 /// - [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage)
+/// - [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage)
 /// - [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage)
 ///   (macOS)
 @_spi(Experimental)

--- a/Sources/Overlays/_Testing_CoreImage/Attachments/CIImage+AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreImage/Attachments/CIImage+AttachableAsCGImage.swift
@@ -1,0 +1,31 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if SWT_TARGET_OS_APPLE && canImport(CoreImage)
+public import CoreImage
+@_spi(Experimental) public import _Testing_CoreGraphics
+
+@_spi(Experimental)
+extension CIImage: AttachableAsCGImage {
+  public var attachableCGImage: CGImage {
+    get throws {
+      guard let result = CIContext().createCGImage(self, from: extent) else {
+        throw ImageAttachmentError.couldNotCreateCGImage
+      }
+      return result
+    }
+  }
+
+  public func _makeCopyForAttachment() -> Self {
+    // CIImage is documented as thread-safe, but does not conform to Sendable.
+    self
+  }
+}
+#endif

--- a/Sources/Overlays/_Testing_CoreImage/Attachments/CIImage+AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreImage/Attachments/CIImage+AttachableAsCGImage.swift
@@ -25,9 +25,9 @@ extension CIImage: AttachableAsCGImage {
 
   public func _makeCopyForAttachment() -> Self {
     // CIImage is documented as thread-safe, but does not conform to Sendable.
-    // It conforms to NSCopying and does have mutable state, so we still want to
-    // make a (shallow) copy of it.
-    return self.copy() as? Self ?? self
+    // It conforms to NSCopying but does not actually copy itself, so there's no
+    // point in calling copy().
+    self
   }
 }
 #endif

--- a/Sources/Overlays/_Testing_CoreImage/Attachments/CIImage+AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreImage/Attachments/CIImage+AttachableAsCGImage.swift
@@ -25,7 +25,9 @@ extension CIImage: AttachableAsCGImage {
 
   public func _makeCopyForAttachment() -> Self {
     // CIImage is documented as thread-safe, but does not conform to Sendable.
-    self
+    // It conforms to NSCopying and does have mutable state, so we still want to
+    // make a (shallow) copy of it.
+    return self.copy() as? Self ?? self
   }
 }
 #endif

--- a/Sources/Overlays/_Testing_CoreImage/ReexportTesting.swift
+++ b/Sources/Overlays/_Testing_CoreImage/ReexportTesting.swift
@@ -8,4 +8,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_exported public import Testing
+@_exported @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import Testing
+@_exported @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import _Testing_CoreGraphics

--- a/Sources/Overlays/_Testing_CoreImage/ReexportTesting.swift
+++ b/Sources/Overlays/_Testing_CoreImage/ReexportTesting.swift
@@ -1,0 +1,11 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@_exported public import Testing

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -22,6 +22,10 @@ import _Testing_Foundation
 import CoreGraphics
 @_spi(Experimental) import _Testing_CoreGraphics
 #endif
+#if canImport(CoreImage)
+import CoreImage
+@_spi(Experimental) import _Testing_CoreImage
+#endif
 #if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers
 #endif
@@ -578,6 +582,18 @@ extension AttachmentTests {
       await #expect(processExitsWith: .failure) {
         let attachment = Attachment(try Self.cgImage.get(), named: "diamond", as: .mp3)
         try attachment.attachableValue.withUnsafeBytes(for: attachment) { _ in }
+      }
+    }
+#endif
+
+#if canImport(CoreImage)
+    @available(_uttypesAPI, *)
+    @Test func attachCIImage() throws {
+      let image = CIImage(cgImage: try Self.cgImage.get())
+      let attachment = Attachment(image, named: "diamond.jpg")
+      #expect(attachment.attachableValue === image)
+      try attachment.attachableValue.withUnsafeBytes(for: attachment) { buffer in
+        #expect(buffer.count > 32)
       }
     }
 #endif


### PR DESCRIPTION
This PR adds on to the Core Graphics cross-import overlay added in #827 to allow attaching instances of `CIImage` to a test.

> [!NOTE]
> Image attachments remain an experimental feature.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
