### PR TITLE
Provide opt-out condition for `sys_signame[]`.

### DIFF
--- a/Sources/Testing/ExitTests/ExitStatus.swift
+++ b/Sources/Testing/ExitTests/ExitStatus.swift
@@ -121,6 +121,7 @@ extension ExitStatus: CustomStringConvertible {
       var signalName: String?
 
 #if SWT_TARGET_OS_APPLE || os(FreeBSD) || os(OpenBSD) || os(Android)
+#if !SWT_NO_SYS_SIGNAME
       // These platforms define sys_signame with a size, which is imported
       // into Swift as a tuple.
       withUnsafeBytes(of: sys_signame) { sys_signame in
@@ -130,6 +131,7 @@ extension ExitStatus: CustomStringConvertible {
           }
         }
       }
+#endif
 #elseif os(Linux)
 #if !SWT_NO_DYNAMIC_LINKING
       signalName = _sigabbrev_np?(signal).flatMap(String.init(validatingCString:))

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -16,7 +16,9 @@ private import _TestingInternals
   @Test("Signal names are reported (where supported)") func signalName() {
     var hasSignalNames = false
 #if SWT_TARGET_OS_APPLE || os(FreeBSD) || os(OpenBSD) || os(Android)
+#if !SWT_NO_SYS_SIGNAME
     hasSignalNames = true
+#endif
 #elseif os(Linux) && !SWT_NO_DYNAMIC_LINKING
     hasSignalNames = (symbol(named: "sigabbrev_np") != nil)
 #endif


### PR DESCRIPTION
This PR adds `SWT_NO_SYS_SIGNAME` which can be set in environments where the [`sys_signame[]`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sys_signame.3.html) array is not available.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
