### PR TITLE
Mention module name and presence in toolchain in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Swift expressions and operators, and captures the evaluated values so you can
 quickly understand what went wrong when a test fails.
 
 ```swift
+import Testing
+
 @Test func helloWorld() {
   let greeting = "Hello, world!"
   #expect(greeting == "Hello") // Expectation failed: (greeting → "Hello, world!") == "Hello"
@@ -84,11 +86,18 @@ func mentionedContinents(videoName: String) async throws {
 
 ### Cross-platform support
 
-Swift Testing works on all major platforms supported by Swift, including Apple
-platforms, Linux, and Windows, so your tests can behave more consistently when
-moving between platforms. It’s developed as open source and discussed on the
-[Swift Forums](https://forums.swift.org/c/development/swift-testing/103) so the
-very best ideas, from anywhere, can help shape the future of testing in Swift.
+Swift Testing is included in officially-supported Swift toolchains, including
+those for Apple platforms, Linux, and Windows. This means you don't need to
+declare a package dependency to use it—just import the `Testing` module:
+
+```swift
+import Testing
+```
+
+Swift Testing is developed as open source and discussed on the
+[Swift Forums](https://forums.swift.org/c/development/swift-testing/103)
+so the very best ideas, from anywhere, can help shape the future of testing in
+Swift.
 
 The table below describes the current level of support that Swift Testing has
 for various platforms:

--- a/README.md
+++ b/README.md
@@ -87,14 +87,15 @@ func mentionedContinents(videoName: String) async throws {
 ### Cross-platform support
 
 Swift Testing is included in officially-supported Swift toolchains, including
-those for Apple platforms, Linux, and Windows. This means you don't need to
-declare a package dependency to use it—just import the `Testing` module:
+those for Apple platforms, Linux, and Windows. To use the library, import the
+`Testing` module:
 
 ```swift
 import Testing
 ```
 
-Swift Testing is developed as open source and discussed on the
+You don't need to declare a package dependency to use Swift Testing. It's
+developed as open source and discussed on the
 [Swift Forums](https://forums.swift.org/c/development/swift-testing/103)
 so the very best ideas, from anywhere, can help shape the future of testing in
 Swift.


### PR DESCRIPTION
This adds a mention of the testing library's module name (`import Testing`) and its presence in officially-supported Swift toolchains in the `README`.

### Motivation:

Some users have been confused about whether they need to declare a package dependency on the `swift-testing` package to use Swift Testing. It's included in Swift toolchains for officially-supported platforms, so we generally do not recommend declaring such a package dependency, and doing so can lead to a degraded experience with integrated tools.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [X] If public symbols are renamed or modified, DocC references should be updated.
