### PR TITLE
[6.2] Disallow the `@Test` attribute on operator declarations.

### DIFF
--- a/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/FunctionDeclSyntaxAdditions.swift
@@ -34,6 +34,16 @@ extension FunctionDeclSyntax {
       .contains(.keyword(.nonisolated))
   }
 
+  /// Whether or not this function declares an operator.
+  var isOperator: Bool {
+    switch name.tokenKind {
+    case .binaryOperator, .prefixOperator, .postfixOperator:
+      true
+    default:
+      false
+    }
+  }
+
   /// The name of this function including parentheses, parameter labels, and
   /// colons.
   var completeName: DeclReferenceExprSyntax {

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -93,7 +93,11 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
     let result: (value: String, article: String)
     switch node.kind {
     case .functionDecl:
-      result = ("function", "a")
+      if node.cast(FunctionDeclSyntax.self).isOperator {
+        result = ("operator", "an")
+      } else {
+        result = ("function", "a")
+      }
     case .classDecl:
       result = ("class", "a")
     case .structDecl:

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -61,7 +61,7 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
     }
 
     // The @Test attribute is only supported on function declarations.
-    guard let function = declaration.as(FunctionDeclSyntax.self) else {
+    guard let function = declaration.as(FunctionDeclSyntax.self), !function.isOperator else {
       diagnostics.append(.attributeNotSupported(testAttribute, on: declaration))
       return false
     }

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -67,6 +67,8 @@ struct TestDeclarationMacroTests {
         "Attribute 'Test' cannot be applied to a structure",
       "@Test enum E {}":
         "Attribute 'Test' cannot be applied to an enumeration",
+      "@Test func +() {}":
+        "Attribute 'Test' cannot be applied to an operator",
 
       // Availability
       "@available(*, unavailable) @Suite struct S {}":


### PR DESCRIPTION
- **Explanation**: Block `@Test` on operator declarations, which doesn't work correctly and was never supported.
- **Scope**: Attempting to declare `@Test func +()`.
- **Issues**: #1204
- **Original PRs**: #1205
- **Risk**: Low (this was never supported)
- **Testing**: New test case added.
- **Reviewers**: @stmontgomery @briancroom