### PR TITLE
Revert "Adopt `Mutex`."

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(Testing
   Support/Graph.swift
   Support/JSON.swift
   Support/Locked.swift
+  Support/Locked+Platform.swift
   Support/VersionNumber.swift
   Support/Versions.swift
   Discovery+Macro.swift

--- a/Sources/Testing/Support/Locked+Platform.swift
+++ b/Sources/Testing/Support/Locked+Platform.swift
@@ -1,0 +1,97 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023–2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+internal import _TestingInternals
+
+extension Never: Lockable {
+  static func initializeLock(at lock: UnsafeMutablePointer<Self>) {}
+  static func deinitializeLock(at lock: UnsafeMutablePointer<Self>) {}
+  static func unsafelyAcquireLock(at lock: UnsafeMutablePointer<Self>) {}
+  static func unsafelyRelinquishLock(at lock: UnsafeMutablePointer<Self>) {}
+}
+
+#if SWT_TARGET_OS_APPLE && !SWT_NO_OS_UNFAIR_LOCK
+extension os_unfair_lock_s: Lockable {
+  static func initializeLock(at lock: UnsafeMutablePointer<Self>) {
+    lock.initialize(to: .init())
+  }
+
+  static func deinitializeLock(at lock: UnsafeMutablePointer<Self>) {
+    // No deinitialization needed.
+  }
+
+  static func unsafelyAcquireLock(at lock: UnsafeMutablePointer<Self>) {
+    os_unfair_lock_lock(lock)
+  }
+
+  static func unsafelyRelinquishLock(at lock: UnsafeMutablePointer<Self>) {
+    os_unfair_lock_unlock(lock)
+  }
+}
+#endif
+
+#if os(FreeBSD) || os(OpenBSD)
+typealias pthread_mutex_t = _TestingInternals.pthread_mutex_t?
+typealias pthread_cond_t = _TestingInternals.pthread_cond_t?
+#endif
+
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || (os(WASI) && _runtime(_multithreaded))
+extension pthread_mutex_t: Lockable {
+  static func initializeLock(at lock: UnsafeMutablePointer<Self>) {
+    _ = pthread_mutex_init(lock, nil)
+  }
+
+  static func deinitializeLock(at lock: UnsafeMutablePointer<Self>) {
+    _ = pthread_mutex_destroy(lock)
+  }
+
+  static func unsafelyAcquireLock(at lock: UnsafeMutablePointer<Self>) {
+    _ = pthread_mutex_lock(lock)
+  }
+
+  static func unsafelyRelinquishLock(at lock: UnsafeMutablePointer<Self>) {
+    _ = pthread_mutex_unlock(lock)
+  }
+}
+#endif
+
+#if os(Windows)
+extension SRWLOCK: Lockable {
+  static func initializeLock(at lock: UnsafeMutablePointer<Self>) {
+    InitializeSRWLock(lock)
+  }
+
+  static func deinitializeLock(at lock: UnsafeMutablePointer<Self>) {
+    // No deinitialization needed.
+  }
+
+  static func unsafelyAcquireLock(at lock: UnsafeMutablePointer<Self>) {
+    AcquireSRWLockExclusive(lock)
+  }
+
+  static func unsafelyRelinquishLock(at lock: UnsafeMutablePointer<Self>) {
+    ReleaseSRWLockExclusive(lock)
+  }
+}
+#endif
+
+#if SWT_TARGET_OS_APPLE && !SWT_NO_OS_UNFAIR_LOCK
+typealias DefaultLock = os_unfair_lock
+#elseif SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || (os(WASI) && _runtime(_multithreaded))
+typealias DefaultLock = pthread_mutex_t
+#elseif os(Windows)
+typealias DefaultLock = SRWLOCK
+#elseif os(WASI)
+// No locks on WASI without multithreaded runtime.
+typealias DefaultLock = Never
+#else
+#warning("Platform-specific implementation missing: locking unavailable")
+typealias DefaultLock = Never
+#endif

--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-internal import _TestingInternals
+private import _TestingInternals
 private import Synchronization
 
 /// A type that wraps a value requiring access from a synchronous caller during

--- a/Tests/TestingTests/Support/LockTests.swift
+++ b/Tests/TestingTests/Support/LockTests.swift
@@ -13,9 +13,7 @@ private import _TestingInternals
 
 @Suite("Locked Tests")
 struct LockTests {
-  @Test("Locking and unlocking")
-  func locking() {
-    let lock = Locked(rawValue: 0)
+  func testLock<L>(_ lock: LockedWith<L, Int>) {
     #expect(lock.rawValue == 0)
     lock.withLock { value in
       value = 1
@@ -23,9 +21,21 @@ struct LockTests {
     #expect(lock.rawValue == 1)
   }
 
-  @Test("Repeatedly accessing a lock")
-  func lockRepeatedly() async {
-    let lock = Locked(rawValue: 0)
+  @Test("Platform-default lock")
+  func locking() {
+    testLock(Locked(rawValue: 0))
+  }
+
+#if SWT_TARGET_OS_APPLE && !SWT_NO_OS_UNFAIR_LOCK
+  @Test("pthread_mutex_t (Darwin alternate)")
+  func lockingWith_pthread_mutex_t() {
+    testLock(LockedWith<pthread_mutex_t, Int>(rawValue: 0))
+  }
+#endif
+
+  @Test("No lock")
+  func noLock() async {
+    let lock = LockedWith<Never, Int>(rawValue: 0)
     await withTaskGroup { taskGroup in
       for _ in 0 ..< 100_000 {
         taskGroup.addTask {
@@ -33,6 +43,20 @@ struct LockTests {
         }
       }
     }
-    #expect(lock.rawValue == 100_000)
+    #expect(lock.rawValue != 100_000)
+  }
+
+  @Test("Get the underlying lock")
+  func underlyingLock() {
+    let lock = Locked(rawValue: 0)
+    testLock(lock)
+    lock.withUnsafeUnderlyingLock { underlyingLock, _ in
+      DefaultLock.unsafelyRelinquishLock(at: underlyingLock)
+      lock.withLock { value in
+        value += 1000
+      }
+      DefaultLock.unsafelyAcquireLock(at: underlyingLock)
+    }
+    #expect(lock.rawValue == 1001)
   }
 }


### PR DESCRIPTION
Reverts #1351, this is failing to build in CI (https://ci.swift.org/job/oss-swift-pr-test-ubuntu-22_04/9662/)