### PR TITLE
Change the semantics of `Test.cancel()`.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -762,7 +762,7 @@ extension ExitTest {
     }
     configuration.eventHandler = { event, eventContext in
       switch event.kind {
-      case .issueRecorded, .valueAttached, .testCancelled, .testCaseCancelled:
+      case .issueRecorded, .valueAttached, .testCancelled:
         eventHandler(event, eventContext)
       default:
         // Don't forward other kinds of event.
@@ -1070,8 +1070,6 @@ extension ExitTest {
       Attachment.record(attachment, sourceLocation: event._sourceLocation!)
     } else if case .testCancelled = event.kind {
       _ = try? Test.cancel(with: skipInfo)
-    } else if case .testCaseCancelled = event.kind {
-      _ = try? Test.Case.cancel(with: skipInfo)
     }
   }
 

--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -206,6 +206,7 @@ extension Test {
   static func withCurrent<R>(_ test: Self, perform body: () async throws -> R) async rethrows -> R {
     var runtimeState = Runner.RuntimeState.current ?? .init()
     runtimeState.test = test
+    runtimeState.testCase = nil
     return try await Runner.RuntimeState.$current.withValue(runtimeState) {
       try await test.withCancellationHandling(body)
     }

--- a/Tests/TestingTests/TestCancellationTests.swift
+++ b/Tests/TestingTests/TestCancellationTests.swift
@@ -60,32 +60,11 @@
     }
   }
 
-  @Test func `Cancelling a non-parameterized test via Test.Case.cancel()`() async {
-    await testCancellation(testCancelled: 1, testCaseCancelled: 1) { configuration in
-      await Test {
-        try Test.Case.cancel("Cancelled test")
-      }.run(configuration: configuration)
-    }
-  }
-
   @Test func `Cancelling a test case in a parameterized test`() async {
     await testCancellation(testCaseCancelled: 5, issueRecorded: 5) { configuration in
       await Test(arguments: 0 ..< 10) { i in
         if (i % 2) == 0 {
-          try Test.Case.cancel("\(i) is even!")
-        }
-        Issue.record("\(i) records an issue!")
-      }.run(configuration: configuration)
-    }
-  }
-
-  @Test func `Cancelling an entire parameterized test`() async {
-    await testCancellation(testCancelled: 1, testCaseCancelled: 10) { configuration in
-      // .serialized to ensure that none of the cases complete before the first
-      // one cancels the test.
-      await Test(.serialized, arguments: 0 ..< 10) { i in
-        if i == 0 {
-          try Test.cancel("\(i) cancelled the test")
+          try Test.cancel("\(i) is even!")
         }
         Issue.record("\(i) records an issue!")
       }.run(configuration: configuration)
@@ -176,18 +155,6 @@
       await Test {
         await #expect(processExitsWith: .success) {
           try Test.cancel("Cancelled test")
-        }
-        #expect(Task.isCancelled)
-        try Task.checkCancellation()
-      }.run(configuration: configuration)
-    }
-  }
-
-  @Test func `Cancelling the current test case from within an exit test`() async {
-    await testCancellation(testCancelled: 1, testCaseCancelled: 1) { configuration in
-      await Test {
-        await #expect(processExitsWith: .success) {
-          try Test.Case.cancel("Cancelled test")
         }
         #expect(Task.isCancelled)
         try Task.checkCancellation()


### PR DESCRIPTION
This PR changes the semantics of `Test.cancel()` such that it only cancels the current test case if the current test is parameterized. This PR also removes `Test.Case.cancel()`, but we may opt to add `Test.Case.cancelAll()` or some such in the future to re-add an interface that cancels an entire parameterized test.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
