### PR TITLE
Declare Xcode 26 availability for IssueHandlingTrait

### DIFF
--- a/Sources/Testing/Traits/IssueHandlingTrait.swift
+++ b/Sources/Testing/Traits/IssueHandlingTrait.swift
@@ -27,6 +27,7 @@
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 public struct IssueHandlingTrait: TestTrait, SuiteTrait {
   /// A function which handles an issue and returns an optional replacement.
@@ -55,6 +56,7 @@ public struct IssueHandlingTrait: TestTrait, SuiteTrait {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public func handleIssue(_ issue: Issue) -> Issue? {
     _handler(issue)
@@ -67,6 +69,7 @@ public struct IssueHandlingTrait: TestTrait, SuiteTrait {
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
 /// }
 extension IssueHandlingTrait: TestScoping {
   public func scopeProvider(for test: Test, testCase: Test.Case?) -> Self? {
@@ -181,6 +184,7 @@ extension Trait where Self == IssueHandlingTrait {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public static func compactMapIssues(_ transform: @escaping @Sendable (Issue) -> Issue?) -> Self {
     Self(handler: transform)
@@ -219,6 +223,7 @@ extension Trait where Self == IssueHandlingTrait {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)
+  ///   @Available(Xcode, introduced: 26.0)
   /// }
   public static func filterIssues(_ isIncluded: @escaping @Sendable (Issue) -> Bool) -> Self {
     Self { issue in


### PR DESCRIPTION
This declares Xcode 26 availability for `IssueHandlingTrait`, which was proposed in [ST-0011: Issue Handling Traits](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0011-issue-handling-traits.md) and included in Swift 6.2 in #1228.

This feature first appeared in Xcode 26 Beta 5, as noted[^1] in the [Release Notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-26-release-notes).

[^1]: Search for "ST-0011" on that page to find the reference.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
