### PR TITLE
Lower more experimental JSON fields.

### DIFF
--- a/Sources/Testing/ABI/ABI.Record.swift
+++ b/Sources/Testing/ABI/ABI.Record.swift
@@ -36,6 +36,10 @@ extension ABI {
       guard let event = EncodedEvent<V>(encoding: event, in: eventContext, messages: messages) else {
         return nil
       }
+      if !V.includesExperimentalFields && event.kind.rawValue.first == "_" {
+        // Don't encode experimental event kinds.
+        return nil
+      }
       kind = .event(event)
     }
   }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -41,7 +41,7 @@ extension ABI {
     init(encoding attachment: borrowing Attachment<AnyAttachable>, in eventContext: borrowing Event.Context) {
       path = attachment.fileSystemPath
 
-      if V.versionNumber >= ABI.v6_3.versionNumber {
+      if V.includesExperimentalFields {
         _preferredName = attachment.preferredName
 
         if path == nil {

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -112,31 +112,22 @@ extension ABI {
       case let .issueRecorded(recordedIssue):
         kind = .issueRecorded
         issue = EncodedIssue(encoding: recordedIssue, in: eventContext)
-        _comments = recordedIssue.comments.map(\.rawValue)
-        _sourceLocation = recordedIssue.sourceLocation
       case let .valueAttached(attachment):
         kind = .valueAttached
         self.attachment = EncodedAttachment(encoding: attachment, in: eventContext)
-        _sourceLocation = attachment.sourceLocation
       case .testCaseEnded:
         if eventContext.test?.isParameterized == false {
           return nil
         }
         kind = .testCaseEnded
-      case let .testCaseCancelled(skipInfo):
+      case .testCaseCancelled:
         kind = .testCaseCancelled
-        _comments = Array(skipInfo.comment).map(\.rawValue)
-        _sourceLocation = skipInfo.sourceLocation
       case .testEnded:
         kind = .testEnded
-      case let .testSkipped(skipInfo):
+      case .testSkipped:
         kind = .testSkipped
-        _comments = Array(skipInfo.comment).map(\.rawValue)
-        _sourceLocation = skipInfo.sourceLocation
-      case let .testCancelled(skipInfo):
+      case .testCancelled:
         kind = .testCancelled
-        _comments = Array(skipInfo.comment).map(\.rawValue)
-        _sourceLocation = skipInfo.sourceLocation
       case .runEnded:
         kind = .runEnded
       default:
@@ -148,6 +139,21 @@ extension ABI {
 
       // Experimental fields
       if V.includesExperimentalFields {
+        switch event.kind {
+        case let .issueRecorded(recordedIssue):
+          _comments = recordedIssue.comments.map(\.rawValue)
+          _sourceLocation = recordedIssue.sourceLocation
+        case let .valueAttached(attachment):
+          _sourceLocation = attachment.sourceLocation
+        case let .testCaseCancelled(skipInfo),
+          let .testSkipped(skipInfo),
+          let .testCancelled(skipInfo):
+          _comments = Array(skipInfo.comment).map(\.rawValue)
+          _sourceLocation = skipInfo.sourceLocation
+        default:
+          break
+        }
+
         if eventContext.test?.isParameterized == true {
           _testCase = eventContext.testCase.map(EncodedTestCase.init)
         }


### PR DESCRIPTION
This PR suppresses more experimental JSON fields if they aren't supposed to be included in the current JSON event stream version:

- All experimental event kinds.
- Attachments' preferred names and bytes/contents.
- Hoisted comments and source locations for all event kinds.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
