### PR TITLE
Remove experimental spi from issue severity

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -65,7 +65,7 @@ extension Issue {
   /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
   @discardableResult public static func record(
     _ comment: Comment? = nil,
-    severity: Severity,
+    severity: Severity = .error,
     sourceLocation: SourceLocation = #_sourceLocation
   ) -> Self {
     let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -50,7 +50,7 @@ extension Issue {
     return self
   }
 
-  /// Record an issue when a running test fails unexpectedly.
+  /// Records an issue that a test encounters while it's running.
   ///
   /// - Parameters:
   ///   - comment: A comment describing the expectation.
@@ -63,6 +63,8 @@ extension Issue {
   /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
   /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
   @_disfavoredOverload
+  @_documentation(visibility: private)
+  @available(*, deprecated, message: "Use record(_:severity:sourceLocation:) instead.")
   @discardableResult public static func record(
     _ comment: Comment? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
@@ -70,11 +72,13 @@ extension Issue {
     record(comment, severity: .error, sourceLocation: sourceLocation)
   }
 
-  /// Record an issue when a running test and an issue occurs.
+  /// Records an issue that a test encounters while it's running.
   ///
   /// - Parameters:
   ///   - comment: A comment describing the expectation.
-  ///   - severity: The severity level of the issue.  The testing library marks the test as failed if the severity is greater than ``Issue/Severity/warning``.  The default is ``Issue/Severity/error``.
+  ///   - severity: The severity level of the issue.  The testing library marks the
+  ///   test as failed if the severity is greater than ``Issue/Severity/warning``.
+  ///   The default is ``Issue/Severity/error``.
   ///   - sourceLocation: The source location to which the issue should be
   ///     attributed.
   ///
@@ -83,6 +87,7 @@ extension Issue {
   /// Use this function if, while running a test, an issue occurs that cannot be
   /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
   /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
+  /// 
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
   /// }

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -50,10 +50,11 @@ extension Issue {
     return self
   }
 
-  /// Record an issue when a running test fails unexpectedly.
+  /// Record an issue when a running test and an issue occurs.
   ///
   /// - Parameters:
   ///   - comment: A comment describing the expectation.
+  ///   - severity: The severity level of the issue.  This factor impacts whether the issue constitutes a failure.
   ///   - sourceLocation: The source location to which the issue should be
   ///     attributed.
   ///
@@ -62,27 +63,6 @@ extension Issue {
   /// Use this function if, while running a test, an issue occurs that cannot be
   /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
   /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
-  @discardableResult public static func record(
-    _ comment: Comment? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation
-  ) -> Self {
-    record(comment, severity: .error, sourceLocation: sourceLocation)
-  }
-
-  /// Record an issue when a running test fails unexpectedly.
-  ///
-  /// - Parameters:
-  ///   - comment: A comment describing the expectation.
-  ///   - severity: The severity of the issue.
-  ///   - sourceLocation: The source location to which the issue should be
-  ///     attributed.
-  ///
-  /// - Returns: The issue that was recorded.
-  ///
-  /// Use this function if, while running a test, an issue occurs that cannot be
-  /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
-  /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
-  @_spi(Experimental)
   @discardableResult public static func record(
     _ comment: Comment? = nil,
     severity: Severity,

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -84,6 +84,9 @@ extension Issue {
   /// Use this function if, while running a test, an issue occurs that cannot be
   /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
   /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   @discardableResult public static func record(
     _ comment: Comment? = nil,
     severity: Severity = .error,

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -50,11 +50,32 @@ extension Issue {
     return self
   }
 
+  /// Record an issue when a running test fails unexpectedly.
+  ///
+  /// - Parameters:
+  ///   - comment: A comment describing the expectation.
+  ///   - sourceLocation: The source location to which the issue should be
+  ///     attributed.
+  ///
+  /// - Returns: The issue that was recorded.
+  ///
+  /// Use this function if, while running a test, an issue occurs that cannot be
+  /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
+  /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
+  @_disfavoredOverload
+  @discardableResult public static func record(
+    _ comment: Comment? = nil,
+    sourceLocation: SourceLocation = #_sourceLocation
+  ) -> Self {
+    record(comment, severity: .error, sourceLocation: sourceLocation)
+  }
+
   /// Record an issue when a running test and an issue occurs.
   ///
   /// - Parameters:
   ///   - comment: A comment describing the expectation.
-  ///   - severity: The severity level of the issue.  This factor impacts whether the issue constitutes a failure.
+  ///   - severity: The severity level of the issue.  This factor impacts whether the
+  ///     issue constitutes a failure.  The default is .error.
   ///   - sourceLocation: The source location to which the issue should be
   ///     attributed.
   ///

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -74,8 +74,7 @@ extension Issue {
   ///
   /// - Parameters:
   ///   - comment: A comment describing the expectation.
-  ///   - severity: The severity level of the issue.  This factor impacts whether the
-  ///     issue constitutes a failure.  The default is .error.
+  ///   - severity: The severity level of the issue.  The testing library marks the test as failed if the severity is greater than ``Issue/Severity/warning``.  The default is ``Issue/Severity/error``.
   ///   - sourceLocation: The source location to which the issue should be
   ///     attributed.
   ///

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -84,6 +84,7 @@ public struct Issue: Sendable {
   ///
   /// - ``warning``
   /// - ``error``
+  ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
   /// }
@@ -103,6 +104,7 @@ public struct Issue: Sendable {
   }
 
   /// The severity of this issue.
+  ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
   /// }
@@ -118,6 +120,7 @@ public struct Issue: Sendable {
   ///
   /// Use this property to determine if an issue should be considered a failure, instead of
   /// directly comparing the value of the ``severity`` property.
+  ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
   /// }
@@ -330,6 +333,7 @@ extension Issue {
     public var kind: Kind.Snapshot
 
     /// The severity of this issue.
+    /// 
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.3)
     /// }

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -169,9 +169,6 @@ public struct Issue: Sendable {
   ///     empty.
   ///   - sourceContext: A ``SourceContext`` indicating where and how this issue
   ///     occurred.
-  /// @Metadata {
-  ///   @Available(Swift, introduced: 6.3)
-  /// }
   init(
     kind: Kind,
     severity: Severity = .error,

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -84,6 +84,9 @@ public struct Issue: Sendable {
   ///
   /// - ``warning``
   /// - ``error``
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public enum Severity: Sendable {
     /// The severity level for an issue which should be noted but is not
     /// necessarily an error.
@@ -100,6 +103,9 @@ public struct Issue: Sendable {
   }
 
   /// The severity of this issue.
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public var severity: Severity
   
   /// Whether or not this issue should cause the test it's associated with to be
@@ -112,6 +118,9 @@ public struct Issue: Sendable {
   ///
   /// Use this property to determine if an issue should be considered a failure, instead of
   /// directly comparing the value of the ``severity`` property.
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public var isFailure: Bool {
     return !self.isKnown && self.severity >= .error
   }
@@ -160,6 +169,9 @@ public struct Issue: Sendable {
   ///     empty.
   ///   - sourceContext: A ``SourceContext`` indicating where and how this issue
   ///     occurred.
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   init(
     kind: Kind,
     severity: Severity = .error,

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -333,6 +333,9 @@ extension Issue {
     public var kind: Kind.Snapshot
 
     /// The severity of this issue.
+    /// @Metadata {
+    ///   @Available(Swift, introduced: 6.3)
+    /// }
     public var severity: Severity
 
     /// Any comments provided by the developer and associated with this issue.

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -84,7 +84,6 @@ public struct Issue: Sendable {
   ///
   /// - ``warning``
   /// - ``error``
-  @_spi(Experimental)
   public enum Severity: Sendable {
     /// The severity level for an issue which should be noted but is not
     /// necessarily an error.
@@ -101,7 +100,6 @@ public struct Issue: Sendable {
   }
 
   /// The severity of this issue.
-  @_spi(Experimental)
   public var severity: Severity
   
   /// Whether or not this issue should cause the test it's associated with to be
@@ -114,7 +112,6 @@ public struct Issue: Sendable {
   ///
   /// Use this property to determine if an issue should be considered a failure, instead of
   /// directly comparing the value of the ``severity`` property.
-  @_spi(Experimental)
   public var isFailure: Bool {
     return !self.isKnown && self.severity >= .error
   }
@@ -324,7 +321,6 @@ extension Issue {
     public var kind: Kind.Snapshot
 
     /// The severity of this issue.
-    @_spi(Experimental)
     public var severity: Severity
 
     /// Any comments provided by the developer and associated with this issue.

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -187,10 +187,7 @@ public struct Configuration: Sendable {
     ///
     /// By default, events matching this criteria are not delivered to event
     /// handlers since this is an experimental feature.
-    ///
-    /// - Warning: Warning issues are not yet an approved feature.
-    @_spi(Experimental)
-    public var isWarningIssueRecordedEventEnabled: Bool = false
+    public var isWarningIssueRecordedEventEnabled: Bool = true
 
     /// Whether or not events of the kind
     /// ``Event/Kind-swift.enum/expectationChecked(_:)`` should be delivered to

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -184,9 +184,6 @@ public struct Configuration: Sendable {
     /// Whether or not events of the kind ``Event/Kind-swift.enum/issueRecorded(_:)``
     /// containing issues with warning (or lower) severity should be delivered
     /// to the event handler of the configuration these options are applied to.
-    ///
-    /// By default, events matching this criteria are not delivered to event
-    /// handlers since this is an experimental feature.
     public var isWarningIssueRecordedEventEnabled: Bool = true
 
     /// Whether or not events of the kind


### PR DESCRIPTION
Remove experimental spi from issue severity

### Motivation:

The Issue Severity proposal was approved.

https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0013-issue-severity-warning.md

### Modifications:

Removed experimental spi from issue severity and updated comments.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
