### PR TITLE
Remove VERSION.txt workaround for OpenBSD 7.7.

### DIFF
--- a/Sources/_TestingInternals/Versions.cpp
+++ b/Sources/_TestingInternals/Versions.cpp
@@ -44,9 +44,6 @@ const char *swt_getTestingLibraryVersion(void) {
 #warning SWT_TESTING_LIBRARY_VERSION not defined and VERSION.txt not found: testing library version is unavailable
   return nullptr;
 #endif
-#elif defined(__OpenBSD__)
-  // OpenBSD's version of clang doesn't support __has_embed or #embed.
-  return nullptr;
 #else
 #warning SWT_TESTING_LIBRARY_VERSION not defined and could not read from VERSION.txt at compile time: testing library version is unavailable
   return nullptr;


### PR DESCRIPTION
This PR removes a workaround for the lack of `#embed` support in OpenBSD 7.7's version of clang. OpenBSD 7.8 has a newer clang that has full `#embed` support, so we no longer need to special-case OpenBSD here.

Swift Testing will continue to compile for OpenBSD 7.7, but will emit a compile-time warning of the form:

> SWT_TESTING_LIBRARY_VERSION not defined and could not read from VERSION.txt at
> compile time: testing library version is unavailable

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
