### PR TITLE
Normalize the order in which we specify our Linux/FreeBSD/OpenBSD checks.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -361,7 +361,7 @@ extension Event.HumanReadableOutputRecorder {
           comments.append("Swift Standard Library Version: \(swiftStandardLibraryVersion)")
         }
         comments.append("Swift Compiler Version: \(swiftCompilerVersion)")
-#if canImport(Glibc) && !os(FreeBSD) && !os(OpenBSD)
+#if os(Linux) && canImport(Glibc)
         comments.append("GNU C Library Version: \(glibcVersion)")
 #endif
       }

--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -137,7 +137,7 @@ func spawnExecutable(
             // standardized in POSIX.1-2024 (see https://pubs.opengroup.org/onlinepubs/9799919799/functions/posix_spawn_file_actions_adddup2.html
             // and https://www.austingroupbugs.net/view.php?id=411).
             _ = posix_spawn_file_actions_adddup2(fileActions, fd, fd)
-#if canImport(Glibc) && !os(FreeBSD) && !os(OpenBSD)
+#if os(Linux) && canImport(Glibc)
             if _slowPath(glibcVersion < VersionNumber(2, 29)) {
               // This system is using an older version of glibc that does not
               // implement FD_CLOEXEC clearing in posix_spawn_file_actions_adddup2(),

--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -85,11 +85,7 @@ private let _childProcessContinuations = LockedWith<pthread_mutex_t, [pid_t: Che
 /// A condition variable used to suspend the waiter thread created by
 /// `_createWaitThread()` when there are no child processes to await.
 private nonisolated(unsafe) let _waitThreadNoChildrenCondition = {
-#if os(FreeBSD) || os(OpenBSD)
-  let result = UnsafeMutablePointer<pthread_cond_t?>.allocate(capacity: 1)
-#else
   let result = UnsafeMutablePointer<pthread_cond_t>.allocate(capacity: 1)
-#endif
   _ = pthread_cond_init(result, nil)
   return result
 }()

--- a/Sources/Testing/Support/Locked+Platform.swift
+++ b/Sources/Testing/Support/Locked+Platform.swift
@@ -39,9 +39,10 @@ extension os_unfair_lock_s: Lockable {
 
 #if os(FreeBSD) || os(OpenBSD)
 typealias pthread_mutex_t = _TestingInternals.pthread_mutex_t?
+typealias pthread_cond_t = _TestingInternals.pthread_cond_t?
 #endif
 
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || (os(WASI) && _runtime(_multithreaded)) || os(FreeBSD) || os(OpenBSD)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || (os(WASI) && _runtime(_multithreaded))
 extension pthread_mutex_t: Lockable {
   static func initializeLock(at lock: UnsafeMutablePointer<Self>) {
     _ = pthread_mutex_init(lock, nil)
@@ -83,7 +84,7 @@ extension SRWLOCK: Lockable {
 
 #if SWT_TARGET_OS_APPLE && !SWT_NO_OS_UNFAIR_LOCK
 typealias DefaultLock = os_unfair_lock
-#elseif SWT_TARGET_OS_APPLE || os(Linux) || os(Android) || (os(WASI) && _runtime(_multithreaded)) || os(FreeBSD) || os(OpenBSD)
+#elseif SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || (os(WASI) && _runtime(_multithreaded))
 typealias DefaultLock = pthread_mutex_t
 #elseif os(Windows)
 typealias DefaultLock = SRWLOCK

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -198,7 +198,7 @@ var swiftCompilerVersion: VersionNumber {
   )
 }
 
-#if canImport(Glibc) && !os(FreeBSD) && !os(OpenBSD)
+#if os(Linux) && canImport(Glibc)
 /// The (runtime, not compile-time) version of glibc in use on this system.
 ///
 /// This value is not part of the public interface of the testing library.


### PR DESCRIPTION
This PR adjusts some of our `#if os(...)` checks to always specify Linux, FreeBSD, OpenBSD, and Android in a consistent order. This makes it easier to find such code in the repo. I've also found a couple of spots where OpenBSD was missing and have fixed them.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
