### PR TITLE
Fix accidentally dropping image encoding quality on the floor on Windows.

### DIFF
--- a/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
@@ -277,12 +277,11 @@ extension AttachableImageFormat {
   @_spi(_)
 #endif
   public init(encoderCLSID: CLSID, encodingQuality: Float = 1.0) {
-    let kind: Kind = switch UInt128(encoderCLSID) {
-    case UInt128(CLSID_WICPngEncoder):
+    let kind: Kind = if encoderCLSID == CLSID_WICPngEncoder {
       .png
-    case UInt128(CLSID_WICJpegEncoder):
+    } else if encoderCLSID == CLSID_WICJpegEncoder {
       .jpeg
-    default:
+    } else {
       .systemValue(encoderCLSID)
     }
     self.init(kind: kind, encodingQuality: encodingQuality)


### PR DESCRIPTION
This fixes a bug in `AttachableImageFormat.init(encoderCLSID:encodingQuality:)` where the `encodingQuality` argument would not be preserved.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
