### PR TITLE
Propagate issue severity from exit test bodies.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -1046,11 +1046,17 @@ extension ExitTest {
         // TODO: improve fidelity of issue kind reporting (especially those without associated values)
         .unconditional
       }
+      let severity: Issue.Severity = switch issue._severity {
+      case .warning:
+        .warning
+      case .error:
+        .error
+      }
       let sourceContext = SourceContext(
         backtrace: nil, // `issue._backtrace` will have the wrong address space.
         sourceLocation: issue.sourceLocation
       )
-      var issueCopy = Issue(kind: issueKind, comments: comments, sourceContext: sourceContext)
+      var issueCopy = Issue(kind: issueKind, severity: severity, comments: comments, sourceContext: sourceContext)
       if issue.isKnown {
         // The known issue comment, if there was one, is already included in
         // the `comments` array above.

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -383,6 +383,26 @@ private import _TestingInternals
     }
   }
 
+  @Test("Issue severity")
+  func issueSeverity() async {
+    await confirmation("Recorded issue had warning severity") { wasWarning in
+      var configuration = Configuration()
+      configuration.eventHandler = { event, _ in
+        if case let .issueRecorded(issue) = event.kind, issue.severity == .warning {
+          wasWarning()
+        }
+      }
+
+      // Mock an exit test where the process exits successfully.
+      configuration.exitTestHandler = ExitTest.handlerForEntryPoint()
+      await Test {
+        await #expect(processExitsWith: .success) {
+          Issue.record("Issue recorded", severity: .warning)
+        }
+      }.run(configuration: configuration)
+    }
+  }
+
   @Test("Capture list")
   func captureList() async {
     let i = 123


### PR DESCRIPTION
This PR ensures that an issue with `.warning` severity is recorded correctly from within the body of an exit test. For example:

```swift
await #expect(processExitsWith: .success) {
  Issue.record("TODO: implement exit test body", severity: .warning)
}
```

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
