### PR TITLE
Mark `Issue.Severity` cases with availability.

### DIFF
--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -94,12 +94,20 @@ public struct Issue: Sendable {
     ///
     /// An issue with warning severity does not cause the test it's associated
     /// with to be marked as a failure, but is noted in the results.
+    ///
+    /// @Metadata {
+    ///   @Available(Swift, introduced: 6.3)
+    /// }
     case warning
 
     /// The severity level for an issue which represents an error in a test.
     ///
     /// An issue with error severity causes the test it's associated with to be
     /// marked as a failure.
+    ///
+    /// @Metadata {
+    ///   @Available(Swift, introduced: 6.3)
+    /// }
     case error
   }
 


### PR DESCRIPTION
It is necessary to explicitly mark the cases of this enum with their Swift 6.3 availability as it is not inherited when rendered in DocC.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
