### PR TITLE
Only clear exit test ID env var upon successful lookup

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -719,14 +719,13 @@ extension ExitTest {
 
   /// The ID of the exit test to run, if any, specified in the environment.
   static var environmentIDForEntryPoint: ID? {
-    var id: ExitTest.ID?
-    if var idString = Environment.variable(named: Self._idEnvironmentVariableName) {
-      id = try? idString.withUTF8 { idBuffer in
-        try JSON.decode(ExitTest.ID.self, from: UnsafeRawBufferPointer(idBuffer))
-      }
+    guard var idString = Environment.variable(named: Self._idEnvironmentVariableName) else {
+      return nil
     }
 
-    return id
+    return try? idString.withUTF8 { idBuffer in
+      try JSON.decode(ExitTest.ID.self, from: UnsafeRawBufferPointer(idBuffer))
+    }
   }
 
   /// Find the exit test function specified in the environment of the current


### PR DESCRIPTION
This changes the logic in `ExitTest.findInEnvironmentForEntryPoint()` to only clear the environment variable containing the ID of the exit test to run if an exit test is successfully located.

### Motivation:

This ensures that if a tool integrates with the testing library and has both its own built-in copy of the library but also may call into the ABI entry point, both usage scenarios can successfully look up the exit test. Without this fix, if an earlier attempt to look up an exit test fails, the environment variable would be cleared which prevents a subsequent lookup attempt from succeeding.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
