### PR TITLE
Unconditionally conform `Attachment` to `CustomStringConvertible`.

### DIFF
--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -50,15 +50,15 @@ struct AttachmentTests {
     let attachableValue = MySendableAttachable(string: "<!doctype html>")
     let attachment = Attachment(attachableValue, named: "AttachmentTests.saveValue.html")
     #expect(String(describing: attachment).contains(#""\#(attachment.preferredName)""#))
-    #expect(attachment.description.contains("MySendableAttachable("))
+    #expect(String(describing: attachment).contains("MySendableAttachable("))
   }
 
 #if compiler(>=6.3) || !os(Windows) // WORKAROUND: swift-#84184
   @Test func moveOnlyDescription() {
     let attachableValue = MyAttachable(string: "<!doctype html>")
     let attachment = Attachment(attachableValue, named: "AttachmentTests.saveValue.html")
-    #expect(attachment.description.contains(#""\#(attachment.preferredName)""#))
-    #expect(attachment.description.contains("'MyAttachable'"))
+    #expect(String(describing: attachment).contains(#""\#(attachment.preferredName)""#))
+    #expect(String(describing: attachment).contains("'MyAttachable'"))
   }
 #endif
 


### PR DESCRIPTION
This PR adjusts `Attachment`'s conformance to `CustomStringConvertible` such that it conforms even when `AttachableValue` is not `Copyable`. We now check at runtime (by way of protocol shenanigans, of course) whether the attachable value is copyable and, if so, take a different code path than we take if it does not conform.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
