### PR TITLE
build: introduce a new option to control library evolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,14 @@ option(SwiftTesting_INSTALL_NESTED_SUBDIR "Install libraries under a platform an
 set(SwiftTesting_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SwiftTesting_PLATFORM_SUBDIR}$<$<AND:$<PLATFORM_ID:Darwin>,$<NOT:$<BOOL:${SwiftTesting_INSTALL_NESTED_SUBDIR}>>>:/testing>$<$<BOOL:${SwiftTesting_INSTALL_NESTED_SUBDIR}>:/${SwiftTesting_ARCH_SUBDIR}>")
 set(SwiftTesting_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SwiftTesting_PLATFORM_SUBDIR}$<$<AND:$<PLATFORM_ID:Darwin>,$<NOT:$<BOOL:${SwiftTesting_INSTALL_NESTED_SUBDIR}>>>:/testing>")
 
+if(APPLE)
+  set(_SwiftTesting_ENABLE_LIBRARY_EVOLUTION YES)
+else()
+  set(_SwiftTesting_ENABLE_LIBRARY_EVOLUTION NO)
+endif()
+option(SwiftTesting_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime libraries"
+  ${_SwiftTesting_ENABLE_LIBRARY_EVOLUTION})
+
 add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-no-toolchain-stdlib-rpath>)
 
 add_subdirectory(Sources)

--- a/Sources/Overlays/_Testing_Foundation/CMakeLists.txt
+++ b/Sources/Overlays/_Testing_Foundation/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(_Testing_Foundation
   ReexportTesting.swift)
 
 target_link_libraries(_Testing_Foundation PUBLIC
+  _TestingInternals
   Testing)
 
 # Although this library links Foundation on all platforms, it only does so using
@@ -35,6 +36,7 @@ endif()
 # interface, because Foundation does not have Library Evolution enabled for all
 # platforms.
 target_compile_options(_Testing_Foundation PRIVATE
-  -emit-module-interface -emit-module-interface-path $<TARGET_PROPERTY:_Testing_Foundation,Swift_MODULE_DIRECTORY>/_Testing_Foundation.swiftinterface)
+  -emit-module-interface
+  -emit-module-interface-path $<TARGET_PROPERTY:_Testing_Foundation,Swift_MODULE_DIRECTORY>/_Testing_Foundation.swiftinterface)
 
 _swift_testing_install_target(_Testing_Foundation)

--- a/Sources/Overlays/_Testing_WinSDK/CMakeLists.txt
+++ b/Sources/Overlays/_Testing_WinSDK/CMakeLists.txt
@@ -22,11 +22,15 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     ReexportTesting.swift)
 
   target_link_libraries(_Testing_WinSDK PUBLIC
+    _TestingInternals
     Testing)
 
-  target_compile_options(_Testing_WinSDK PRIVATE
-    -enable-library-evolution
-    -emit-module-interface -emit-module-interface-path $<TARGET_PROPERTY:_Testing_WinSDK,Swift_MODULE_DIRECTORY>/_Testing_WinSDK.swiftinterface)
+  if(SwiftTesting_ENABLE_LIBRARY_EVOLUTION)
+    target_compile_options(_Testing_WinSDK PRIVATE
+      -enable-library-evolution
+      -emit-module-interface
+      -emit-module-interface-path $<TARGET_PROPERTY:_Testing_WinSDK,Swift_MODULE_DIRECTORY>/_Testing_WinSDK.swiftinterface)
+  endif()
 
   _swift_testing_install_target(_Testing_WinSDK)
 endif()

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -136,9 +136,13 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 add_dependencies(Testing
   TestingMacros)
-target_compile_options(Testing PRIVATE
-  -enable-library-evolution
-  -emit-module-interface -emit-module-interface-path $<TARGET_PROPERTY:Testing,Swift_MODULE_DIRECTORY>/Testing.swiftinterface)
+
+if(SwiftTesting_ENABLE_LIBRARY_EVOLUTION)
+  target_compile_options(Testing PRIVATE
+    -enable-library-evolution
+    -emit-module-interface
+    -emit-module-interface-path $<TARGET_PROPERTY:Testing,Swift_MODULE_DIRECTORY>/Testing.swiftinterface)
+endif()
 
 _swift_testing_install_target(Testing)
 

--- a/Sources/_TestDiscovery/CMakeLists.txt
+++ b/Sources/_TestDiscovery/CMakeLists.txt
@@ -16,9 +16,12 @@ add_library(_TestDiscovery STATIC
 target_link_libraries(_TestDiscovery PRIVATE
   _TestingInternals)
 
-target_compile_options(_TestDiscovery PRIVATE
-  -enable-library-evolution
-  -emit-module-interface -emit-module-interface-path $<TARGET_PROPERTY:_TestDiscovery,Swift_MODULE_DIRECTORY>/_TestDiscovery.swiftinterface)
+if(SwiftTesting_ENABLE_LIBRARY_EVOLUTION)
+  target_compile_options(_TestDiscovery PRIVATE
+    -enable-library-evolution
+    -emit-module-interface
+    -emit-module-interface-path $<TARGET_PROPERTY:_TestDiscovery,Swift_MODULE_DIRECTORY>/_TestDiscovery.swiftinterface)
+endif()
 set(CMAKE_STATIC_LIBRARY_PREFIX_Swift "lib")
 
 _swift_testing_install_target(_TestDiscovery)

--- a/cmake/modules/SwiftModuleInstallation.cmake
+++ b/cmake/modules/SwiftModuleInstallation.cmake
@@ -26,9 +26,15 @@ function(_swift_testing_install_target module)
   install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
     DESTINATION "${module_dir}"
     RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftdoc)
-  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftinterface
-    DESTINATION "${module_dir}"
-    RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftinterface)
+  if(SwiftTesting_ENABLE_LIBRARY_EVOLUTION)
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftinterface
+      DESTINATION "${module_dir}"
+      RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftinterface)
+  else()
+    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+      DESTINATION "${module_dir}"
+      RENAME ${SwiftTesting_MODULE_TRIPLE}.swiftmodule)
+  endif()
 endfunction()
 
 # Install the specified .swiftcrossimport directory for the specified declaring


### PR DESCRIPTION
Library evolution only makes sense on platforms where ABI stability is available. Introduce a new option which defaults to `TRUE` only on Darwin, the only platform currently providing ABI stability.