### PR TITLE
Add FreeBSD and OpenBSD as experimentally supported in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ for various platforms:
 | **tvOS** | | | Supported |
 | **visionOS** | | | Supported |
 | **Ubuntu 22.04** | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-6.1-linux)](https://ci.swift.org/job/swift-testing-main-swift-6.1-linux/) | [![Build Status](https://ci.swift.org/buildStatus/icon?job=swift-testing-main-swift-main-linux)](https://ci.swift.org/view/Swift%20Packages/job/swift-testing-main-swift-main-linux/) | Supported |
+| **FreeBSD** | | | Experimental |
+| **OpenBSD** | | | Experimental |
 | **Windows** | [![Build Status](https://ci-external.swift.org/buildStatus/icon?job=swift-testing-main-swift-6.1-windows)](https://ci-external.swift.org/view/all/job/swift-testing-main-swift-6.1-windows/) | [![Build Status](https://ci-external.swift.org/buildStatus/icon?job=swift-testing-main-swift-main-windows)](https://ci-external.swift.org/job/swift-testing-main-swift-main-windows/) | Supported |
 | **Wasm** | | | Experimental |
 


### PR DESCRIPTION
This PR adds FreeBSD and OpenBSD to README.md as experimentally supported. (FreeBSD will be fully supported in an upcoming Swift release.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
