### PR TITLE
Add a stub update-version.yml file for testing.

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,12 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2025 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+name: Update Swift Testing version
+
+on:
+  pull_request:

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -10,3 +10,5 @@ name: Update Swift Testing version
 
 on:
   pull_request:
+
+jobs:


### PR DESCRIPTION
GitHub Action workflows can't be tested until they exist on main in some form. This PR adds an empty copy of update-version.yml in order to allow me to test it. (We can delete this file if we don't move forward with merging the actual workflow.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
