### PR TITLE
[EXPERIMENTAL] `XCTSkip` interop with test cancellation.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -1076,9 +1076,9 @@ extension ExitTest {
     } else if let attachment = event.attachment {
       Attachment.record(attachment, sourceLocation: event._sourceLocation!)
     } else if case .testCancelled = event.kind {
-      _ = try? Test.cancel(with: skipInfo)
+      Test.cancel(with: skipInfo)
     } else if case .testCaseCancelled = event.kind {
-      _ = try? Test.Case.cancel(with: skipInfo)
+      Test.Case.cancel(with: skipInfo)
     }
   }
 


### PR DESCRIPTION
This PR adds a small amount of interop between Swift Testing and XCTest so that, if a test throws an error of type `XCTSkip`, it is treated as if the test were cancelled.

Additional changes will be needed in XCTest and corelibs-xctest to fully implement this functionality.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
