### PR TITLE
Ensure `NonisolatedNonsendingByDefault` doesn't break exit tests.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -392,6 +392,7 @@ extension ExitTest {
   ///
   /// - Warning: This function is used to implement the
   ///   `#expect(processExitsWith:)` macro. Do not use it directly.
+  @_disfavoredOverload
   @safe public static func __store<T>(
     _ id: (UInt64, UInt64, UInt64, UInt64),
     _ body: T,


### PR DESCRIPTION
When `NonisolatedNonsendingByDefault` is enabled, overload resolution of `ExitTest.__store()` picks the overload that takes any old `T` instead of taking a function. This overload exists only to suppress certain unhelpful compiler diagnostics and its implementation immediately aborts, which causes the described failure.

Adding `nonisolated(nonsending)` or `@concurrent` to the "good" overload doesn't appear to satisfy the type checker, so mark the "bad" overload as explicitly disfavoured instead.

I am unable to add a unit test for this case due to https://github.com/swiftlang/swift-package-manager/issues/9293.

Resolves #1375.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
