### PR TITLE
Revert remaining workaround preventing the use of SymbolLinkageMarkers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -348,10 +348,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       // This setting is enabled in the package, but not in the toolchain build
       // (via CMake). Enabling it is dependent on acceptance of the @section
       // proposal via Swift Evolution.
-      //
-      // FIXME: Re-enable this once a CI blocker is resolved:
-      // https://github.com/swiftlang/swift-testing/issues/1138.
-//      .enableExperimentalFeature("SymbolLinkageMarkers"),
+      .enableExperimentalFeature("SymbolLinkageMarkers"),
 
       // This setting is no longer needed when building with a 6.2 or later
       // toolchain now that SE-0458 has been accepted and implemented, but it is


### PR DESCRIPTION
Revert this remaining workaround, originally added in #1139, now that a follow-on fix has landed.

Fixes #1138

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
