### PR TITLE
Reset the working directory of child processes we spawn on Windows.

### DIFF
--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -297,9 +297,9 @@ func spawnExecutable(
       //
       // SEE: https://devblogs.microsoft.com/oldnewthing/20101109-00/?p=12323
       let workingDirectoryPath: UnsafeMutablePointer<wchar_t>? = {
-        let systemDrive = Environment.variable(named: "SYSTEMDRIVE") ?? "C:"
+        var systemDrive = Environment.variable(named: "SYSTEMDRIVE") ?? "C:"
         if systemDrive.last == ":" {
-          return #"\#(systemDrive)\"#
+          systemDrive = #"\#(systemDrive)\"#
         }
         return systemDrive.withCString(encodedAs: UTF16.self) { _wcsdup($0) }
       }()

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -741,11 +741,11 @@ let rootDirectoryPath: String = {
         result = String.decodeCString(buffer.baseAddress!, as: UTF16.self)?.result
       }
     }
-
-    // If we weren't able to get a path, fall back to "C:\" on the assumption
-    // that it's the common case and most likely correct.
-    return result ?? #"C:\"#
   }
+
+  // If we weren't able to get a path, fall back to "C:\" on the assumption that
+  // it's the common case and most likely correct.
+  return result ?? #"C:\"#
 #else
   return "/"
 #endif

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -213,7 +213,7 @@ struct FileHandleTests {
       #expect(Environment.setVariable("Q:", named: "SYSTEMDRIVE"))
       #expect(rootDirectoryPath == #"Q:\"#)
 
-      #expect(Environment.setVariable("Q:\abc123", named: "SYSTEMDRIVE"))
+      #expect(Environment.setVariable(#"Q:\abc123"#, named: "SYSTEMDRIVE"))
       #expect(rootDirectoryPath == #"Q:\abc123\"#)
     }
 #endif

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -201,6 +201,26 @@ struct FileHandleTests {
 #endif
   }
 #endif
+
+  @Test("Root directory path is correct")
+  func rootDirectoryPathIsCorrect() async {
+#if os(Windows)
+#if !SWT_NO_EXIT_TESTS
+    await #expect(processExitsWith: .success) {
+      #expect(Environment.setVariable(nil, named: "SYSTEMDRIVE"))
+      #expect(rootDirectoryPath == #"C:\"#)
+
+      #expect(Environment.setVariable("Q:", named: "SYSTEMDRIVE"))
+      #expect(rootDirectoryPath == #"Q:\"#)
+
+      #expect(Environment.setVariable("Q:\abc123", named: "SYSTEMDRIVE"))
+      #expect(rootDirectoryPath == #"Q:\abc123\"#)
+    }
+#endif
+#else
+    #expect(rootDirectoryPath == "/")
+#endif
+  }
 }
 
 // MARK: - Fixtures

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -203,24 +203,11 @@ struct FileHandleTests {
 #endif
 
   @Test("Root directory path is correct")
-  func rootDirectoryPathIsCorrect() async {
+  func rootDirectoryPathIsCorrect() throws {
 #if os(Windows)
-#if !SWT_NO_EXIT_TESTS
-    await #expect(processExitsWith: .success) {
-      #expect(Environment.setVariable(nil, named: "SYSTEMDRIVE"))
-      #expect(rootDirectoryPath == #"C:\"#)
+    if let systemDrive = Environment.variable(named: "SYSTEMDRIVE") {
+      #expect(rootDirectoryPath.starts(with: systemDrive))
     }
-
-    await #expect(processExitsWith: .success) {
-      #expect(Environment.setVariable("Q:", named: "SYSTEMDRIVE"))
-      #expect(rootDirectoryPath == #"Q:\"#)
-    }
-
-    await #expect(processExitsWith: .success) {
-      #expect(Environment.setVariable(#"Q:\abc123"#, named: "SYSTEMDRIVE"))
-      #expect(rootDirectoryPath == #"Q:\abc123\"#)
-    }
-#endif
 #else
     #expect(rootDirectoryPath == "/")
 #endif

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -209,10 +209,14 @@ struct FileHandleTests {
     await #expect(processExitsWith: .success) {
       #expect(Environment.setVariable(nil, named: "SYSTEMDRIVE"))
       #expect(rootDirectoryPath == #"C:\"#)
+    }
 
+    await #expect(processExitsWith: .success) {
       #expect(Environment.setVariable("Q:", named: "SYSTEMDRIVE"))
       #expect(rootDirectoryPath == #"Q:\"#)
+    }
 
+    await #expect(processExitsWith: .success) {
       #expect(Environment.setVariable(#"Q:\abc123"#, named: "SYSTEMDRIVE"))
       #expect(rootDirectoryPath == #"Q:\abc123\"#)
     }


### PR DESCRIPTION
This PR modifies the Windows implementation of `spawnProcess()` so that it sets the working directory of the new process to "C:\" (or thereabouts). This prevents a race condition on Windows because that system won't let you delete a directory if it's the working directory of any process. See [The Old New Thing](https://devblogs.microsoft.com/oldnewthing/20101109-00/?p=12323) for a very on-the-nose blog post.

Note that we do not specify the value of the working directory in an exit test body. A test should generally not rely on it anyway because it is global state and any thread could change its value at any time.

I haven't written a unit test for this change because it's unclear what I could write that would be easily verifiable, and because I don't know what state I might perturb outside such a test by calling `SetCurrentDirectory()`.

Resolves #1209.
(This is a speculative fix.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
