### PR TITLE
Adopt `SuspendingClock.systemEpoch`.

### DIFF
--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -55,7 +55,7 @@ struct TimeValue: Sendable {
   @available(_clockAPI, *)
   init(_ instant: SuspendingClock.Instant) {
 #if compiler(>=6.2)
-    self.init(SuspendingClock.systemEpoch.duration(to: instant))
+    self.init(SuspendingClock().systemEpoch.duration(to: instant))
 #else
     self.init(unsafeBitCast(instant, to: Duration.self))
 #endif
@@ -115,7 +115,7 @@ extension Duration {
 extension SuspendingClock.Instant {
   init(_ timeValue: TimeValue) {
 #if compiler(>=6.2)
-    self = SuspendingClock.systemEpoch.advanced(by: Duration(timeValue))
+    self = SuspendingClock().systemEpoch.advanced(by: Duration(timeValue))
 #else
     self = unsafeBitCast(Duration(timeValue), to: SuspendingClock.Instant.self)
 #endif


### PR DESCRIPTION
This PR adopts the new `systemEpoch` API added with [SE-0473](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0473-clock-epochs.md).

This API is back-deployed, so we don't need availability annotations on Darwin. It is not available with the 6.1 toolchain though, so the old `unsafeBitCast()` calls remain if building from source with a 6.1 toolchain.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
