### PR TITLE
Add an SPI `Attachment.uncheckedPreferredName` property.

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -42,7 +42,7 @@ extension ABI {
       path = attachment.fileSystemPath
 
       if V.includesExperimentalFields {
-        _preferredName = attachment.preferredName
+        _preferredName = attachment.uncheckedPreferredName
 
         if path == nil {
           _bytes = try? attachment.withUnsafeBytes { bytes in

--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -78,6 +78,19 @@ public struct Attachment<AttachableValue> where AttachableValue: Attachable & ~C
 
   /// A filename to use when saving this attachment.
   ///
+  /// The value of this property is equal to ``preferredName`` if the test
+  /// author specified a preferred name when creating the attachment. Otherwise,
+  /// the value of this property is `nil`.
+  @_spi(ForToolsIntegrationOnly)
+  public var uncheckedPreferredName: String? {
+    if let _preferredName, !_preferredName.isEmpty {
+      return attachableValue.preferredName(for: self, basedOn: _preferredName)
+    }
+    return nil
+  }
+
+  /// A filename to use when saving this attachment.
+  ///
   /// The value of this property is used as a hint to the testing library. The
   /// testing library may substitute a different filename as needed. If the
   /// value of this property has not been explicitly set, the testing library
@@ -88,12 +101,7 @@ public struct Attachment<AttachableValue> where AttachableValue: Attachable & ~C
   ///   @Available(Xcode, introduced: 26.0)
   /// }
   public var preferredName: String {
-    let suggestedName = if let _preferredName, !_preferredName.isEmpty {
-      _preferredName
-    } else {
-      Self.defaultPreferredName
-    }
-    return attachableValue.preferredName(for: self, basedOn: suggestedName)
+    uncheckedPreferredName ?? attachableValue.preferredName(for: self, basedOn: Self.defaultPreferredName)
   }
 
   /// The source location of this instance.


### PR DESCRIPTION
This PR adds a for-tools SPI property `uncheckedPreferredName` to `Attachment`. We can then use this property to distinguish when the developer provided or did not provide a name for an attachment.

Tools can then use this property and apply their own naming rules when consuming attachments from the event stream.

Naming is hard; I'm open to other/better names.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
