### PR TITLE
Exclude Xcode 16.4 from GitHub Actions.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
       linux_os_versions: '["amazonlinux2", "jammy"]'
       windows_swift_versions: '["nightly-main", "nightly-6.2"]'
       enable_macos_checks: true
-      macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.2\"}, {\"xcode_version\": \"16.3\"}]"
+      macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.2\"}, {\"xcode_version\": \"16.3\"}, {\"xcode_version\": \"16.4\"}]"
       enable_wasm_sdk_build: true
   soundness:
     name: Soundness


### PR DESCRIPTION
We don't support building with Xcode 16.4 which only has Swift 6.1.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
