### PR TITLE
[6.2] Only clear exit test ID env var upon successful lookup

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -233,6 +233,10 @@ extension ExitTest {
 #endif
   }
 
+  /// The name of the environment variable used to identify the exit test to
+  /// call in a spawned exit test process.
+  private static let _idEnvironmentVariableName = "SWT_EXIT_TEST_ID"
+
   /// Call the exit test in the current process.
   ///
   /// This function invokes the closure originally passed to
@@ -698,6 +702,17 @@ extension ExitTest {
 #endif
   }
 
+  /// The ID of the exit test to run, if any, specified in the environment.
+  static var environmentIDForEntryPoint: ID? {
+    guard var idString = Environment.variable(named: Self._idEnvironmentVariableName) else {
+      return nil
+    }
+
+    return try? idString.withUTF8 { idBuffer in
+      try JSON.decode(ExitTest.ID.self, from: UnsafeRawBufferPointer(idBuffer))
+    }
+  }
+
   /// Find the exit test function specified in the environment of the current
   /// process, if any.
   ///
@@ -708,20 +723,14 @@ extension ExitTest {
   /// `__swiftPMEntryPoint()` function. The effect of using it under other
   /// configurations is undefined.
   static func findInEnvironmentForEntryPoint() -> Self? {
-    // Find the ID of the exit test to run, if any, in the environment block.
-    var id: ExitTest.ID?
-    if var idString = Environment.variable(named: "SWT_EXIT_TEST_ID") {
-      // Clear the environment variable. It's an implementation detail and exit
-      // test code shouldn't be dependent on it. Use ExitTest.current if needed!
-      Environment.setVariable(nil, named: "SWT_EXIT_TEST_ID")
-
-      id = try? idString.withUTF8 { idBuffer in
-        try JSON.decode(ExitTest.ID.self, from: UnsafeRawBufferPointer(idBuffer))
-      }
-    }
-    guard let id, var result = find(identifiedBy: id) else {
+    guard let id = environmentIDForEntryPoint, var result = find(identifiedBy: id) else {
       return nil
     }
+
+    // Since an exit test was found, clear the environment variable. It's an
+    // implementation detail and exit test code shouldn't be dependent on it.
+    // Use ExitTest.current if needed!
+    Environment.setVariable(nil, named: Self._idEnvironmentVariableName)
 
     // If an exit test was found, inject back channel handling into its body.
     // External tools authors should set up their own back channel mechanisms
@@ -852,7 +861,7 @@ extension ExitTest {
       // Insert a specific variable that tells the child process which exit test
       // to run.
       try JSON.withEncoding(of: exitTest.id) { json in
-        childEnvironment["SWT_EXIT_TEST_ID"] = String(decoding: json, as: UTF8.self)
+        childEnvironment[Self._idEnvironmentVariableName] = String(decoding: json, as: UTF8.self)
       }
 
       typealias ResultUpdater = @Sendable (inout ExitTest.Result) -> Void


### PR DESCRIPTION
- **Explanation**: This changes the logic in `ExitTest.findInEnvironmentForEntryPoint()` to only clear the environment variable containing the ID of the exit test to run if an exit test is successfully located.
- **Scope**: Affects exit tests and tools that integrate with them.
- **Issues**: Motivated by rdar://153326967
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1226
- **Risk**: Low
- **Testing**: Manual verification
- **Reviewers**: @grynspan, @briancroom 
