### PR TITLE
Fix two broken Forum category links in this project's New Issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,7 +9,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: 🌐 Discuss an idea
-    url: https://forums.swift.org/c/related-projects/swift-testing
+    url: https://forums.swift.org/c/development/swift-testing/103
     about: >
       Share an idea with the Swift Testing community.
   - name: 📄 Formally propose a change
@@ -18,10 +18,10 @@ contact_links:
       Formally propose an addition, removal, or change to the APIs or features
       of Swift Testing.
   - name: 🙋 Ask a question
-    url: https://forums.swift.org/c/related-projects/swift-testing
+    url: https://forums.swift.org/c/swift-users/15
     about: >
-      Ask a question about or get help with Swift Testing. Beginner questions
-      welcome!
+      Ask a question or get help by starting a new Forum topic with the 'swift-testing' tag.
+      Beginner questions welcome!
   - name: 🪲 Report an issue with Swift Package Manager
     url: https://github.com/swiftlang/swift-package-manager/issues/new/choose
     about: >


### PR DESCRIPTION
This fixes two broken Forum category links in this project's [New Issue](https://github.com/swiftlang/swift-testing/issues/new/choose) template chooser. The location of the "Development > Swift Testing" subcategory changed around the time of the formation of the [Testing Workgroup](https://swift.org/testing-workgroup/).

I also took this opportunity to switch to the [Using Swift](https://forums.swift.org/c/swift-users/15) category for the "Ask a question" link, since that's generally more appropriate for general usage questions.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
