### PR TITLE
Get exit tests functioning on OpenBSD.

### DIFF
--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -113,6 +113,13 @@ func spawnExecutable(
       withUnsafeTemporaryAllocation(of: sigset_t.self, capacity: 1) { allSignals in
         let allSignals = allSignals.baseAddress!
         sigfillset(allSignals)
+#if os(OpenBSD)
+        // On OpenBSD, attempting to set the signal handler for SIGKILL or
+        // SIGSTOP will cause the child process of a call to posix_spawn() to
+        // exit abnormally with exit code 127. See https://man.openbsd.org/sigaction.2#ERRORS
+        sigdelset(allSignals, SIGKILL)
+        sigdelset(allSignals, SIGSTOP)
+#endif
         posix_spawnattr_setsigdefault(attrs, allSignals);
         flags |= CShort(POSIX_SPAWN_SETSIGDEF)
       }


### PR DESCRIPTION
This PR adjusts the implementation of exit tests on OpenBSD so that they correctly spawn child processes there.

Without this change, exit tests all abnormally terminate with exit code 127. `ktrace` and `kdump` report:

```
63170 swift-testingPackageTes CALL  sigaction(SIGHUP,0x932dd7e5ca0,0)
63170 swift-testingPackageTes STRU  struct sigaction { handler=SIG_DFL, mask=0<>, flags=0<> }
63170 swift-testingPackageTes RET   sigaction 0
63170 swift-testingPackageTes CALL  sigaction(SIGINT,0x932dd7e5ca0,0)
63170 swift-testingPackageTes STRU  struct sigaction { handler=SIG_DFL, mask=0<>, flags=0<> }
63170 swift-testingPackageTes RET   sigaction 0
[...]
63170 swift-testingPackageTes CALL  sigaction(SIGKILL,0x932dd7e5ca0,0)
63170 swift-testingPackageTes RET   sigaction -1 errno 22 Invalid argument
63170 swift-testingPackageTes CALL  exit(127)
```

OpenBSD is more strict in its handling of `posix_spawnattr_setsigdefault()` than our other target platforms. Specifically, the child process will self-terminate after forking but before execing if either `SIGKILL` or `SIGSTOP` is in the signal mask passed to that function. Other platforms silently ignore these signals (since their handlers cannot be set per POSIX anyway.)

With this change, exit tests function correctly and Swift Testing's test suite passes with zero issues on OpenBSD. 🥳

<img width="1152" height="864" alt="openbsd" src="https://github.com/user-attachments/assets/c97dbe39-6486-4953-9f3c-7c43c300b938" />

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
