### PR TITLE
[6.2.2] Disfavor overloads of `__checkFunctionCall()` with variadic generics.

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -198,6 +198,7 @@ private func _callBinaryOperator<T, U, R>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
+@_disfavoredOverload
 public func __checkFunctionCall<T, each U>(
   _ lhs: T, calling functionCall: (T, repeat each U) throws -> Bool, _ arguments: repeat each U,
   expression: __Expression,
@@ -367,6 +368,7 @@ public func __checkInoutFunctionCall<T, /*each*/ U>(
 ///
 /// - Warning: This function is used to implement the `#expect()` and
 ///   `#require()` macros. Do not call it directly.
+@_disfavoredOverload
 public func __checkFunctionCall<T, each U, R>(
   _ lhs: T, calling functionCall: (T, repeat each U) throws -> R?, _ arguments: repeat each U,
   expression: __Expression,


### PR DESCRIPTION
- **Explanation**: Adds `@_disfavoredOverload` so that the `__check()` function we use during expansion of `#expect()` for function call expressions is preferentially the one with hard-coded arguments rather than variadic generics (which suffer from a bug that's fixed in 6.3.)
- **Scope**: `#expect()` macro expansion
- **Issues**: rdar://122011759
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1389
- **Risk**: Low
- **Testing**: Manual testing as well as unit testing.
- **Reviewers**: @stmontgomery @briancroom @jerryjrchen