### PR TITLE
Support command-line arguments specified as `--foo=bar`.

### DIFF
--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -492,4 +492,25 @@ struct SwiftPMTests {
     let args = try parseCommandLineArguments(from: ["PATH", "--verbosity", "12345"])
     #expect(args.verbosity == 12345)
   }
+
+  @Test("--foo=bar form")
+  func equalsSignForm() throws {
+    // We can split the string and parse the result correctly.
+    do {
+      let args = try parseCommandLineArguments(from: ["PATH", "--verbosity=12345"])
+      #expect(args.verbosity == 12345)
+    }
+
+    // We don't overrun the string and correctly handle empty values.
+    do {
+      let args = try parseCommandLineArguments(from: ["PATH", "--xunit-output="])
+      #expect(args.xunitOutput == "")
+    }
+
+    // We split at the first equals-sign.
+    do {
+      let args = try parseCommandLineArguments(from: ["PATH", "--xunit-output=abc=123"])
+      #expect(args.xunitOutput == "abc=123")
+    }
+  }
 }


### PR DESCRIPTION
SwiftPM and `swift test` use Swift Argument Parser which allows developers to specify arguments of the form `--foo=bar`. Our bare-bones argument parser doesn't currently recognize that pattern, which means that the developer could write `--foo=bar` but get the wrong behavior.

This PR adds support for that pattern by changing how we parse command-line arguments to allow for both `--foo bar` and `--foo=bar`.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
