### PR TITLE
Update docs for decoding stdout and stderr from exit tests

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.Result.swift
+++ b/Sources/Testing/ExitTests/ExitTest.Result.swift
@@ -38,7 +38,7 @@ extension ExitTest {
     /// The value of this property may contain any arbitrary sequence of bytes,
     /// including sequences that are not valid UTF-8 and cannot be decoded by
     /// [`String.init(cString:)`](https://developer.apple.com/documentation/swift/string/init(cstring:)-6kr8s).
-    /// Consider using [`String.init(validatingCString:)`](https://developer.apple.com/documentation/swift/string/init(validatingcstring:)-992vo)
+    /// Consider using [`String.init(validating:as:)`](https://developer.apple.com/documentation/swift/string/init(validating:as:)-84qr9)
     /// instead.
     ///
     /// When checking the value of this property, keep in mind that the standard
@@ -69,7 +69,7 @@ extension ExitTest {
     /// The value of this property may contain any arbitrary sequence of bytes,
     /// including sequences that are not valid UTF-8 and cannot be decoded by
     /// [`String.init(cString:)`](https://developer.apple.com/documentation/swift/string/init(cstring:)-6kr8s).
-    /// Consider using [`String.init(validatingCString:)`](https://developer.apple.com/documentation/swift/string/init(validatingcstring:)-992vo)
+    /// Consider using [`String.init(validating:as:)`](https://developer.apple.com/documentation/swift/string/init(validating:as:)-84qr9)
     /// instead.
     ///
     /// When checking the value of this property, keep in mind that the standard


### PR DESCRIPTION
### Motivation:

The API documentation for `ExitTest.Result.standardOutputContent` and `ExitTest.Result.standardErrorContent` has advice on how to construct a string from their contents. It recommends using `String.init(validatingCString:)`, which has two problems:

1. You cannot just pass it in since these properties are `[UInt8]` and `String.init(validatingCString:)` takes sequences whose element is `CChar` (aka `Int8`):

```swift
_ = String(validatingCString: result.standardErrorContent)  // error: Cannot convert value of type '[UInt8]' to expected argument type '[CChar]' (aka 'Array<Int8>')
```

2. Even if you had the sequence of the correct element type, the matching initializer is now deprecated:

```swift
_ = String(validatingCString: result.standardErrorContent.map(Int8.init))  // warning: 'init(validatingCString:)' is deprecated: Use String(validating: array, as: UTF8.self) instead, after truncating the null termination.
```

So, in order to get this working without warnings, adopters will likely want this:

```swift
try #require(String(validating: result.standardErrorContent, as: UTF8.self))
```

### Modifications:

- Update the API documentation to advise using String(validating: array, as: UTF8.self).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] ~If public symbols are renamed or modified, DocC references should be updated.~
