### PR TITLE
Test that the fixups are generated if display name is empty

### DIFF
--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -273,8 +273,7 @@ struct TestDeclarationMacroTests {
          ),
        #"@Suite("") struct S {}"#:
        (
-         message:
-         "Attribute 'Suite' specifies an empty display name for this structure",
+         message: "Attribute 'Suite' specifies an empty display name for this structure",
          fixIts: [
            ExpectedFixIt(
              message: "Remove display name argument",

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -149,14 +149,6 @@ struct TestDeclarationMacroTests {
         "Attribute 'Test' cannot be applied to a function within structure 'S' because its conformance to 'Escapable' has been suppressed",
       "struct S: ~(Escapable) { @Test func f() {} }":
         "Attribute 'Test' cannot be applied to a function within structure 'S' because its conformance to 'Escapable' has been suppressed",
-
-      // empty display name string literal
-      #"@Test("") func f() {}"#:
-        "Attribute 'Test' specifies an empty display name for this function",
-      ##"@Test(#""#) func f() {}"##:
-        "Attribute 'Test' specifies an empty display name for this function",
-      #"@Suite("") struct S {}"#:
-        "Attribute 'Suite' specifies an empty display name for this structure",
     ]
   )
   func apiMisuseErrors(input: String, expectedMessage: String) throws {
@@ -241,6 +233,63 @@ struct TestDeclarationMacroTests {
             ),
           ]
         ),
+
+      // empty display name string literal
+      #"@Test("") func f() {}"#:
+        (
+          message: "Attribute 'Test' specifies an empty display name for this function",
+          fixIts: [
+            ExpectedFixIt(
+              message: "Remove display name argument",
+              changes: [
+                .replace(oldSourceCode: #""""#, newSourceCode: "")
+              ]),
+            ExpectedFixIt(
+              message: "Add display name",
+              changes: [
+                .replace(
+                  oldSourceCode: #""""#,
+                  newSourceCode: #""\#(EditorPlaceholderExprSyntax("display name"))""#)
+              ])
+          ]
+        ),
+       ##"@Test(#""#) func f() {}"##:
+         (
+           message: "Attribute 'Test' specifies an empty display name for this function",
+           fixIts: [
+             ExpectedFixIt(
+               message: "Remove display name argument",
+               changes: [
+                 .replace(oldSourceCode: ##"#""#"##, newSourceCode: "")
+               ]),
+             ExpectedFixIt(
+               message: "Add display name",
+               changes: [
+                 .replace(
+                   oldSourceCode: ##"#""#"##,
+                   newSourceCode: #""\#(EditorPlaceholderExprSyntax("display name"))""#)
+               ])
+           ]
+         ),
+       #"@Suite("") struct S {}"#:
+       (
+         message:
+         "Attribute 'Suite' specifies an empty display name for this structure",
+         fixIts: [
+           ExpectedFixIt(
+             message: "Remove display name argument",
+             changes: [
+               .replace(oldSourceCode: #""""#, newSourceCode: "")
+             ]),
+           ExpectedFixIt(
+            message: "Add display name",
+            changes: [
+              .replace(
+                oldSourceCode: #""""#,
+                newSourceCode: #""\#(EditorPlaceholderExprSyntax("display name"))""#)
+            ])
+         ]
+       )
     ]
   }
 


### PR DESCRIPTION
No functional change: just adds new test cases for the change in #1256



### Motivation:

Slightly improves effective test coverage for Stuart's earlier change.

### Modifications:

* Moved the tests previously added to `apiMisuseErrors` -> `apiMisuseErrorsIncludingFixIts`, and include the expected fixits

  It would probably be ok to leave them in `apiMisuseErrors` as well, but I think it would be kinda redundant since we also test the expected message along with the fixits already.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
