### PR TITLE
Revert "[CI] Add Amazon Linux 2 in PR testing (#1322)"

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,6 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.2"]'
-      linux_os_versions: '["amazonlinux2", "jammy"]'
       windows_swift_versions: '["nightly-main", "nightly-6.2"]'
       enable_macos_checks: true
       macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.2\"}, {\"xcode_version\": \"16.3\"}]"


### PR DESCRIPTION
This reverts commit 2e4f1a59c3422638d2b2e04352633341ace15028.

Amazon Linux 2 jobs are failing in exit tests with signal 4 (`SIGILL`?) Disabling for now while we figure out the root cause.