### PR TITLE
Add isFailure to ABI.EncodedIssue

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -31,7 +31,7 @@ extension ABI {
     
     /// If the issue is a failing issue.
     ///
-    /// - Warning: isFailure is not yet part of the JSON schema.
+    /// - Warning: Non-failing issues are not yet part of the JSON schema.
     var _isFailure: Bool
 
     /// Whether or not this issue is known to occur.


### PR DESCRIPTION
This adds `isFailure` to `ABI.EncodedIssue`

### Motivation:

Clients need to know if an issue is failing so that they know how to handle it.

### Modifications:

This adds `isFailure` to `ABI.EncodedIssue`

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
