### PR TITLE
Fixes to the AppKit/`NSImage` overlay.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -198,7 +198,7 @@ let package = Package(
         "_Testing_CoreGraphics",
       ],
       path: "Sources/Overlays/_Testing_AppKit",
-      swiftSettings: .packageSettings
+      swiftSettings: .packageSettings + .enableLibraryEvolution()
     ),
     .target(
       name: "_Testing_CoreGraphics",

--- a/Sources/Overlays/_Testing_AppKit/Attachments/NSImage+AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_AppKit/Attachments/NSImage+AttachableAsCGImage.swift
@@ -10,7 +10,7 @@
 
 #if SWT_TARGET_OS_APPLE && canImport(AppKit)
 public import AppKit
-@_spi(ForSwiftTestingOnly) @_spi(Experimental) public import _Testing_CoreGraphics
+@_spi(Experimental) public import _Testing_CoreGraphics
 
 @_spi(Experimental)
 extension NSImage: AttachableAsCGImage {


### PR DESCRIPTION
The PR (#869) that just added the AppKit overlay for `NSImage` was a bit stale. This PR corrects a couple of bugs that snuck in due to its age and the resulting bit rot.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
