### PR TITLE
Make `ExitTest._current` immutable.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -153,7 +153,7 @@ extension ExitTest {
   ///
   /// A pointer is used for indirection because `ManagedBuffer` cannot yet hold
   /// move-only types.
-  private static nonisolated(unsafe) var _current: Locked<UnsafeMutablePointer<ExitTest?>> = {
+  private static nonisolated(unsafe) let _current: Locked<UnsafeMutablePointer<ExitTest?>> = {
     let current = UnsafeMutablePointer<ExitTest?>.allocate(capacity: 1)
     current.initialize(to: nil)
     return Locked(rawValue: current)


### PR DESCRIPTION
This PR makes the private `ExitTest._current` stored property a `let` instead of a `var`. This has no practical effect but is more correct.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
