### PR TITLE
Add `@_preInverseGenerics` to `Attachment: CustomStringConvertible`.

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -193,6 +193,7 @@ public struct AnyAttachable: AttachableWrapper, Sendable, Copyable {
 
 // MARK: - Describing an attachment
 
+@_preInverseGenerics
 extension Attachment: CustomStringConvertible where AttachableValue: ~Copyable {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)


### PR DESCRIPTION
To avoid a crash in Xcode 26, we need `Attachment`'s conformance to `CustomStringConvertible` to not take `~Copyable` into account. Yay.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
