### PR TITLE
Don't use `_getSuperclass()` from the Swift runtime.

### DIFF
--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -360,13 +360,10 @@ extension TypeInfo {
 /// - Returns: Whether `subclass` is a subclass of, or is equal to,
 ///   `superclass`.
 func isClass(_ subclass: AnyClass, subclassOf superclass: AnyClass) -> Bool {
-  if subclass == superclass {
-    true
-  } else if let subclassImmediateSuperclass = _getSuperclass(subclass) {
-    isClass(subclassImmediateSuperclass, subclassOf: superclass)
-  } else {
-    false
+  func open<T, U>(_: T.Type, _: U.Type) -> Bool where T: AnyObject, U: AnyObject {
+    T.self is U.Type
   }
+  return open(subclass, superclass)
 }
 
 // MARK: - CustomStringConvertible, CustomDebugStringConvertible, CustomTestStringConvertible


### PR DESCRIPTION
To determine if a class is a subclass of another, we can use `T.self is U.Type` in an implicitly-opened existential context. Prior to the Swift 6 language mode, type existentials weren't openable, so we had to recursively call a runtime function to check this. That's no longer a concern for us.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
