### PR TITLE
Clarify note about supported target types in "Defining test functions" article

### DIFF
--- a/Sources/Testing/Testing.docc/DefiningTests.md
+++ b/Sources/Testing/Testing.docc/DefiningTests.md
@@ -25,8 +25,9 @@ contains the test:
 import Testing
 ```
 
-- Note: Only import the testing library into a test target. Importing the
-  testing library into an application, library, or binary target isn't
+- Note: Only import the testing library into a test target or library meant for
+  test targets. Importing the testing library into a target intended for
+  distribution such as an application, app library, or executable target isn't
   supported or recommended. Test functions aren't stripped from binaries when
   building for release, so logic and fixtures of a test may be visible to anyone
   who inspects a build product that contains a test function.


### PR DESCRIPTION
This adjusts the wording of a `- Note:` in our [Defining test functions](https://developer.apple.com/documentation/testing/definingtests) documentation article which advises that users only import the testing library in test targets. It expands the kinds of supported targets to include "library targets meant for test targets", which is a supported use case.

### Motivation:

The wording should not imply that it's _never_ supported to vend a library which extends the testing library. There is an important distinction between libraries which are distributed to end users (e.g. those bundles within apps or alongside executables) vs. libraries intended solely to support test targets or other testing libraries.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
