### PR TITLE
[WIP] Adopt lifetime annotations for owned resources.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -366,6 +366,8 @@ extension Array where Element == PackageDescription.SwiftSetting {
 
       .enableUpcomingFeature("InferIsolatedConformances"),
 
+      .enableExperimentalFeature("Lifetimes"),
+
       // When building as a package, the macro plugin always builds as an
       // executable rather than a library.
       .define("SWT_NO_LIBRARY_MACRO_PLUGINS"),

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -54,9 +54,7 @@ public func __swiftPMEntryPoint(passing args: __CommandLineArguments_v0? = nil) 
   // Ensure that stdout is line- rather than block-buffered. Swift Package
   // Manager reroutes standard I/O through pipes, so we tend to end up with
   // block-buffered streams.
-  FileHandle.stdout.withUnsafeCFILEHandle { stdout in
-    _ = setvbuf(stdout, nil, _IOLBF, Int(BUFSIZ))
-  }
+  _ = setvbuf(FileHandle.stdout.unsafeCFILEHandle, nil, _IOLBF, Int(BUFSIZ))
 #endif
 
   return await entryPoint(passing: args, eventHandler: nil)

--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -120,34 +120,32 @@ func spawnExecutable(
       // Forward standard I/O streams and any explicitly added file handles.
       var highestFD = max(STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO)
       func inherit(_ fileHandle: borrowing FileHandle, as standardFD: CInt? = nil) throws {
-        try fileHandle.withUnsafePOSIXFileDescriptor { fd in
-          guard let fd else {
-            throw SystemError(description: "A child process cannot inherit a file handle without an associated file descriptor. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
-          }
-          if let standardFD, standardFD != fd {
-            _ = posix_spawn_file_actions_adddup2(fileActions, fd, standardFD)
-          } else {
+        guard let fd = fileHandle.unsafePOSIXFileDescriptor else {
+          throw SystemError(description: "A child process cannot inherit a file handle without an associated file descriptor. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
+        }
+        if let standardFD, standardFD != fd {
+          _ = posix_spawn_file_actions_adddup2(fileActions, fd, standardFD)
+        } else {
 #if SWT_TARGET_OS_APPLE
-            _ = posix_spawn_file_actions_addinherit_np(fileActions, fd)
+          _ = posix_spawn_file_actions_addinherit_np(fileActions, fd)
 #else
-            // posix_spawn_file_actions_adddup2() will automatically clear
-            // FD_CLOEXEC after forking but before execing even if the old and
-            // new file descriptors are equal. This behavior is supported by
-            // Glibc ≥ 2.29, FreeBSD, OpenBSD, and Android (Bionic) and is
-            // standardized in POSIX.1-2024 (see https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_spawn_file_actions_adddup2.html
-            // and https://www.austingroupbugs.net/view.php?id=411).
-            _ = posix_spawn_file_actions_adddup2(fileActions, fd, fd)
+          // posix_spawn_file_actions_adddup2() will automatically clear
+          // FD_CLOEXEC after forking but before execing even if the old and new
+          // file descriptors are equal. This behavior is supported by
+          // Glibc ≥ 2.29, FreeBSD, OpenBSD, and Android (Bionic) and is
+          // standardized in POSIX.1-2024 (see https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_spawn_file_actions_adddup2.html
+          // and https://www.austingroupbugs.net/view.php?id=411).
+          _ = posix_spawn_file_actions_adddup2(fileActions, fd, fd)
 #if canImport(Glibc) && !os(FreeBSD) && !os(OpenBSD)
-            if _slowPath(glibcVersion.major < 2 || (glibcVersion.major == 2 && glibcVersion.minor < 29)) {
-              // This system is using an older version of glibc that does not
-              // implement FD_CLOEXEC clearing in posix_spawn_file_actions_adddup2(),
-              // so we must clear it here in the parent process.
-              try setFD_CLOEXEC(false, onFileDescriptor: fd)
-            }
-#endif
-#endif
-            highestFD = max(highestFD, fd)
+          if _slowPath(glibcVersion.major < 2 || (glibcVersion.major == 2 && glibcVersion.minor < 29)) {
+            // This system is using an older version of glibc that does not
+            // implement FD_CLOEXEC clearing in posix_spawn_file_actions_adddup2(),
+            // so we must clear it here in the parent process.
+            try setFD_CLOEXEC(false, onFileDescriptor: fd)
           }
+#endif
+#endif
+          highestFD = max(highestFD, fd)
         }
       }
       func inherit(_ fileHandle: borrowing FileHandle?, as standardFD: CInt? = nil) throws {
@@ -231,20 +229,19 @@ func spawnExecutable(
   }
 #elseif os(Windows)
   return try _withStartupInfoEx(attributeCount: 1) { startupInfo in
+    @_lifetime(fileHandle)
     func inherit(_ fileHandle: borrowing FileHandle) throws -> HANDLE? {
-      try fileHandle.withUnsafeWindowsHANDLE { windowsHANDLE in
-        guard let windowsHANDLE else {
-          throw SystemError(description: "A child process cannot inherit a file handle without an associated Windows handle. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
-        }
-
-        // Ensure the file handle can be inherited by the child process.
-        guard SetHandleInformation(windowsHANDLE, DWORD(HANDLE_FLAG_INHERIT), DWORD(HANDLE_FLAG_INHERIT)) else {
-          throw Win32Error(rawValue: GetLastError())
-        }
-
-        return windowsHANDLE
+      guard let windowsHANDLE = fileHandle.unsafeWindowsHANDLE else {
+        throw SystemError(description: "A child process cannot inherit a file handle without an associated Windows handle. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
       }
+      // Ensure the file handle can be inherited by the child process.
+      guard SetHandleInformation(windowsHANDLE, DWORD(HANDLE_FLAG_INHERIT), DWORD(HANDLE_FLAG_INHERIT)) else {
+        throw Win32Error(rawValue: GetLastError())
+      }
+
+      return windowsHANDLE
     }
+    @_lifetime(fileHandle)
     func inherit(_ fileHandle: borrowing FileHandle?) throws -> HANDLE? {
       if fileHandle != nil {
         return try inherit(fileHandle!)

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -25,6 +25,15 @@ struct FileHandleTests {
     #expect(EOF != feof(file))
   }
 
+  @Test func foo() throws {
+    var fd: CInt?
+    do {
+      let file = try FileHandle.temporary()
+      fd = file.unsafePOSIXFileDescriptor
+    }
+    print(fd as Any)
+  }
+
   @Test("Can get stdout")
   func canGetStdout() {
     canGet(.stdout)

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -21,9 +21,8 @@ struct FileHandleTests {
   func canGet(_ fileHandle: borrowing FileHandle) {
     // This test function doesn't really do much other than check that the
     // standard I/O files can be accessed.
-    fileHandle.withUnsafeCFILEHandle { fileHandle in
-      #expect(EOF != feof(fileHandle))
-    }
+    let file = fileHandle.unsafeCFILEHandle
+    #expect(EOF != feof(file))
   }
 
   @Test("Can get stdout")
@@ -39,9 +38,8 @@ struct FileHandleTests {
   @Test("Can get file descriptor")
   func fileDescriptor() throws {
     let fileHandle = try FileHandle.temporary()
-    try fileHandle.withUnsafePOSIXFileDescriptor { fd in
-      try #require(fd != nil)
-    }
+    let fd = fileHandle.unsafePOSIXFileDescriptor
+    try #require(fd != nil)
   }
 
 #if !os(Windows) // Windows does not like invalid file descriptors.
@@ -57,9 +55,8 @@ struct FileHandleTests {
   @Test("Can get Windows file HANDLE")
   func fileHANDLE() throws {
     let fileHandle = try FileHandle.temporary()
-    try fileHandle.withUnsafeWindowsHANDLE { handle in
-      try #require(handle != nil)
-    }
+    let handle = fileHandle.unsafeWindowsHANDLE
+    try #require(handle != nil)
   }
 #endif
 


### PR DESCRIPTION
This PR adopts the experimental `@_lifetime` attribute for resources owned by `FileHandle` and (on Windows) `HMODULE` so that we can use them without needing a `with { }`-style function call.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
