### PR TITLE
Tests link with libutil for openpty on OpenBSD.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -139,7 +139,10 @@ let package = Package(
         "_Testing_WinSDK",
         "MemorySafeTestingTests",
       ],
-      swiftSettings: .packageSettings
+      swiftSettings: .packageSettings,
+      linkerSettings: [
+        .linkedLibrary("util", .when(platforms: [.openbsd]))
+      ]
     ),
 
     // Use a plain `.target` instead of a `.testTarget` to avoid the unnecessary


### PR DESCRIPTION
One of the tests refers to openpty, which requires linking with libutil on OpenBSD.

### Motivation:

swift test on the project has a link failure on OpenBSD.

### Modifications:

Add the libutil linker flag in Package.swift

### Checklist:

- [X] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [X] If public symbols are renamed or modified, DocC references should be updated. ***(not required).***
