### PR TITLE
Disfavor overloads of `__checkFunctionCall()` with variadic generics.

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -198,6 +198,7 @@ private func _callBinaryOperator<T, U, R>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
+@_disfavoredOverload
 public func __checkFunctionCall<T, each U>(
   _ lhs: T, calling functionCall: (T, repeat each U) throws -> Bool, _ arguments: repeat each U,
   expression: __Expression,
@@ -367,6 +368,7 @@ public func __checkInoutFunctionCall<T, /*each*/ U>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
+@_disfavoredOverload
 public func __checkFunctionCall<T, each U, R>(
   _ lhs: T, calling functionCall: (T, repeat each U) throws -> R?, _ arguments: repeat each U,
   expression: __Expression,


### PR DESCRIPTION
This works around rdar://122011759 which appears to have been exacerbated by https://github.com/swiftlang/swift/pull/84907.

For example:

```swift
let file = try #require(fmemopen(nil, 1, "wb+"))
```

The third parameter of `fmemopen()` is of type `const char *` (AKA `UnsafePointer<CChar>`) and we're passing the string literal `"wb+"` which is implicitly cast to a C string by the compiler. However, overload resolution of the expansion function used by `#require()` is now preferring an overload that uses variadic generics, and that overload is impacted by a compiler issue (rdar://122011759) that causes it to pass a garbage pointer as the temporary C string. Previously, the type checker would pick an overload with a concrete, finite set of generic arguments (`<T, Arg0, Arg1, Arg2, R>` instead of `<T, each U, R>`.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
