### PR TITLE
Remove some uses of `@unchecked Sendable` and `AnySequence`.

### DIFF
--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -69,26 +69,19 @@ public struct Test: Sendable {
   public nonisolated(unsafe) var xcTestCompatibleSelector: __XCTestCompatibleSelector?
 
   /// An enumeration describing the evaluation state of a test's cases.
-  ///
-  /// This use of `@unchecked Sendable` and of `AnySequence` in this type's
-  /// cases is necessary because it is not currently possible to express
-  /// `Sequence<Test.Case> & Sendable` as an existential (`any`)
-  /// ([96960993](rdar://96960993)). It is also not possible to have a value of
-  /// an underlying generic sequence type without specifying its generic
-  /// parameters.
-  fileprivate enum TestCasesState: @unchecked Sendable {
+  fileprivate enum TestCasesState: Sendable {
     /// The test's cases have not yet been evaluated.
     ///
     /// - Parameters:
     ///   - function: The function to call to evaluate the test's cases. The
     ///     result is a sequence of test cases.
-    case unevaluated(_ function: @Sendable () async throws -> AnySequence<Test.Case>)
+    case unevaluated(_ function: @Sendable () async throws -> any Sequence<Test.Case> & Sendable)
 
     /// The test's cases have been evaluated.
     ///
     /// - Parameters:
     ///   - testCases: The test's cases.
-    case evaluated(_ testCases: AnySequence<Test.Case>)
+    case evaluated(_ testCases: any Sequence<Test.Case> & Sendable)
 
     /// An error was thrown when the testing library attempted to evaluate the
     /// test's cases.
@@ -124,7 +117,7 @@ public struct Test: Sendable {
         // attempt to run it, and thus never access this property.
         preconditionFailure("Attempting to access test cases with invalid state. Please file a bug report at https://github.com/swiftlang/swift-testing/issues/new and include this information: \(String(reflecting: testCasesState))")
       }
-      return testCases
+      return AnySequence(testCases)
     }
   }
 
@@ -139,7 +132,7 @@ public struct Test: Sendable {
   var uncheckedTestCases: (some Sequence<Test.Case>)? {
     testCasesState.flatMap { testCasesState in
       if case let .evaluated(testCases) = testCasesState {
-        return testCases
+        return AnySequence(testCases)
       }
       return nil
     }
@@ -239,7 +232,7 @@ public struct Test: Sendable {
     self.sourceLocation = sourceLocation
     self.containingTypeInfo = containingTypeInfo
     self.xcTestCompatibleSelector = xcTestCompatibleSelector
-    self.testCasesState = .unevaluated { .init(try await testCases()) }
+    self.testCasesState = .unevaluated { try await testCases() }
     self.parameters = parameters
   }
 
@@ -260,7 +253,7 @@ public struct Test: Sendable {
     self.sourceLocation = sourceLocation
     self.containingTypeInfo = containingTypeInfo
     self.xcTestCompatibleSelector = xcTestCompatibleSelector
-    self.testCasesState = .evaluated(.init(testCases))
+    self.testCasesState = .evaluated(testCases)
     self.parameters = parameters
   }
 }

--- a/Sources/_TestDiscovery/TestContentRecord.swift
+++ b/Sources/_TestDiscovery/TestContentRecord.swift
@@ -85,7 +85,7 @@ public struct TestContentRecord<T> where T: DiscoverableAsTestContent {
   public private(set) nonisolated(unsafe) var imageAddress: UnsafeRawPointer?
 
   /// A type defining storage for the underlying test content record.
-  private enum _RecordStorage: @unchecked Sendable {
+  private enum _RecordStorage {
     /// The test content record is stored by address.
     case atAddress(UnsafePointer<_TestContentRecord>)
 
@@ -94,7 +94,7 @@ public struct TestContentRecord<T> where T: DiscoverableAsTestContent {
   }
 
   /// Storage for `_record`.
-  private var _recordStorage: _RecordStorage
+  private nonisolated(unsafe) var _recordStorage: _RecordStorage
 
   /// The underlying test content record.
   private var _record: _TestContentRecord {


### PR DESCRIPTION
This PR removes some outstanding uses of `@unchecked Sendable` and of `AnySequence`.

Ironically we still need `Test.testCases` to type-erase with `AnySequence` _in its implementation only_ for now because if we change it from `some Sequence<Test.Case>` to `any Sequence<Test.Case>` we get this diagnostic:

> 🛑 Runtime support for parameterized protocol types is only available in macOS
> 13.0.0 or newer

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
