### PR TITLE
Use the prefix `swift_testing_` for future exported symbols.

### DIFF
--- a/Documentation/StyleGuide.md
+++ b/Documentation/StyleGuide.md
@@ -71,16 +71,25 @@ to the code called by the initialization expression causing the inferred type of
 its property to change unknowingly, which could break clients. Properties with
 lower access levels may have an inferred type.
 
-Exported C and C++ symbols that are exported should be given the prefix `swt_`
-and should otherwise be named using the same lowerCamelCase naming rules as in
-Swift. Use the `SWT_EXTERN` macro to ensure that symbols are consistently
-visible in C, C++, and Swift. For example:
+C and C++ symbols that are used by the testing library should be given the
+prefix `swt_` and should otherwise be named using the same lowerCamelCase naming
+rules as in Swift. Use the `SWT_EXTERN` macro to ensure that symbols are
+consistently visible in C, C++, and Swift. For example:
 
 ```c
 SWT_EXTERN bool swt_isDebugModeEnabled(void);
 
 SWT_EXTERN void swt_setDebugModeEnabled(bool isEnabled);
 ```
+
+> [!NOTE]
+> If a symbol is meant to be **publicly visible** and can be called by modules
+> other than Swift Testing, use the prefix `swift_testing_` instead of `swt_`
+> for consistency with the Swift standard library:
+>
+> ```c
+> SWT_EXTERN void swift_testing_debugIfNeeded(void);
+> ```
 
 C and C++ types should be given the prefix `SWT` and should otherwise be named
 using the same UpperCamelCase naming rules as in Swift. For example:

--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -67,6 +67,10 @@ extension ABI.v0 {
 ///
 /// - Returns: The value of ``ABI/v0/entryPoint-swift.type.property`` cast to an
 ///   untyped pointer.
+///
+/// - Note: This function's name is prefixed with `swt_` instead of
+///   `swift_testing_` for binary compatibility reasons. Future ABI entry point
+///   functions should use the `swift_testing_` prefix instead.
 @_cdecl("swt_abiv0_getEntryPoint")
 @usableFromInline func abiv0_getEntryPoint() -> UnsafeRawPointer {
   unsafeBitCast(ABI.v0.entryPoint, to: UnsafeRawPointer.self)


### PR DESCRIPTION
This PR updates our naming guidelines for exported/public C symbols. Right now, the only functions that would qualify are `swt_abiv0_getEntryPoint()` and `swt_copyABIEntryPoint_v0()` and their names must be preserved for binary compatibility with Xcode 16 through Xcode 26 anyway.

Thus, this change is a documentation change only.

Resolves #1064.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
