### PR TITLE
Add support for experimental "custom availability domains" feature.

### DIFF
--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -415,7 +415,12 @@ struct TestDeclarationMacroTests {
         [
           #"#if os(moofOS)"#,
           #".__available("moofOS", obsoleted: nil, message: "Moof!", "#,
-        ]
+        ],
+      #"@available(customAvailabilityDomain) @Test func f() {}"#:
+        [
+          #".__available("customAvailabilityDomain", introduced: nil, "#,
+          #"guard #available (customAvailabilityDomain) else"#,
+        ],
     ]
   )
   func availabilityAttributeCapture(input: String, expectedOutputs: [String]) throws {


### PR DESCRIPTION
This PR updates our parsing of the `@available` attribute during expansion of the `@Test` and `@Suite` macros to support custom availability domains of the form:

```swift
@available(Foo) @Test func f() {}
```

This change means the macro expansion will include `if #available(Foo)` instead of `if #available(Foo, *)` in this case.

Resolves rdar://160323829.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
