### PR TITLE
Promote Windows image attachments to API.

### DIFF
--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
@@ -27,9 +27,7 @@ private import ImageIO
 /// |-|-|
 /// | macOS | [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage), [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage), [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage) |
 /// | iOS, watchOS, tvOS, and visionOS | [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage), [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage), [`UIImage`](https://developer.apple.com/documentation/uikit/uiimage) |
-/// @Comment {
 /// | Windows | [`HBITMAP`](https://learn.microsoft.com/en-us/windows/win32/gdi/bitmaps), [`HICON`](https://learn.microsoft.com/en-us/windows/win32/menurc/icons), [`IWICBitmapSource`](https://learn.microsoft.com/en-us/windows/win32/api/wincodec/nn-wincodec-iwicbitmapsource) (including its subclasses declared by Windows Imaging Component) |
-/// }
 ///
 /// You do not generally need to add your own conformances to this protocol. If
 /// you have an image in another format that needs to be attached to a test,

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableImageFormat+UTType.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableImageFormat+UTType.swift
@@ -107,11 +107,7 @@ extension AttachableImageFormat {
     )
     self.init(kind: .systemValue(contentType), encodingQuality: encodingQuality)
   }
-}
 
-@available(_uttypesAPI, *)
-@_spi(Experimental) // STOP: not part of ST-0014
-extension AttachableImageFormat {
   /// Construct an instance of this type with the given path extension and
   /// encoding quality.
   ///
@@ -132,6 +128,10 @@ extension AttachableImageFormat {
   ///   must conform to [`UTType.image`](https://developer.apple.com/documentation/uniformtypeidentifiers/uttype-swift.struct/image).
   /// - On Windows, there must be a corresponding subclass of [`IWICBitmapEncoder`](https://learn.microsoft.com/en-us/windows/win32/api/wincodec/nn-wincodec-iwicbitmapencoder)
   ///   registered with Windows Imaging Component.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public init?(pathExtension: String, encodingQuality: Float = 1.0) {
     let pathExtension = pathExtension.drop { $0 == "." }
 

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableAsIWICBitmapSource.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableAsIWICBitmapSource.swift
@@ -32,7 +32,6 @@ public import WinSDK
 /// You do not generally need to add your own conformances to this protocol. If
 /// you have an image in another format that needs to be attached to a test,
 /// first convert it to an instance of one of the types above.
-@_spi(Experimental)
 public protocol _AttachableByAddressAsIWICBitmapSource {
   /// Create a WIC bitmap source representing an instance of this type at the
   /// given address.
@@ -112,7 +111,10 @@ public protocol _AttachableByAddressAsIWICBitmapSource {
 /// You do not generally need to add your own conformances to this protocol. If
 /// you have an image in another format that needs to be attached to a test,
 /// first convert it to an instance of one of the types above.
-@_spi(Experimental)
+///
+/// @Metadata {
+///   @Available(Swift, introduced: 6.3)
+/// }
 public protocol AttachableAsIWICBitmapSource: _AttachableAsImage, SendableMetatype {
   /// Create a WIC bitmap source representing an instance of this type.
   ///
@@ -120,6 +122,10 @@ public protocol AttachableAsIWICBitmapSource: _AttachableAsImage, SendableMetaty
   ///   The caller is responsible for releasing this image when done with it.
   ///
   /// - Throws: Any error that prevented the creation of the WIC bitmap source.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   func copyAttachableIWICBitmapSource() throws -> UnsafeMutablePointer<IWICBitmapSource>
 
   /// Create a WIC bitmap representing an instance of this type.

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
@@ -9,10 +9,9 @@
 //
 
 #if os(Windows)
-@_spi(Experimental) public import Testing
+public import Testing
 public import WinSDK
 
-@_spi(Experimental)
 extension AttachableImageFormat {
   private static let _encoderPathExtensionsByCLSID = Result<[UInt128: [String]], any Error> {
     var result = [UInt128: [String]]()
@@ -235,6 +234,13 @@ extension AttachableImageFormat {
   ///
   /// For example, if this image format equals ``png``, the value of this
   /// property equals [`CLSID_WICPngEncoder`](https://learn.microsoft.com/en-us/windows/win32/wic/-wic-guids-clsids#wic-guids-and-clsids).
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
+#if compiler(>=6.3) && !SWT_FIXED_84466
+  @_spi(_)
+#endif
   public var encoderCLSID: CLSID {
     switch kind {
     case .png:
@@ -263,6 +269,13 @@ extension AttachableImageFormat {
   /// result is undefined. For a list of image encoder classes supported by WIC,
   /// see the documentation for the [`IWICBitmapEncoder`](https://learn.microsoft.com/en-us/windows/win32/api/wincodec/nn-wincodec-iwicbitmapencoder)
   /// class.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
+#if compiler(>=6.3) && !SWT_FIXED_84466
+  @_spi(_)
+#endif
   public init(encoderCLSID: CLSID, encodingQuality: Float = 1.0) {
     if encoderCLSID == CLSID_WICPngEncoder {
       self = .png
@@ -293,6 +306,10 @@ extension AttachableImageFormat {
   ///   must conform to [`UTType.image`](https://developer.apple.com/documentation/uniformtypeidentifiers/uttype-swift.struct/image).
   /// - On Windows, there must be a corresponding subclass of [`IWICBitmapEncoder`](https://learn.microsoft.com/en-us/windows/win32/api/wincodec/nn-wincodec-iwicbitmapencoder)
   ///   registered with Windows Imaging Component.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public init?(pathExtension: String, encodingQuality: Float = 1.0) {
     let pathExtension = pathExtension.drop { $0 == "." }
 

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/HBITMAP+AttachableAsIWICBitmapSource.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/HBITMAP+AttachableAsIWICBitmapSource.swift
@@ -12,7 +12,6 @@
 private import Testing
 public import WinSDK
 
-@_spi(Experimental)
 extension HBITMAP__: _AttachableByAddressAsIWICBitmapSource {
   public static func _copyAttachableIWICBitmapSource(
     from imageAddress: UnsafeMutablePointer<Self>,

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/HICON+AttachableAsIWICBitmapSource.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/HICON+AttachableAsIWICBitmapSource.swift
@@ -12,7 +12,6 @@
 private import Testing
 public import WinSDK
 
-@_spi(Experimental)
 extension HICON__: _AttachableByAddressAsIWICBitmapSource {
   public static func _copyAttachableIWICBitmapSource(
     from imageAddress: UnsafeMutablePointer<Self>,

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/IWICBitmapSource+AttachableAsIWICBitmapSource.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/IWICBitmapSource+AttachableAsIWICBitmapSource.swift
@@ -34,31 +34,14 @@ public import WinSDK
 /// allows us to reuse code across all subclasses of `IWICBitmapSource`.
 protocol IWICBitmapSourceProtocol: _AttachableByAddressAsIWICBitmapSource {}
 
-@_spi(Experimental)
 extension IWICBitmapSource: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-
-@_spi(Experimental)
 extension IWICBitmap: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-
-@_spi(Experimental)
 extension IWICBitmapClipper: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-
-@_spi(Experimental)
 extension IWICBitmapFlipRotator: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-
-@_spi(Experimental)
 extension IWICBitmapFrameDecode: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-
-@_spi(Experimental)
 extension IWICBitmapScaler: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-
-@_spi(Experimental)
 extension IWICColorTransform: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-
-@_spi(Experimental)
 extension IWICFormatConverter: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-
-@_spi(Experimental)
 extension IWICPlanarFormatConverter: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
 
 // MARK: - Upcasting conveniences
@@ -96,7 +79,6 @@ extension UnsafeMutablePointer where Pointee: IWICBitmapSourceProtocol {
 
 // MARK: - _AttachableByAddressAsIWICBitmapSource implementation
 
-@_spi(Experimental)
 extension IWICBitmapSourceProtocol {
   public static func _copyAttachableIWICBitmapSource(
     from imageAddress: UnsafeMutablePointer<Self>,
@@ -120,7 +102,6 @@ extension IWICBitmapSourceProtocol {
 }
 
 extension IWICBitmapSource {
-  @_spi(Experimental)
   public static func _copyAttachableIWICBitmapSource(
     from imageAddress: UnsafeMutablePointer<Self>,
     using factory: UnsafeMutablePointer<IWICImagingFactory>

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/UnsafeMutablePointer+AttachableAsIWICBitmapSource.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/UnsafeMutablePointer+AttachableAsIWICBitmapSource.swift
@@ -12,8 +12,13 @@
 private import Testing
 public import WinSDK
 
-@_spi(Experimental)
+/// @Metadata {
+///   @Available(Swift, introduced: 6.3)
+/// }
 extension UnsafeMutablePointer: _AttachableAsImage, AttachableAsIWICBitmapSource where Pointee: _AttachableByAddressAsIWICBitmapSource {
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public func copyAttachableIWICBitmapSource() throws -> UnsafeMutablePointer<IWICBitmapSource> {
     let factory = try IWICImagingFactory.create()
     defer {

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/_AttachableImageWrapper+AttachableWrapper.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/_AttachableImageWrapper+AttachableWrapper.swift
@@ -9,10 +9,9 @@
 //
 
 #if os(Windows)
-@_spi(Experimental) public import Testing
+public import Testing
 private import WinSDK
 
-@_spi(Experimental)
 extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: AttachableAsIWICBitmapSource {
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<_AttachableImageWrapper>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     // Create an in-memory stream to write the image data to. Note that Windows

--- a/Sources/Overlays/_Testing_WinSDK/ReexportTesting.swift
+++ b/Sources/Overlays/_Testing_WinSDK/ReexportTesting.swift
@@ -8,4 +8,4 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@_exported @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import Testing
+@_exported public import Testing

--- a/Sources/Testing/Attachments/Images/AttachableImageFormat.swift
+++ b/Sources/Testing/Attachments/Images/AttachableImageFormat.swift
@@ -23,15 +23,14 @@
 /// - On Apple platforms, you can use [`CGImageDestinationCopyTypeIdentifiers()`](https://developer.apple.com/documentation/imageio/cgimagedestinationcopytypeidentifiers())
 ///   from the [Image I/O framework](https://developer.apple.com/documentation/imageio)
 ///   to determine which formats are supported.
-/// @Comment {
 /// - On Windows, you can use [`IWICImagingFactory.CreateComponentEnumerator()`](https://learn.microsoft.com/en-us/windows/win32/api/wincodec/nf-wincodec-iwicimagingfactory-createcomponentenumerator)
 ///   to enumerate the available image encoders.
-/// }
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
 /// }
 #if SWT_NO_IMAGE_ATTACHMENTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
 #endif
 @available(_uttypesAPI, *)
@@ -81,6 +80,7 @@ public struct AttachableImageFormat: Sendable {
 // MARK: -
 
 #if SWT_NO_IMAGE_ATTACHMENTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
 #endif
 @available(_uttypesAPI, *)

--- a/Sources/Testing/Attachments/Images/Attachment+_AttachableAsImage.swift
+++ b/Sources/Testing/Attachments/Images/Attachment+_AttachableAsImage.swift
@@ -9,6 +9,7 @@
 //
 
 #if SWT_NO_IMAGE_ATTACHMENTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
 #endif
 @available(_uttypesAPI, *)
@@ -32,9 +33,7 @@ extension Attachment {
   /// |-|-|
   /// | macOS | [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage), [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage), [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage) |
   /// | iOS, watchOS, tvOS, and visionOS | [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage), [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage), [`UIImage`](https://developer.apple.com/documentation/uikit/uiimage) |
-  /// @Comment {
   /// | Windows | [`HBITMAP`](https://learn.microsoft.com/en-us/windows/win32/gdi/bitmaps), [`HICON`](https://learn.microsoft.com/en-us/windows/win32/menurc/icons), [`IWICBitmapSource`](https://learn.microsoft.com/en-us/windows/win32/api/wincodec/nn-wincodec-iwicbitmapsource) (including its subclasses declared by Windows Imaging Component) |
-  /// }
   ///
   /// The testing library uses the image format specified by `imageFormat`. Pass
   /// `nil` to let the testing library decide which image format to use. If you
@@ -75,9 +74,7 @@ extension Attachment {
   /// |-|-|
   /// | macOS | [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage), [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage), [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage) |
   /// | iOS, watchOS, tvOS, and visionOS | [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage), [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage), [`UIImage`](https://developer.apple.com/documentation/uikit/uiimage) |
-  /// @Comment {
   /// | Windows | [`HBITMAP`](https://learn.microsoft.com/en-us/windows/win32/gdi/bitmaps), [`HICON`](https://learn.microsoft.com/en-us/windows/win32/menurc/icons), [`IWICBitmapSource`](https://learn.microsoft.com/en-us/windows/win32/api/wincodec/nn-wincodec-iwicbitmapsource) (including its subclasses declared by Windows Imaging Component) |
-  /// }
   ///
   /// The testing library uses the image format specified by `imageFormat`. Pass
   /// `nil` to let the testing library decide which image format to use. If you
@@ -105,6 +102,7 @@ extension Attachment {
 
 @_spi(Experimental) // STOP: not part of ST-0014
 #if SWT_NO_IMAGE_ATTACHMENTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
 #endif
 @available(_uttypesAPI, *)

--- a/Sources/Testing/Attachments/Images/ImageAttachmentError.swift
+++ b/Sources/Testing/Attachments/Images/ImageAttachmentError.swift
@@ -12,6 +12,7 @@ private import _TestingInternals
 
 /// A type representing an error that can occur when attaching an image.
 #if SWT_NO_IMAGE_ATTACHMENTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
 #endif
 package enum ImageAttachmentError: Error {
@@ -43,6 +44,7 @@ package enum ImageAttachmentError: Error {
 }
 
 #if SWT_NO_IMAGE_ATTACHMENTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
 #endif
 extension ImageAttachmentError: CustomStringConvertible {

--- a/Sources/Testing/Attachments/Images/_AttachableAsImage.swift
+++ b/Sources/Testing/Attachments/Images/_AttachableAsImage.swift
@@ -27,6 +27,7 @@
 ///   that we don't need to underscore its name.
 /// }
 #if SWT_NO_IMAGE_ATTACHMENTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
 #endif
 @available(_uttypesAPI, *)

--- a/Sources/Testing/Attachments/Images/_AttachableImageWrapper.swift
+++ b/Sources/Testing/Attachments/Images/_AttachableImageWrapper.swift
@@ -17,10 +17,9 @@
 /// |-|-|
 /// | macOS | [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage), [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage), [`NSImage`](https://developer.apple.com/documentation/appkit/nsimage) |
 /// | iOS, watchOS, tvOS, and visionOS | [`CGImage`](https://developer.apple.com/documentation/coregraphics/cgimage), [`CIImage`](https://developer.apple.com/documentation/coreimage/ciimage), [`UIImage`](https://developer.apple.com/documentation/uikit/uiimage) |
-/// @Comment {
 /// | Windows | [`HBITMAP`](https://learn.microsoft.com/en-us/windows/win32/gdi/bitmaps), [`HICON`](https://learn.microsoft.com/en-us/windows/win32/menurc/icons), [`IWICBitmapSource`](https://learn.microsoft.com/en-us/windows/win32/api/wincodec/nn-wincodec-iwicbitmapsource) (including its subclasses declared by Windows Imaging Component) |
-/// }
 #if SWT_NO_IMAGE_ATTACHMENTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
 #endif
 @available(_uttypesAPI, *)
@@ -42,6 +41,7 @@ public final class _AttachableImageWrapper<Image>: Sendable where Image: _Attach
 }
 
 #if SWT_NO_IMAGE_ATTACHMENTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
 #endif
 @available(_uttypesAPI, *)

--- a/Sources/Testing/Testing.docc/Attachments.md
+++ b/Sources/Testing/Testing.docc/Attachments.md
@@ -34,9 +34,10 @@ protocol to create your own attachable types.
 
 ### Attaching images to tests
 
-- ``AttachableImageFormat``
 <!-- TODO: set up DocC content for overlays if possible
 - ``AttachableAsCGImage``
+- ``AttachableAsIWICBitmapSource``
+-->
+- ``AttachableImageFormat``
 - ``Attachment/init(_:named:as:sourceLocation:)``
 - ``Attachment/record(_:named:as:sourceLocation:)``
--->


### PR DESCRIPTION
Remove `@_spi` and adjust documentation as needed now that [ST-0015](https://forums.swift.org/t/st-0015-image-attachments-in-swift-testing-windows/82241) has been approved.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
