### PR TITLE
Validate format of event stream version CLI argument when passed

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -255,7 +255,7 @@ public struct __CommandLineArguments_v0: Sendable {
   /// whichever occurs first.
   public var eventStreamOutputPath: String?
 
-  /// The value of the `--event-stream-version` or `experimental-event-stream-version`
+  /// The value of the `--event-stream-version` or `--experimental-event-stream-version`
   /// argument, representing the version of the event stream schema to use when
   /// writing events to ``eventStreamOutput``.
   ///

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -308,6 +308,13 @@ struct SwiftPMTests {
       _ = try configurationForEntryPoint(withArguments: ["PATH", "--event-stream-version", "\(experimentalVersion)"])
     }
   }
+
+  @Test("Invalid event stream version throws an invalid argument error")
+  func invalidEventStreamVersionThrows() {
+    #expect(throws: (any Error).self) {
+      _ = try configurationForEntryPoint(withArguments: ["PATH", "--event-stream-version", "xyz-invalid"])
+    }
+  }
 #endif
 #endif
 


### PR DESCRIPTION
This adds validation of the user-specified `--event-stream-version` (or `--experimental-event-stream-version`) command-line arguments when they are passed, to ensure they have a valid format.

### Motivation:

Currently, these flags only accept integers like `0`, `1`, etc. But I am moving towards making the entry point and event stream versions align with the Swift version, rather than having an independent versioning scheme which users must look up or keep track of. Once this effort is finished, in order to use the event stream format included in (for example) Swift 6.3, a user would pass `--event-stream-version 6.3`.

In https://github.com/swiftlang/swift-package-manager/pull/8944, I recently landed a SwiftPM change which will permit any arbitrary string for these arguments, and this means we need to begin validating the format of supported versions within the testing library. In a subsequent PR, I plan to introduce support for non-integer versions, at which point having some existing validation logic will be even more valuable.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
