### PR TITLE
[WIP] Add GitHub Action workflows which build main branch (post-merge)

### DIFF
--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -1,0 +1,22 @@
+name: main branch, main toolchain
+
+on:
+  push:
+    branches:
+      - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Test
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      linux_swift_versions: '["nightly-main"]'
+      linux_os_versions: '["amazonlinux2", "jammy"]'
+      windows_swift_versions: '["nightly-main"]'
+      enable_macos_checks: true
+      macos_exclude_xcode_versions: '[{"xcode_version": "16.2"}, {"xcode_version": "16.3"}, {"xcode_version": "16.4"}]'
+      enable_wasm_sdk_build: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -1,0 +1,22 @@
+name: main branch, 6.2 toolchain
+
+on:
+  push:
+    branches:
+      - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Test
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      linux_swift_versions: '["nightly-6.2"]'
+      linux_os_versions: '["amazonlinux2", "jammy"]'
+      windows_swift_versions: '["nightly-6.2"]'
+      enable_macos_checks: true
+      macos_exclude_xcode_versions: '[{"xcode_version": "16.2"}, {"xcode_version": "16.3"}, {"xcode_version": "16.4"}]'
+      enable_wasm_sdk_build: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
       linux_os_versions: '["amazonlinux2", "jammy"]'
       windows_swift_versions: '["nightly-main", "nightly-6.2"]'
       enable_macos_checks: true
-      macos_exclude_xcode_versions: "[{\"xcode_version\": \"16.2\"}, {\"xcode_version\": \"16.3\"}, {\"xcode_version\": \"16.4\"}]"
+      macos_exclude_xcode_versions: '[{"xcode_version": "16.2"}, {"xcode_version": "16.3"}, {"xcode_version": "16.4"}]'
       enable_wasm_sdk_build: true
   soundness:
     name: Soundness


### PR DESCRIPTION
WIP: This adds GitHub Action workflows which build the `main` branch when commits are pushed (generally, post-merge of a PR) using both `main` and 6.2 development snapshot toolchains.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
