### PR TITLE
Revert "Work around a compiler regression affecting exit test value capturing. (#1171)"

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1175,7 +1175,6 @@ public func __checkClosureCall(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
-#if SWT_FIXED_154221449
 @_spi(Experimental)
 public func __checkClosureCall<each T>(
   identifiedBy exitTestID: (UInt64, UInt64, UInt64, UInt64),
@@ -1200,32 +1199,6 @@ public func __checkClosureCall<each T>(
     sourceLocation: sourceLocation
   )
 }
-#else
-@_spi(Experimental)
-public func __checkClosureCall<each T>(
-  identifiedBy exitTestID: (UInt64, UInt64, UInt64, UInt64),
-  encodingCapturedValues capturedValues: repeat each T,
-  processExitsWith expectedExitCondition: ExitTest.Condition,
-  observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
-  performing _: @convention(c) () -> Void,
-  expression: __Expression,
-  comments: @autoclosure () -> [Comment],
-  isRequired: Bool,
-  isolation: isolated (any Actor)? = #isolation,
-  sourceLocation: SourceLocation
-) async -> Result<ExitTest.Result?, any Error> where repeat each T: Codable & Sendable {
-  await callExitTest(
-    identifiedBy: exitTestID,
-    encodingCapturedValues: Array(repeat each capturedValues),
-    processExitsWith: expectedExitCondition,
-    observing: observedValues,
-    expression: expression,
-    comments: comments(),
-    isRequired: isRequired,
-    sourceLocation: sourceLocation
-  )
-}
-#endif
 #endif
 
 // MARK: -

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -98,20 +98,7 @@ extension ConditionMacro {
     if let trailingClosureIndex {
       // Assume that the comment, if present is the last argument in the
       // argument list prior to the trailing closure that has no label.
-#if SWT_FIXED_154221449
       commentIndex = macroArguments[..<trailingClosureIndex].lastIndex { $0.label == nil }
-#else
-      commentIndex = macroArguments[..<trailingClosureIndex].lastIndex { argument in
-        guard argument.label == nil else {
-          return false
-        }
-        if let expr = argument.expression.as(MacroExpansionExprSyntax.self),
-           expr.macroName.tokenKind == .identifier("__capturedValue") {
-          return false
-        }
-        return true
-      }
-#endif
     } else if macroArguments.count > 1 {
       // If there is no trailing closure argument and there is more than one
       // argument, then the comment is the last argument with no label (and also
@@ -560,7 +547,6 @@ extension ExitTestConditionMacro {
     var leadingArguments = [
       Argument(label: "identifiedBy", expression: idExpr),
     ]
-#if SWT_FIXED_154221449
     if !capturedValues.isEmpty {
       leadingArguments.append(
         Argument(
@@ -573,19 +559,6 @@ extension ExitTestConditionMacro {
         )
       )
     }
-#else
-    if let firstCapturedValue = capturedValues.first {
-      leadingArguments.append(
-        Argument(
-          label: "encodingCapturedValues",
-          expression: firstCapturedValue.typeCheckedExpression
-        )
-      )
-      leadingArguments += capturedValues.dropFirst()
-        .map(\.typeCheckedExpression)
-        .map { Argument(expression: $0) }
-    }
-#endif
     arguments = leadingArguments + arguments
 
     // Replace the exit test body (as an argument to the macro) with a stub

--- a/Sources/TestingMacros/Support/ClosureCaptureListParsing.swift
+++ b/Sources/TestingMacros/Support/ClosureCaptureListParsing.swift
@@ -36,7 +36,7 @@ struct CapturedValueInfo {
 
   /// The expression to assign to the captured value with type-checking applied.
   var typeCheckedExpression: ExprSyntax {
-    #"#__capturedValue(\#(expression.trimmed), \#(literal: name.trimmedDescription), \#(type.trimmed).self)"#
+    #"#__capturedValue(\#(expression.trimmed), \#(literal: name.trimmedDescription), (\#(type.trimmed)).self)"#
   }
 
   init(_ capture: ClosureCaptureSyntax, in context: some MacroExpansionContext) {


### PR DESCRIPTION
This reverts commit 77de51d550fe406c15af4eb5ac3834580afa3eaf.