### PR TITLE
Adopt `_CFErrorCopyCallStackReturnAddresses()`.

### DIFF
--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -335,9 +335,8 @@ extension Backtrace {
   ///   when it was created, or `nil` if none was captured. The caller is
   ///   responsible for releasing this object when done.
   ///
-  /// This function was added in an internal Foundation PR
-  /// ([#2678](https://github.pie.apple.com/Cocoa/Foundation/pull/2678)) and is
-  /// not available on older systems.
+  /// This function was added in an internal Foundation PR and is not available
+  /// on older systems.
   private static let _CFErrorCopyCallStackReturnAddresses = symbol(named: "_CFErrorCopyCallStackReturnAddresses").map {
     castCFunction(at: $0, to: (@convention(c) (_ error: any Error) -> Unmanaged<AnyObject>?).self)
   }

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -446,11 +446,15 @@ extension Backtrace {
   @inline(never)
   init?(forFirstThrowOf error: any Error, checkFoundation: Bool = true) {
     if checkFoundation && Self.isFoundationCaptureEnabled {
+#if !hasFeature(Embedded) && SWT_TARGET_OS_APPLE && !SWT_NO_DYNAMIC_LINKING
       if let addresses = Self._CFErrorCopyCallStackReturnAddresses?(error)?.takeRetainedValue() as? [Address] {
         self.init(addresses: addresses)
         return
-      } else if let userInfo = error._userInfo as? [String: Any],
-                let addresses = userInfo["NSCallStackReturnAddresses"] as? [Address], !addresses.isEmpty {
+      }
+#endif
+
+      if let userInfo = error._userInfo as? [String: Any],
+         let addresses = userInfo["NSCallStackReturnAddresses"] as? [Address], !addresses.isEmpty {
         self.init(addresses: addresses)
         return
       }


### PR DESCRIPTION
This PR adopts a Core Foundation function, new in macOS 15.4/etc. and added for us to use, that captures backtraces for `NSError` and `CFError` instances at initialization time and stores them in a sidecar location for consumption by Swift Testing and/or XCTest.

Upstreaming from Apple's fork (rdar://139841808, 508230a + dd7bae2)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
