### PR TITLE
Remove `@_spi(Experimental)` from `ExitTest.CapturedValue`.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.CapturedValue.swift
+++ b/Sources/Testing/ExitTests/ExitTest.CapturedValue.swift
@@ -10,7 +10,7 @@
 
 private import _TestingInternals
 
-@_spi(Experimental) @_spi(ForToolsIntegrationOnly)
+@_spi(ForToolsIntegrationOnly)
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif

--- a/Sources/Testing/ExitTests/ExitTest.Condition.swift
+++ b/Sources/Testing/ExitTests/ExitTest.Condition.swift
@@ -176,7 +176,6 @@ extension ExitTest.Condition {
 
 // MARK: - CustomStringConvertible
 
-@_spi(Experimental)
 #if SWT_NO_EXIT_TESTS
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -128,7 +128,7 @@ public struct ExitTest: Sendable, ~Copyable {
   ///
   /// The order of values in this array must be the same between the parent and
   /// child processes.
-  @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
+  @_spi(ForToolsIntegrationOnly)
   public var capturedValues = [CapturedValue]()
 
   /// Make a copy of this instance.


### PR DESCRIPTION
These symbols should be `@_spi(ForToolsIntegrationOnly)` but are no longer considered experimental.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
