### PR TITLE
AdvancedConsoleOutputRecorderTests is missing an import of Foundation

### DIFF
--- a/Tests/TestingTests/AdvancedConsoleOutputRecorderTests.swift
+++ b/Tests/TestingTests/AdvancedConsoleOutputRecorderTests.swift
@@ -8,7 +8,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if canImport(Foundation)
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+import Foundation
 
 @Suite("Advanced Console Output Recorder Tests")
 struct AdvancedConsoleOutputRecorderTests {
@@ -237,3 +239,4 @@ struct SimpleTestSuite {
     #expect(Bool(true))
   }
 } 
+#endif


### PR DESCRIPTION
Import `Foundation` in `AdvancedConsoleOutputRecorderTests`.

This is required due to `MemberImportVisibility` although in practice this problem only shows up when building for non-macOS Apple platforms, such as iOS, due to the differing deployment target versions we use for non-macOS platforms.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
