### PR TITLE
Apply the 'traitRelated' tag to more tests and suites

### DIFF
--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -452,6 +452,7 @@ struct TestDeclarationMacroTests {
   }
 
   @Test("Valid tag expressions are allowed",
+    .tags(.traitRelated),
     arguments: [
       #"@Test(.tags(.f)) func f() {}"#,
       #"@Test(Tag.List.tags(.f)) func f() {}"#,
@@ -472,6 +473,7 @@ struct TestDeclarationMacroTests {
   }
 
   @Test("Invalid tag expressions are detected",
+    .tags(.traitRelated),
     arguments: [
       "f()", ".f()", "loose",
       "WrongType.tag", "WrongType.f()",
@@ -490,6 +492,7 @@ struct TestDeclarationMacroTests {
   }
 
   @Test("Valid bug identifiers are allowed",
+    .tags(.traitRelated),
     arguments: [
       #"@Test(.bug(id: 12345)) func f() {}"#,
       #"@Test(.bug(id: "12345")) func f() {}"#,
@@ -512,6 +515,7 @@ struct TestDeclarationMacroTests {
   }
 
   @Test("Invalid bug URLs are detected",
+    .tags(.traitRelated),
     arguments: [
       "mailto: a@example.com", "example.com",
     ]

--- a/Tests/TestingMacrosTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingMacrosTests/TestSupport/TestingAdditions.swift
@@ -1,0 +1,16 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+import Testing
+
+extension Tag {
+  /// A tag indicating that a test is related to a trait.
+  @Tag static var traitRelated: Self
+}

--- a/Tests/TestingTests/PlanTests.swift
+++ b/Tests/TestingTests/PlanTests.swift
@@ -369,7 +369,7 @@ struct PlanTests {
     #expect(!planTests.contains(testC))
   }
 
-  @Test("Recursive trait application")
+  @Test("Recursive trait application", .tags(.traitRelated))
   func recursiveTraitApplication() async throws {
     let outerTestType = try #require(await test(for: OuterTest.self))
     // Intentionally omitting intermediate tests here...
@@ -387,7 +387,7 @@ struct PlanTests {
     #expect(testWithTraitAdded.traits.contains { $0 is DummyRecursiveTrait })
   }
 
-  @Test("Relative order of recursively applied traits")
+  @Test("Relative order of recursively applied traits", .tags(.traitRelated))
   func recursiveTraitOrder() async throws {
     let testSuiteA = try #require(await test(for: RelativeTraitOrderingTests.A.self))
     let testSuiteB = try #require(await test(for: RelativeTraitOrderingTests.A.B.self))

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -133,7 +133,7 @@ struct SwiftPMTests {
     #expect(planTests.contains(test2))
   }
 
-  @Test(".hidden trait")
+  @Test(".hidden trait", .tags(.traitRelated))
   func hidden() async throws {
     let configuration = try configurationForEntryPoint(withArguments: ["PATH"])
     let test1 = Test(name: "hello") {}

--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -98,7 +98,7 @@ struct Test_SnapshotTests {
   private static let bug: Bug = Bug.bug(id: 12345, "Lorem ipsum")
 
   @available(_clockAPI, *)
-  @Test("timeLimit property", _timeLimitIfAvailable(minutes: 999_999_999))
+  @Test("timeLimit property", .tags(.traitRelated), _timeLimitIfAvailable(minutes: 999_999_999))
   func timeLimit() async throws {
     let test = try #require(Test.current)
     let snapshot = Test.Snapshot(snapshotting: test)

--- a/Tests/TestingTests/Traits/IssueHandlingTraitTests.swift
+++ b/Tests/TestingTests/Traits/IssueHandlingTraitTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-@Suite("IssueHandlingTrait Tests")
+@Suite("IssueHandlingTrait Tests", .tags(.traitRelated))
 struct IssueHandlingTraitTests {
   @Test("Transforming an issue by appending a comment")
   func addComment() async throws {

--- a/Tests/TestingTests/Traits/TestScopingTraitTests.swift
+++ b/Tests/TestingTests/Traits/TestScopingTraitTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-@Suite("TestScoping-conforming Trait Tests")
+@Suite("TestScoping-conforming Trait Tests", .tags(.traitRelated))
 struct TestScopingTraitTests {
   @Test("Execute code before and after a non-parameterized test.")
   func executeCodeBeforeAndAfterNonParameterizedTest() async {


### PR DESCRIPTION
This is a small, test-only enhancement which applies the `.traitRelated` tag to more tests and suites which are related to specific traits or the trait subsystem.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
