### PR TITLE
Bump the required compiler version for `systemEpoch` to 6.3.

### DIFF
--- a/Sources/Testing/Events/TimeValue.swift
+++ b/Sources/Testing/Events/TimeValue.swift
@@ -54,7 +54,7 @@ struct TimeValue: Sendable {
 
   @available(_clockAPI, *)
   init(_ instant: SuspendingClock.Instant) {
-#if compiler(>=6.2)
+#if compiler(>=6.3)
     self.init(SuspendingClock().systemEpoch.duration(to: instant))
 #else
     self.init(unsafeBitCast(instant, to: Duration.self))
@@ -114,7 +114,7 @@ extension Duration {
 @available(_clockAPI, *)
 extension SuspendingClock.Instant {
   init(_ timeValue: TimeValue) {
-#if compiler(>=6.2)
+#if compiler(>=6.3)
     self = SuspendingClock().systemEpoch.advanced(by: Duration(timeValue))
 #else
     self = unsafeBitCast(Duration(timeValue), to: SuspendingClock.Instant.self)


### PR DESCRIPTION
There are some workflows including Xcode 26 betas where the compiler version is 6.2 but `systemEpoch` isn't available yet, so bump the requirement for it to 6.3. This is temporary and we can delete the check outright after 6.2 ships.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
