### PR TITLE
Add a cross-import overlay with UIKit to allow attaching `UIImage`s.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -91,6 +91,7 @@ let package = Package(
           "_Testing_AppKit",
           "_Testing_CoreGraphics",
           "_Testing_CoreImage",
+          "_Testing_UIKit",
         ]
       )
     ]
@@ -140,6 +141,7 @@ let package = Package(
         "_Testing_CoreGraphics",
         "_Testing_CoreImage",
         "_Testing_Foundation",
+        "_Testing_UIKit",
         "MemorySafeTestingTests",
       ],
       swiftSettings: .packageSettings
@@ -240,6 +242,16 @@ let package = Package(
       // platforms, and since this target's module publicly imports Foundation,
       // it can only enable Library Evolution itself on those platforms.
       swiftSettings: .packageSettings + .enableLibraryEvolution(.whenApple())
+    ),
+    .target(
+      name: "_Testing_UIKit",
+      dependencies: [
+        "Testing",
+        "_Testing_CoreGraphics",
+        "_Testing_CoreImage",
+      ],
+      path: "Sources/Overlays/_Testing_UIKit",
+      swiftSettings: .packageSettings + .enableLibraryEvolution()
     ),
 
     // Utility targets: These are utilities intended for use when developing

--- a/Sources/Overlays/_Testing_UIKit/Attachments/UIImage+AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_UIKit/Attachments/UIImage+AttachableAsCGImage.swift
@@ -1,0 +1,50 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if SWT_TARGET_OS_APPLE && canImport(UIKit)
+public import UIKit
+@_spi(Experimental) public import _Testing_CoreGraphics
+@_spi(Experimental) private import _Testing_CoreImage
+
+private import ImageIO
+
+@_spi(Experimental)
+extension UIImage: AttachableAsCGImage {
+  public var attachableCGImage: CGImage {
+    get throws {
+      if let cgImage {
+        return cgImage
+      } else if let ciImage {
+        return try ciImage.attachableCGImage
+      }
+      throw ImageAttachmentError.couldNotCreateCGImage
+    }
+  }
+
+  public var _attachmentOrientation: UInt32 {
+    let result: CGImagePropertyOrientation = switch imageOrientation {
+    case .up: .up
+    case .down: .down
+    case .left: .left
+    case .right: .right
+    case .upMirrored: .upMirrored
+    case .downMirrored: .downMirrored
+    case .leftMirrored: .leftMirrored
+    case .rightMirrored: .rightMirrored
+    @unknown default: .up
+    }
+    return result.rawValue
+  }
+
+  public var _attachmentScaleFactor: CGFloat {
+    scale
+  }
+}
+#endif

--- a/Sources/Overlays/_Testing_UIKit/ReexportTesting.swift
+++ b/Sources/Overlays/_Testing_UIKit/ReexportTesting.swift
@@ -1,0 +1,12 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@_exported @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import Testing
+@_exported @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import _Testing_CoreGraphics

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -26,6 +26,10 @@ import CoreGraphics
 import CoreImage
 @_spi(Experimental) import _Testing_CoreImage
 #endif
+#if canImport(UIKit)
+import UIKit
+@_spi(Experimental) import _Testing_UIKit
+#endif
 #if canImport(UniformTypeIdentifiers)
 import UniformTypeIdentifiers
 #endif
@@ -673,6 +677,18 @@ extension AttachmentTests {
       #expect(attachment.attachableValue.size == image.size) // NSImage makes a copy
       let firstRep = try #require(attachment.attachableValue.representations.first)
       #expect(!(firstRep is MyImageRep<Int>))
+      try attachment.attachableValue.withUnsafeBytes(for: attachment) { buffer in
+        #expect(buffer.count > 32)
+      }
+    }
+#endif
+
+#if canImport(UIKit)
+    @available(_uttypesAPI, *)
+    @Test func attachUIImage() throws {
+      let image = UIImage(cgImage: try Self.cgImage.get())
+      let attachment = Attachment(image, named: "diamond.jpg")
+      #expect(attachment.attachableValue === image)
       try attachment.attachableValue.withUnsafeBytes(for: attachment) { buffer in
         #expect(buffer.count > 32)
       }

--- a/Tests/_MemorySafeTestingTests/MemorySafeTestDecls.swift
+++ b/Tests/_MemorySafeTestingTests/MemorySafeTestDecls.swift
@@ -24,8 +24,10 @@ struct ExampleSuite {
   @Test func example() {}
 }
 
+#if !SWT_NO_EXIT_TESTS
 func exampleExitTest() async {
   await #expect(processExitsWith: .success) {}
 }
+#endif
 
 #endif


### PR DESCRIPTION
This PR adds on to the Core Graphics cross-import overlay added in #827 to allow attaching instances of `UIImage` to a test.

> [!NOTE]
> Image attachments remain an experimental feature.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
