### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 #
 
-* @stmontgomery @grynspan @briancroom @suzannaratcliff @jerryjrchen
+* @stmontgomery @grynspan @briancroom @jerryjrchen


### PR DESCRIPTION
This updates the `CODEOWNERS` file to remove @suzannaratcliff as a code owner to better reflect her current focus areas.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
