### PR TITLE
Silence a warning on FreeBSD/OpenBSD when calling `pthread_set_name_np()`.

### DIFF
--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -167,9 +167,9 @@ private let _createWaitThread: Void = {
       _ = _pthread_setname_np?(pthread_self(), "SWT ExT monitor")
 #endif
 #elseif os(FreeBSD)
-      _ = pthread_set_name_np(pthread_self(), "SWT ex test monitor")
+      pthread_set_name_np(pthread_self(), "SWT ex test monitor")
 #elseif os(OpenBSD)
-      _ = pthread_set_name_np(pthread_self(), "SWT exit test monitor")
+      pthread_set_name_np(pthread_self(), "SWT exit test monitor")
 #else
 #warning("Platform-specific implementation missing: thread naming unavailable")
 #endif


### PR DESCRIPTION
On FreeBSD and OpenBSD, `pthread_set_name_np()` returns `void`, so we don't need to suppress the result (assigning it to `_`) and the Swift compiler complains that we do.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
