### PR TITLE
[6.2] Reset the working directory of child processes we spawn on Windows.

### DIFF
--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -201,6 +201,17 @@ struct FileHandleTests {
 #endif
   }
 #endif
+
+  @Test("Root directory path is correct")
+  func rootDirectoryPathIsCorrect() throws {
+#if os(Windows)
+    if let systemDrive = Environment.variable(named: "SYSTEMDRIVE") {
+      #expect(rootDirectoryPath.starts(with: systemDrive))
+    }
+#else
+    #expect(rootDirectoryPath == "/")
+#endif
+  }
 }
 
 // MARK: - Fixtures


### PR DESCRIPTION
- **Explanation**: Works around a behavioural difference on Windows where a process prevents the deletion of its CWD which means exit tests can cause Foundation unit tests to fail.
- **Scope**: Windows exit tests.
- **Issues**: #1209
- **Original PRs**: #1212
- **Risk**: Low, but it is a Windows-specific behavioural change so non-zero?
- **Testing**: Existing CI jobs and a new unit test.
- **Reviewers**: @stmontgomery @jmschonfeld @briancroom