### PR TITLE
OpenBSD needs execinfo as well.

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -124,7 +124,8 @@ if(NOT APPLE)
   endif()
   target_link_libraries(Testing PUBLIC
     Foundation)
-  if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR
+      CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     target_link_libraries(Testing PUBLIC execinfo)
   endif()
 endif()


### PR DESCRIPTION
Add OpenBSD to the CMake clause that adds libexecinfo.

### Motivation:

`swift test` fails on some projects with `ld: error: undefined reference due to --no-allow-shlib-undefined: backtrace`; `backtrace` is provided by `libexecinfo` on OpenBSD.

### Modifications:

Add OpenBSD to the CMake clause that adds libexecinfo.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
