### PR TITLE
[6.2] Adopt `SuspendingClock.systemEpoch`.

### DIFF
--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -54,7 +54,11 @@ struct TimeValue: Sendable {
 
   @available(_clockAPI, *)
   init(_ instant: SuspendingClock.Instant) {
+#if compiler(>=6.2)
+    self.init(SuspendingClock().systemEpoch.duration(to: instant))
+#else
     self.init(unsafeBitCast(instant, to: Duration.self))
+#endif
   }
 }
 
@@ -110,7 +114,11 @@ extension Duration {
 @available(_clockAPI, *)
 extension SuspendingClock.Instant {
   init(_ timeValue: TimeValue) {
+#if compiler(>=6.2)
+    self = SuspendingClock().systemEpoch.advanced(by: Duration(timeValue))
+#else
     self = unsafeBitCast(Duration(timeValue), to: SuspendingClock.Instant.self)
+#endif
   }
 }
 


### PR DESCRIPTION
- **Explanation**: Adopts the new `systemEpoch` constant on `SuspendingClock` so that we don't have to use `unsafeBitCast()` to get an absolute value for a test timestamp.
- **Scope**: Test timing logic.
- **Issues**: N/A
- **Original PRs**: #1202
- **Risk**: Low: the implementation of `systemEpoch` is equivalent to ours.
- **Testing**: Existing CI/testing is sufficient.
- **Reviewers**: @stmontgomery @briancroom