### PR TITLE
Add missing links to `UIImage` documentation.

### DIFF
--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
@@ -27,6 +27,8 @@ private import ImageIO
 /// - [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage)
 /// - [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage)
 ///   (macOS)
+/// - [`UIImage`](https://developer.apple.com/documentation/uikit/uiimage)
+///   (iOS, watchOS, tvOS, visionOS, and Mac Catalyst)
 ///
 /// You do not generally need to add your own conformances to this protocol. If
 /// you have an image in another format that needs to be attached to a test,

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/Attachment+AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/Attachment+AttachableAsCGImage.swift
@@ -34,6 +34,8 @@ extension Attachment {
   /// - [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage)
   /// - [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage)
   ///   (macOS)
+  /// - [`UIImage`](https://developer.apple.com/documentation/uikit/uiimage)
+  ///   (iOS, watchOS, tvOS, visionOS, and Mac Catalyst)
   ///
   /// The testing library uses the image format specified by `imageFormat`. Pass
   /// `nil` to let the testing library decide which image format to use. If you
@@ -72,6 +74,8 @@ extension Attachment {
   /// - [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage)
   /// - [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage)
   ///   (macOS)
+  /// - [`UIImage`](https://developer.apple.com/documentation/uikit/uiimage)
+  ///   (iOS, watchOS, tvOS, visionOS, and Mac Catalyst)
   ///
   /// The testing library uses the image format specified by `imageFormat`. Pass
   /// `nil` to let the testing library decide which image format to use. If you

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/_AttachableImageWrapper.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/_AttachableImageWrapper.swift
@@ -50,6 +50,8 @@ import UniformTypeIdentifiers
 /// - [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage)
 /// - [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage)
 ///   (macOS)
+/// - [`UIImage`](https://developer.apple.com/documentation/uikit/uiimage)
+///   (iOS, watchOS, tvOS, visionOS, and Mac Catalyst)
 @_spi(Experimental)
 @available(_uttypesAPI, *)
 public struct _AttachableImageWrapper<Image>: Sendable where Image: AttachableAsCGImage {


### PR DESCRIPTION
Add missing links to `UIImage` documentation in the comment blobs that cover `CGImage`, `NSImage`, etc. This got omitted during a merge from main.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
