### PR TITLE
Disable the API breakage check in GitHub Actions.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,4 +27,4 @@ jobs:
       docs_check_enabled: false
       unacceptable_language_check_enabled: false
       format_check_enabled: false
-      api_breakage_check_container_image: swift:nightly-main-jammy
+      api_breakage_check_enabled: false


### PR DESCRIPTION
Disable the API breakage check in GitHub Actions. We are not targetting the 6.1 toolchain, so we aren't worried about API breakage when built against it.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
