### PR TITLE
Mark exit tests unavailable in Embedded Swift.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.CapturedValue.swift
+++ b/Sources/Testing/ExitTests/ExitTest.CapturedValue.swift
@@ -12,6 +12,7 @@ private import _TestingInternals
 
 @_spi(ForToolsIntegrationOnly)
 #if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 extension ExitTest {

--- a/Sources/Testing/ExitTests/ExitTest.Condition.swift
+++ b/Sources/Testing/ExitTests/ExitTest.Condition.swift
@@ -11,6 +11,7 @@
 private import _TestingInternals
 
 #if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 extension ExitTest {
@@ -58,6 +59,7 @@ extension ExitTest {
 // MARK: -
 
 #if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 extension ExitTest.Condition {
@@ -177,6 +179,7 @@ extension ExitTest.Condition {
 // MARK: - CustomStringConvertible
 
 #if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 extension ExitTest.Condition: CustomStringConvertible {
@@ -199,6 +202,7 @@ extension ExitTest.Condition: CustomStringConvertible {
 // MARK: - Comparison
 
 #if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 extension ExitTest.Condition {

--- a/Sources/Testing/ExitTests/ExitTest.Result.swift
+++ b/Sources/Testing/ExitTests/ExitTest.Result.swift
@@ -9,6 +9,7 @@
 //
 
 #if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 extension ExitTest {

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -35,6 +35,7 @@ private import _TestingInternals
 ///   @Available(Xcode, introduced: 26.0)
 /// }
 #if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 public struct ExitTest: Sendable, ~Copyable {

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -877,6 +877,7 @@ public macro require<R>(
 @freestanding(expression)
 @discardableResult
 #if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 public macro expect(
@@ -924,6 +925,7 @@ public macro expect(
 @freestanding(expression)
 @discardableResult
 #if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
 @available(*, unavailable, message: "Exit tests are not available on this platform.")
 #endif
 public macro require(


### PR DESCRIPTION
For the moment at least, we don't support exit tests in Embedded Swift. We can investigate supporting them in the future.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
