### PR TITLE
Clarify the number of supported argument collections in article which discusses combinatoric parameterized testing

### DIFF
--- a/Sources/Testing/Testing.docc/ParameterizedTesting.md
+++ b/Sources/Testing/Testing.docc/ParameterizedTesting.md
@@ -146,11 +146,11 @@ func makeLargeOrder(of food: Food, count: Int) async throws {
 ```
 
 Elements from the first collection are passed as the first argument to the test
-function, elements from the second collection are passed as the second argument,
-and so forth.
+function, and elements from the second collection are passed as the second
+argument.
 
 Assuming there are five cases in the `Food` enumeration, this test function
-will, when run, be invoked 500 times (5 x 100) with every possible combination
+will, when run, be invoked 500 times (5 × 100) with every possible combination
 of food and order size. These combinations are referred to as the collections'
 Cartesian product.
 


### PR DESCRIPTION
This is a small adjustment to the documentation article [Implementing parameterized tests](https://swiftpackageindex.com/swiftlang/swift-testing/main/documentation/testing/parameterizedtesting), in the section [Test with more than one collection](https://swiftpackageindex.com/swiftlang/swift-testing/main/documentation/testing/parameterizedtesting#Test-with-more-than-one-collection). It currently has a sentence which ends:

> …, elements from the second collection are passed as the second argument, **and so forth.**

The "and so forth" has caused some confusion since it implies that you can pass more than two argument collections, but in reality only two are supported currently. Eventually this could potentially be expanded with further improvements to the testing library, but that is tracked separately and the docs should reflect its current capabilities.

Fixes rdar://154647425

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
