### PR TITLE
Add more availability annotations for image attachment symbols.

### DIFF
--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableImageFormat+UTType.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableImageFormat+UTType.swift
@@ -11,6 +11,9 @@
 #if SWT_TARGET_OS_APPLE && canImport(CoreGraphics)
 public import UniformTypeIdentifiers
 
+/// @Metadata {
+///   @Available(Swift, introduced: 6.3)
+/// }
 @available(_uttypesAPI, *)
 extension AttachableImageFormat {
   /// The content type corresponding to this image format.

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/_AttachableImageWrapper+AttachableWrapper.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/_AttachableImageWrapper+AttachableWrapper.swift
@@ -13,6 +13,9 @@ private import CoreGraphics
 
 private import UniformTypeIdentifiers
 
+/// @Metadata {
+///   @Available(Swift, introduced: 6.3)
+/// }
 @available(_uttypesAPI, *)
 extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: AttachableAsImage {
   /// Get the image format to use when encoding an image, substituting a
@@ -47,11 +50,17 @@ extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: At
     return encodingQuality < 1.0 ? .jpeg : .png
   }
 
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<_AttachableImageWrapper>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     let imageFormat = _imageFormat(forPreferredName: attachment.preferredName)
     return try wrappedValue.withUnsafeBytes(as: imageFormat, body)
   }
 
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public borrowing func preferredName(for attachment: borrowing Attachment<_AttachableImageWrapper>, basedOn suggestedName: String) -> String {
     let imageFormat = _imageFormat(forPreferredName: suggestedName)
     return (suggestedName as NSString).appendingPathExtension(for: imageFormat.contentType)

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
@@ -11,6 +11,9 @@
 #if os(Windows)
 public import WinSDK
 
+/// @Metadata {
+///   @Available(Swift, introduced: 6.3)
+/// }
 extension AttachableImageFormat {
   private static let _encoderPathExtensionsByCLSID = Result {
     var result = [CLSID.Wrapper: [String]]()

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/_AttachableImageWrapper+AttachableWrapper.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/_AttachableImageWrapper+AttachableWrapper.swift
@@ -11,6 +11,9 @@
 #if os(Windows)
 private import WinSDK
 
+/// @Metadata {
+///   @Available(Swift, introduced: 6.3)
+/// }
 extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: AttachableAsImage {
   /// Get the image format to use when encoding an image.
   ///
@@ -38,11 +41,17 @@ extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: At
     return encodingQuality < 1.0 ? .jpeg : .png
   }
 
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<_AttachableImageWrapper>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     let imageFormat = _imageFormat(forPreferredName: attachment.preferredName)
     return try wrappedValue.withUnsafeBytes(as: imageFormat, body)
   }
 
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public borrowing func preferredName(for attachment: borrowing Attachment<_AttachableImageWrapper>, basedOn suggestedName: String) -> String {
     let imageFormat = _imageFormat(forPreferredName: suggestedName)
     return AttachableImageFormat.appendPathExtension(for: imageFormat.encoderCLSID, to: suggestedName)

--- a/Sources/Testing/Attachments/Images/AttachableAsImage.swift
+++ b/Sources/Testing/Attachments/Images/AttachableAsImage.swift
@@ -81,6 +81,10 @@ public protocol AttachableAsImage {
   /// The testing library uses this function when saving an image as an
   /// attachment. The implementation should use `imageFormat` to determine what
   /// encoder to use.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   borrowing func withUnsafeBytes<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R
 
   /// Make a copy of this instance to pass to an attachment.

--- a/Sources/Testing/Attachments/Images/AttachableImageFormat.swift
+++ b/Sources/Testing/Attachments/Images/AttachableImageFormat.swift
@@ -79,6 +79,9 @@ public struct AttachableImageFormat: Sendable {
 
 // MARK: - Equatable, Hashable
 
+/// @Metadata {
+///   @Available(Swift, introduced: 6.3)
+/// }
 #if SWT_NO_IMAGE_ATTACHMENTS
 @_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
@@ -120,12 +123,18 @@ extension AttachableImageFormat.Kind: Equatable, Hashable {
 
 // MARK: - CustomStringConvertible, CustomDebugStringConvertible
 
+/// @Metadata {
+///   @Available(Swift, introduced: 6.3)
+/// }
 #if SWT_NO_IMAGE_ATTACHMENTS
 @_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
 #endif
 @available(_uttypesAPI, *)
 extension AttachableImageFormat: CustomStringConvertible, CustomDebugStringConvertible {
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public var description: String {
     let kindDescription = String(describing: kind)
     if encodingQuality < 1.0 {
@@ -134,6 +143,9 @@ extension AttachableImageFormat: CustomStringConvertible, CustomDebugStringConve
     return kindDescription
   }
 
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public var debugDescription: String {
     let kindDescription = String(reflecting: kind)
     return "\(kindDescription) at quality \(encodingQuality)"
@@ -142,6 +154,9 @@ extension AttachableImageFormat: CustomStringConvertible, CustomDebugStringConve
 
 // MARK: -
 
+/// @Metadata {
+///   @Available(Swift, introduced: 6.3)
+/// }
 #if SWT_NO_IMAGE_ATTACHMENTS
 @_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")

--- a/Sources/Testing/Attachments/Images/Attachment+AttachableAsImage.swift
+++ b/Sources/Testing/Attachments/Images/Attachment+AttachableAsImage.swift
@@ -8,6 +8,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+/// @Metadata {
+///   @Available(Swift, introduced: 6.3)
+/// }
 #if SWT_NO_IMAGE_ATTACHMENTS
 @_unavailableInEmbedded
 @available(*, unavailable, message: "Image attachments are not available on this platform.")


### PR DESCRIPTION
Adds more of these:

```swift
/// @Metadata {
///   @Available(Swift, introduced: 6.3)
/// }
```

To public symbols that DocC can see.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
