### PR TITLE
Add task names to structured tasks we create.

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(Testing
   Support/Additions/CommandLineAdditions.swift
   Support/Additions/NumericAdditions.swift
   Support/Additions/ResultAdditions.swift
+  Support/Additions/TaskAdditions.swift
   Support/Additions/WinSDKAdditions.swift
   Support/CartesianProduct.swift
   Support/CError.swift

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -187,6 +187,26 @@ private func _capitalizedTitle(for test: Test?) -> String {
   test?.isSuite == true ? "Suite" : "Test"
 }
 
+extension Test {
+  /// The name to use for this test in a human-readable context such as console
+  /// output.
+  ///
+  /// - Parameters:
+  ///   - verbosity: The verbosity with which to describe this test.
+  ///
+  /// - Returns: The name of this test, suitable for display to the user.
+  func humanReadableName(withVerbosity verbosity: Int = 0) -> String {
+    switch (displayName, verbosity) {
+    case let (.some(displayName), ...0):
+      displayName
+    case let (.some(displayName), _):
+      #""\#(displayName)" (aka '\#(name)')"#
+    default:
+      name
+    }
+  }
+}
+
 extension Test.Case {
   /// The arguments of this test case, formatted for presentation, prefixed by
   /// their corresponding parameter label when available.
@@ -256,19 +276,7 @@ extension Event.HumanReadableOutputRecorder {
     let test = eventContext.test
     let testCase = eventContext.testCase
     let keyPath = eventContext.keyPath
-    let testName = if let test {
-      if let displayName = test.displayName {
-        if verbosity > 0 {
-          "\"\(displayName)\" (aka '\(test.name)')"
-        } else {
-          "\"\(displayName)\""
-        }
-      } else {
-        test.name
-      }
-    } else {
-      "«unknown»"
-    }
+    let testName = test?.humanReadableName(withVerbosity: verbosity) ?? "«unknown»"
     let instant = event.instant
     let iterationCount = eventContext.configuration?.repetitionPolicy.maximumIterationCount
 

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -196,11 +196,11 @@ extension Test {
   ///
   /// - Returns: The name of this test, suitable for display to the user.
   func humanReadableName(withVerbosity verbosity: Int = 0) -> String {
-    switch (displayName, verbosity) {
-    case let (.some(displayName), ...0):
-      displayName
-    case let (.some(displayName), _):
+    switch displayName {
+    case let .some(displayName) where verbosity > 0:
       #""\#(displayName)" (aka '\#(name)')"#
+    case let .some(displayName):
+      #""\#(displayName)""#
     default:
       name
     }

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -955,7 +955,7 @@ extension ExitTest {
         capturedValuesWriteEnd.close()
 
         // Await termination of the child process.
-        taskGroup.addTask(name: "exit test (awaiting termination)") {
+        taskGroup.addTask(name: makeTaskName("exit test (awaiting termination)")) {
           let exitStatus = try await wait(for: processID)
           return { $0.exitStatus = exitStatus }
         }
@@ -963,14 +963,14 @@ extension ExitTest {
         // Read back the stdout and stderr streams.
         if let stdoutReadEnd {
           stdoutWriteEnd?.close()
-          taskGroup.addTask(name: "exit test (reading stdout)") {
+          taskGroup.addTask(name: makeTaskName("exit test (reading stdout)")) {
             let standardOutputContent = try Self._trimToBarrierValues(stdoutReadEnd.readToEnd())
             return { $0.standardOutputContent = standardOutputContent }
           }
         }
         if let stderrReadEnd {
           stderrWriteEnd?.close()
-          taskGroup.addTask(name: "exit test (reading stderr)") {
+          taskGroup.addTask(name: makeTaskName("exit test (reading stderr)")) {
             let standardErrorContent = try Self._trimToBarrierValues(stderrReadEnd.readToEnd())
             return { $0.standardErrorContent = standardErrorContent }
           }
@@ -979,7 +979,7 @@ extension ExitTest {
         // Read back all data written to the back channel by the child process
         // and process it as a (minimal) event stream.
         backChannelWriteEnd.close()
-        taskGroup.addTask(name: "exit test (processing events)") {
+        taskGroup.addTask(name: makeTaskName("exit test (processing events)")) {
           Self._processRecords(fromBackChannel: backChannelReadEnd)
           return nil
         }

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -955,7 +955,7 @@ extension ExitTest {
         capturedValuesWriteEnd.close()
 
         // Await termination of the child process.
-        taskGroup.addTask {
+        taskGroup.addTask(name: "exit test (awaiting termination)") {
           let exitStatus = try await wait(for: processID)
           return { $0.exitStatus = exitStatus }
         }
@@ -963,14 +963,14 @@ extension ExitTest {
         // Read back the stdout and stderr streams.
         if let stdoutReadEnd {
           stdoutWriteEnd?.close()
-          taskGroup.addTask {
+          taskGroup.addTask(name: "exit test (reading stdout)") {
             let standardOutputContent = try Self._trimToBarrierValues(stdoutReadEnd.readToEnd())
             return { $0.standardOutputContent = standardOutputContent }
           }
         }
         if let stderrReadEnd {
           stderrWriteEnd?.close()
-          taskGroup.addTask {
+          taskGroup.addTask(name: "exit test (reading stderr)") {
             let standardErrorContent = try Self._trimToBarrierValues(stderrReadEnd.readToEnd())
             return { $0.standardErrorContent = standardErrorContent }
           }
@@ -979,7 +979,7 @@ extension ExitTest {
         // Read back all data written to the back channel by the child process
         // and process it as a (minimal) event stream.
         backChannelWriteEnd.close()
-        taskGroup.addTask {
+        taskGroup.addTask(name: "exit test (processing events)") {
           Self._processRecords(fromBackChannel: backChannelReadEnd)
           return nil
         }

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -955,7 +955,7 @@ extension ExitTest {
         capturedValuesWriteEnd.close()
 
         // Await termination of the child process.
-        taskGroup.addTask(name: makeTaskName("exit test (awaiting termination)")) {
+        taskGroup.addTask(name: decorateTaskName("exit test", withAction: "awaiting termination")) {
           let exitStatus = try await wait(for: processID)
           return { $0.exitStatus = exitStatus }
         }
@@ -963,14 +963,14 @@ extension ExitTest {
         // Read back the stdout and stderr streams.
         if let stdoutReadEnd {
           stdoutWriteEnd?.close()
-          taskGroup.addTask(name: makeTaskName("exit test (reading stdout)")) {
+          taskGroup.addTask(name: decorateTaskName("exit test", withAction: "reading stdout")) {
             let standardOutputContent = try Self._trimToBarrierValues(stdoutReadEnd.readToEnd())
             return { $0.standardOutputContent = standardOutputContent }
           }
         }
         if let stderrReadEnd {
           stderrWriteEnd?.close()
-          taskGroup.addTask(name: makeTaskName("exit test (reading stderr)")) {
+          taskGroup.addTask(name: decorateTaskName("exit test", withAction: "reading stderr")) {
             let standardErrorContent = try Self._trimToBarrierValues(stderrReadEnd.readToEnd())
             return { $0.standardErrorContent = standardErrorContent }
           }
@@ -979,7 +979,7 @@ extension ExitTest {
         // Read back all data written to the back channel by the child process
         // and process it as a (minimal) event stream.
         backChannelWriteEnd.close()
-        taskGroup.addTask(name: makeTaskName("exit test (processing events)")) {
+        taskGroup.addTask(name: decorateTaskName("exit test", withAction: "processing events")) {
           Self._processRecords(fromBackChannel: backChannelReadEnd)
           return nil
         }

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -213,7 +213,8 @@ extension Runner.Plan {
     // FIXME: Parallelize this work. Calling `prepare(...)` on all traits and
     // evaluating all test arguments should be safely parallelizable.
     (test, result) = await withTaskGroup(returning: (Test, Action).self) { [test] taskGroup in
-      taskGroup.addTask {
+      let taskName = "\(test.humanReadableName()) (evaluating traits)"
+      taskGroup.addTask(name: taskName) {
         var test = test
         var action = _runAction
 

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -213,8 +213,14 @@ extension Runner.Plan {
     // FIXME: Parallelize this work. Calling `prepare(...)` on all traits and
     // evaluating all test arguments should be safely parallelizable.
     (test, result) = await withTaskGroup(returning: (Test, Action).self) { [test] taskGroup in
-      let taskName = "\(test.humanReadableName()) (evaluating traits)"
-      taskGroup.addTask(name: makeTaskName(taskName)) {
+      let testName = test.humanReadableName()
+      let (taskName, taskAction) = if test.isSuite {
+        ("suite \(testName)", "evaluating traits")
+      } else {
+        // TODO: split the task group's single task into two serially-run subtasks
+        ("test \(testName)", "evaluating traits and test cases")
+      }
+      taskGroup.addTask(name: decorateTaskName(taskName, withAction: taskAction)) {
         var test = test
         var action = _runAction
 

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -214,7 +214,7 @@ extension Runner.Plan {
     // evaluating all test arguments should be safely parallelizable.
     (test, result) = await withTaskGroup(returning: (Test, Action).self) { [test] taskGroup in
       let taskName = "\(test.humanReadableName()) (evaluating traits)"
-      taskGroup.addTask(name: taskName) {
+      taskGroup.addTask(name: makeTaskName(taskName)) {
         var test = test
         var action = _runAction
 

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -8,6 +8,23 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+/// Make a (decorated) task name from the given undecorated task name.
+///
+/// - Parameters:
+///   - taskName: The undecorated task name to modify.
+///
+/// - Returns: A copy of `taskName` with a common prefix applied, or `nil` if
+///   `taskName` was `nil`.
+func makeTaskName(_ taskName: String?) -> String? {
+  let prefix = "[Swift Testing]"
+  return taskName.map { taskName in
+#if DEBUG
+    precondition(!taskName.hasPrefix(prefix), "Applied prefix '\(prefix)' to task name '\(taskName)' twice. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
+#endif
+    return "\(prefix) \(taskName)"
+  }
+}
+
 /// A type that runs tests according to a given configuration.
 @_spi(ForToolsIntegrationOnly)
 public struct Runner: Sendable {
@@ -162,7 +179,8 @@ extension Runner {
     try await withThrowingTaskGroup { taskGroup in
       for element in sequence {
         // Each element gets its own subtask to run in.
-        taskGroup.addTask(name: taskNamer(element)) {
+        let taskName = taskNamer(element)
+        taskGroup.addTask(name: makeTaskName(taskName)) {
           try await body(element)
         }
 
@@ -442,12 +460,12 @@ extension Runner {
         }
 
         await withTaskGroup { [runner] taskGroup in
-          let taskName = if iterationCount > 1 {
+          var taskName = if iterationCount > 1 {
             "test run (iteration #\(iterationIndex + 1))"
           } else {
             "test run"
           }
-          _ = taskGroup.addTaskUnlessCancelled(name: taskName) {
+          _ = taskGroup.addTaskUnlessCancelled(name: makeTaskName(taskName)) {
             try? await _runStep(atRootOf: runner.plan.stepGraph)
           }
           await taskGroup.waitForAll()

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -320,7 +320,13 @@ extension Runner {
 
     // Figure out how to name child tasks.
     func taskNamer(_ childGraph: Graph<String, Plan.Step?>) -> String? {
-      childGraph.value.map { $0.test.humanReadableName() }
+      childGraph.value.map { step in
+        let testName = step.test.humanReadableName()
+        if step.test.isSuite {
+          return "suite \(testName)"
+        }
+        return "test \(testName)"
+      }
     }
 
     // Run the child nodes.

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -149,9 +149,9 @@ extension Runner {
   ///
   /// - Parameters:
   ///   - sequence: The sequence to enumerate.
-  ///   - body: The function to invoke.
   ///   - taskNamer: A function to invoke for each element in `sequence`. The
   ///     result of this function is used to name each child task.
+  ///   - body: The function to invoke.
   ///
   /// - Throws: Whatever is thrown by `body`.
   private static func _forEach<E>(

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -167,7 +167,7 @@ extension Runner {
   /// - Parameters:
   ///   - sequence: The sequence to enumerate.
   ///   - body: The function to invoke.
-  ///   - elementNamer: A function to invoke for each element in `sequence`. The
+  ///   - taskNamer: A function to invoke for each element in `sequence`. The
   ///     result of this function is used to name each child task.
   ///
   /// - Throws: Whatever is thrown by `body`.

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -8,23 +8,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-/// Make a (decorated) task name from the given undecorated task name.
-///
-/// - Parameters:
-///   - taskName: The undecorated task name to modify.
-///
-/// - Returns: A copy of `taskName` with a common prefix applied, or `nil` if
-///   `taskName` was `nil`.
-func makeTaskName(_ taskName: String?) -> String? {
-  let prefix = "[Swift Testing]"
-  return taskName.map { taskName in
-#if DEBUG
-    precondition(!taskName.hasPrefix(prefix), "Applied prefix '\(prefix)' to task name '\(taskName)' twice. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
-#endif
-    return "\(prefix) \(taskName)"
-  }
-}
-
 /// A type that runs tests according to a given configuration.
 @_spi(ForToolsIntegrationOnly)
 public struct Runner: Sendable {

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -449,7 +449,7 @@ extension Runner {
         }
 
         await withTaskGroup { [runner] taskGroup in
-          var taskName = if iterationCount > 1 {
+          let taskName = if iterationCount > 1 {
             "test run (iteration #\(iterationIndex + 1))"
           } else {
             "test run"

--- a/Sources/Testing/Support/Additions/TaskAdditions.swift
+++ b/Sources/Testing/Support/Additions/TaskAdditions.swift
@@ -15,12 +15,13 @@
 ///
 /// - Returns: A copy of `taskName` with a common prefix applied, or `nil` if
 ///   `taskName` was `nil`.
-func makeTaskName(_ taskName: String?) -> String? {
+func decorateTaskName(_ taskName: String?, withAction action: String?) -> String? {
   let prefix = "[Swift Testing]"
   return taskName.map { taskName in
 #if DEBUG
     precondition(!taskName.hasPrefix(prefix), "Applied prefix '\(prefix)' to task name '\(taskName)' twice. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
 #endif
-    return "\(prefix) \(taskName)"
+    let action = action.map { " - \($0)" } ?? ""
+    return "\(prefix) \(taskName)\(action)"
   }
 }

--- a/Sources/Testing/Support/Additions/TaskAdditions.swift
+++ b/Sources/Testing/Support/Additions/TaskAdditions.swift
@@ -1,0 +1,26 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// Make a (decorated) task name from the given undecorated task name.
+///
+/// - Parameters:
+///   - taskName: The undecorated task name to modify.
+///
+/// - Returns: A copy of `taskName` with a common prefix applied, or `nil` if
+///   `taskName` was `nil`.
+func makeTaskName(_ taskName: String?) -> String? {
+  let prefix = "[Swift Testing]"
+  return taskName.map { taskName in
+#if DEBUG
+    precondition(!taskName.hasPrefix(prefix), "Applied prefix '\(prefix)' to task name '\(taskName)' twice. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new")
+#endif
+    return "\(prefix) \(taskName)"
+  }
+}

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -90,7 +90,7 @@ extension Test {
         await withTaskGroup { taskGroup in
           for (i, generator) in generators.enumerated() {
             let taskName = "test discovery (#\(i))"
-            taskGroup.addTask(name: taskName) { await generator.rawValue() }
+            taskGroup.addTask(name: makeTaskName(taskName)) { await generator.rawValue() }
           }
           result = await taskGroup.reduce(into: result) { $0.insert($1) }
         }
@@ -103,7 +103,7 @@ extension Test {
         await withTaskGroup { taskGroup in
           for (i, generator) in generators.enumerated() {
             let taskName = "legacy test discovery (#\(i))"
-            taskGroup.addTask(name: taskName) { await generator.rawValue() }
+            taskGroup.addTask(name: makeTaskName(taskName)) { await generator.rawValue() }
           }
           result = await taskGroup.reduce(into: result) { $0.insert($1) }
         }

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -88,8 +88,9 @@ extension Test {
       if useNewMode {
         let generators = Generator.allTestContentRecords().lazy.compactMap { $0.load() }
         await withTaskGroup { taskGroup in
-          for generator in generators {
-            taskGroup.addTask { await generator.rawValue() }
+          for (i, generator) in generators.enumerated() {
+            let taskName = "test discovery (#\(i))"
+            taskGroup.addTask(name: taskName) { await generator.rawValue() }
           }
           result = await taskGroup.reduce(into: result) { $0.insert($1) }
         }
@@ -100,8 +101,9 @@ extension Test {
       if useLegacyMode && result.isEmpty {
         let generators = Generator.allTypeMetadataBasedTestContentRecords().lazy.compactMap { $0.load() }
         await withTaskGroup { taskGroup in
-          for generator in generators {
-            taskGroup.addTask { await generator.rawValue() }
+          for (i, generator) in generators.enumerated() {
+            let taskName = "legacy test discovery (#\(i))"
+            taskGroup.addTask(name: taskName) { await generator.rawValue() }
           }
           result = await taskGroup.reduce(into: result) { $0.insert($1) }
         }

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -102,7 +102,7 @@ extension Test {
         let generators = Generator.allTypeMetadataBasedTestContentRecords().lazy.compactMap { $0.load() }
         await withTaskGroup { taskGroup in
           for (i, generator) in generators.enumerated() {
-            let taskName = "legacy test discovery (#\(i))"
+            let taskName = "type-based test discovery (#\(i))"
             taskGroup.addTask(name: makeTaskName(taskName)) { await generator.rawValue() }
           }
           result = await taskGroup.reduce(into: result) { $0.insert($1) }

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -89,8 +89,9 @@ extension Test {
         let generators = Generator.allTestContentRecords().lazy.compactMap { $0.load() }
         await withTaskGroup { taskGroup in
           for (i, generator) in generators.enumerated() {
-            let taskName = "test discovery (#\(i))"
-            taskGroup.addTask(name: makeTaskName(taskName)) { await generator.rawValue() }
+            taskGroup.addTask(name: decorateTaskName("test discovery", withAction: "loading test #\(i)")) {
+              await generator.rawValue()
+            }
           }
           result = await taskGroup.reduce(into: result) { $0.insert($1) }
         }
@@ -102,8 +103,9 @@ extension Test {
         let generators = Generator.allTypeMetadataBasedTestContentRecords().lazy.compactMap { $0.load() }
         await withTaskGroup { taskGroup in
           for (i, generator) in generators.enumerated() {
-            let taskName = "type-based test discovery (#\(i))"
-            taskGroup.addTask(name: makeTaskName(taskName)) { await generator.rawValue() }
+            taskGroup.addTask(name: decorateTaskName("type-based test discovery", withAction: "loading test #\(i)")) {
+              await generator.rawValue()
+            }
           }
           result = await taskGroup.reduce(into: result) { $0.insert($1) }
         }

--- a/Sources/Testing/Traits/TimeLimitTrait.swift
+++ b/Sources/Testing/Traits/TimeLimitTrait.swift
@@ -263,7 +263,7 @@ struct TimeoutError: Error, CustomStringConvertible {
 /// Invoke a function with a timeout.
 ///
 /// - Parameters:
-///   - taskName: The name of the child task that runs `body`.
+///   - taskName: The name of the child task that runs `body`, if any.
 ///   - timeLimit: The amount of time until the closure times out.
 ///   - body: The function to invoke.
 ///   - timeoutHandler: A function to invoke if `body` times out.

--- a/Sources/Testing/Traits/TimeLimitTrait.swift
+++ b/Sources/Testing/Traits/TimeLimitTrait.swift
@@ -284,14 +284,14 @@ func withTimeLimit(
 ) async throws {
   try await withThrowingTaskGroup { group in
     let timeoutHandlerTaskName = taskName.map { "\($0) (timeout handler)" }
-    group.addTask(name: timeoutHandlerTaskName) {
+    group.addTask(name: makeTaskName(timeoutHandlerTaskName)) {
       // If sleep() returns instead of throwing a CancellationError, that means
       // the timeout was reached before this task could be cancelled, so call
       // the timeout handler.
       try await Test.Clock.sleep(for: timeLimit)
       timeoutHandler()
     }
-    group.addTask(name: taskName, operation: body)
+    group.addTask(name: makeTaskName(taskName), operation: body)
 
     defer {
       group.cancelAll()


### PR DESCRIPTION
This PR sets a task name for every child task created by Swift Testing. These names are useful for debugging.

Example result:

<img width="440" height="132" alt="Screenshot 2025-09-10 at 11 49 42 AM" src="https://github.com/user-attachments/assets/691d7e60-1fdc-4b31-bae7-baa99948123c" />

Resolves #1303.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
