### PR TITLE
Avoid passive voice and clarify macro in exit test docs.

### DIFF
--- a/Sources/Testing/Testing.docc/exit-testing.md
+++ b/Sources/Testing/Testing.docc/exit-testing.md
@@ -128,13 +128,14 @@ value using the `as` operator:
 
 Every value you capture in an exit test must conform to [`Sendable`](https://developer.apple.com/documentation/swift/sendable)
 and [`Codable`](https://developer.apple.com/documentation/swift/codable). The
-testing library passes each value to the exit test body by following this process:
+testing library passes each value to the exit test body by performing the
+following steps:
 
 1. It encodes each value using [`encode(to:)`](https://developer.apple.com/documentation/swift/encodable/encode(to:))
-in the parent process
+   in the parent process
 2. It passes the encoded value to the child process
 3. It decodes each value using [`init(from:)`](https://developer.apple.com/documentation/swift/decodable/init(from:))
-in the child process
+   in the child process
 
 If a captured value's type does not conform to both `Sendable` and `Codable`, or
 if the value is not explicitly specified in the exit test body's capture list,


### PR DESCRIPTION
Review recent changes in the exit test documentation.

### Motivation:

@grynspan asked me to review #1165 but it was already merged by the time I got there, so here are my review suggestions as a fresh PR.

### Modifications:

- Specified which macro we mean by "this macro" in the exit tests docs.
- Removed instances of the passive voice.

### Checklist:

- [X] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [X] If public symbols are renamed or modified, DocC references should be updated.
