### PR TITLE
Adjust README to show status badges from GitHub Actions workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,16 +108,12 @@ for various platforms:
 
 | **Platform** | **Support Status** |
 |-|-|
-| **macOS** | Supported |
-| **iOS** | Supported |
-| **watchOS** | Supported |
-| **tvOS** | Supported |
-| **visionOS** | Supported |
-| **Ubuntu 22.04** | Supported |
-| **Windows** | Supported |
-| **FreeBSD** | Experimental |
-| **OpenBSD** | Experimental |
-| **Wasm** | Experimental |
+| Apple platforms | Supported |
+| Linux | Supported |
+| Windows | Supported |
+| FreeBSD, OpenBSD | Experimental |
+| Wasm | Experimental |
+| Android | Experimental |
 
 ### Works with XCTest
 


### PR DESCRIPTION
This adjusts `README.md` to begin showing CI status badges from the GitHub Actions workflows I configured in #1361.

View [rendered README document](https://github.com/stmontgomery/swift-testing/blob/github-actions-badges/README.md).

### Motivation:

This will help ensure our CI status badges remain consistent with the CI status shown on Pull Requests.

### Modifications:

- Remove the CI status column on the "Supported platforms" table from the README.
  - This is because the new workflows do not offer granular, per-platform status badges (see [GitHub's documentation](https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge)).
- Add a new section to the README showing this status.
- Drive-by improvement: Move "Windows" platform up a few rows so that all the Supported platforms are listed first, followed by all Experimental platforms.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
