### PR TITLE
Replace `wchar_t` with `CWideChar`.

### DIFF
--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
@@ -121,14 +121,14 @@ private let _archiverPath: String? = {
     return nil
   }
 
-  return withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: Int(bufferCount)) { buffer -> String? in
+  return withUnsafeTemporaryAllocation(of: CWideChar.self, capacity: Int(bufferCount)) { buffer -> String? in
     let bufferCount = GetSystemDirectoryW(buffer.baseAddress!, UINT(buffer.count))
     guard bufferCount > 0 && bufferCount < buffer.count else {
       return nil
     }
 
     return _archiverName.withCString(encodedAs: UTF16.self) { archiverName -> String? in
-      var result: UnsafeMutablePointer<wchar_t>?
+      var result: UnsafeMutablePointer<CWideChar>?
 
       let flags = ULONG(PATHCCH_ALLOW_LONG_PATHS.rawValue)
       guard S_OK == PathAllocCombine(buffer.baseAddress!, archiverName, flags, &result) else {

--- a/Sources/Testing/Support/Additions/CommandLineAdditions.swift
+++ b/Sources/Testing/Support/Additions/CommandLineAdditions.swift
@@ -90,7 +90,7 @@ extension CommandLine {
       var bufferCount = Int(MAX_PATH)
 #endif
       while result == nil {
-        try withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: bufferCount) { buffer in
+        try withUnsafeTemporaryAllocation(of: CWideChar.self, capacity: bufferCount) { buffer in
           SetLastError(DWORD(ERROR_SUCCESS))
           _ = GetModuleFileNameW(nil, buffer.baseAddress!, DWORD(buffer.count))
           switch GetLastError() {

--- a/Sources/Testing/Support/CError.swift
+++ b/Sources/Testing/Support/CError.swift
@@ -76,9 +76,9 @@ extension Win32Error: CustomStringConvertible {
       // error message... _unless_ you pass `FORMAT_MESSAGE_ALLOCATE_BUFFER` in
       // which case it takes a pointer-to-pointer that it populates with a
       // heap-allocated string. However, the signature for FormatMessageW()
-      // still takes an LPWSTR? (Optional<UnsafeMutablePointer<wchar_t>>), so we
-      // need to temporarily mis-cast the pointer before we can pass it in.
-      let count = buffer.withMemoryRebound(to: wchar_t.self) { buffer in
+      // still takes an LPWSTR? (Optional<UnsafeMutablePointer<CWideChar>>), so
+      // we need to temporarily mis-cast the pointer before we can pass it in.
+      let count = buffer.withMemoryRebound(to: CWideChar.self) { buffer in
         FormatMessageW(
           DWORD(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK),
           nil,

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -175,7 +175,7 @@ package enum Environment {
 #elseif os(Windows)
     name.withCString(encodedAs: UTF16.self) { name in
       func getVariable(maxCount: Int) -> String? {
-        withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: maxCount) { buffer in
+        withUnsafeTemporaryAllocation(of: CWideChar.self, capacity: maxCount) { buffer in
           SetLastError(DWORD(ERROR_SUCCESS))
           let count = GetEnvironmentVariableW(name, buffer.baseAddress!, DWORD(buffer.count))
           if count == 0 {

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -625,7 +625,7 @@ func appendPathComponent(_ pathComponent: String, to path: String) -> String {
 #if os(Windows)
   path.withCString(encodedAs: UTF16.self) { path in
     pathComponent.withCString(encodedAs: UTF16.self) { pathComponent in
-      withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: (wcslen(path) + wcslen(pathComponent)) * 2 + 1) { buffer in
+      withUnsafeTemporaryAllocation(of: CWideChar.self, capacity: (wcslen(path) + wcslen(pathComponent)) * 2 + 1) { buffer in
         _ = wcscpy_s(buffer.baseAddress, buffer.count, path)
         _ = PathCchAppendEx(buffer.baseAddress, buffer.count, pathComponent, ULONG(PATHCCH_ALLOW_LONG_PATHS.rawValue))
         return (String.decodeCString(buffer.baseAddress, as: UTF16.self)?.result)!
@@ -734,7 +734,7 @@ let rootDirectoryPath: String = {
   // https://devblogs.microsoft.com/oldnewthing/20140723-00/?p=423 .
   let count = GetSystemWindowsDirectoryW(nil, 0)
   if count > 0 {
-    withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: Int(count) + 1) { buffer in
+    withUnsafeTemporaryAllocation(of: CWideChar.self, capacity: Int(count) + 1) { buffer in
       _ = GetSystemWindowsDirectoryW(buffer.baseAddress!, UINT(buffer.count))
       let rStrip = PathCchStripToRoot(buffer.baseAddress!, buffer.count)
       if rStrip == S_OK || rStrip == S_FALSE {

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -77,7 +77,7 @@ let operatingSystemVersion: String = {
       // Include Service Pack details if available.
       if versionInfo.szCSDVersion.0 != 0 {
         withUnsafeBytes(of: versionInfo.szCSDVersion) { szCSDVersion in
-          szCSDVersion.withMemoryRebound(to: wchar_t.self) { szCSDVersion in
+          szCSDVersion.withMemoryRebound(to: CWideChar.self) { szCSDVersion in
             if let szCSDVersion = String.decodeCString(szCSDVersion.baseAddress!, as: UTF16.self)?.result {
               result += " (\(szCSDVersion))"
             }

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -192,7 +192,7 @@ private func withTestingLibraryImageAddress<R>(_ body: (ImageAddress?) throws ->
   // ELF-based platforms.
 #elseif os(Windows)
   let flags = DWORD(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS)
-  try addressInTestingLibrary.withMemoryRebound(to: wchar_t.self, capacity: MemoryLayout<UnsafeRawPointer>.stride / MemoryLayout<wchar_t>.stride) { addressInTestingLibrary in
+  try addressInTestingLibrary.withMemoryRebound(to: CWideChar.self, capacity: MemoryLayout<UnsafeRawPointer>.stride / MemoryLayout<CWideChar>.stride) { addressInTestingLibrary in
     try #require(GetModuleHandleExW(flags, addressInTestingLibrary, &testingLibraryAddress))
   }
   defer {

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -271,7 +271,7 @@ func temporaryDirectory() throws -> String {
 #elseif os(Android)
   Environment.variable(named: "TMPDIR") ?? "/data/local/tmp"
 #elseif os(Windows)
-  try withUnsafeTemporaryAllocation(of: wchar_t.self, capacity: Int(MAX_PATH + 1)) { buffer in
+  try withUnsafeTemporaryAllocation(of: CWideChar.self, capacity: Int(MAX_PATH + 1)) { buffer in
     // NOTE: GetTempPath2W() was introduced in Windows 10 Build 20348.
     if 0 == GetTempPathW(DWORD(buffer.count), buffer.baseAddress) {
       throw Win32Error(rawValue: GetLastError())


### PR DESCRIPTION
Previously, the definition of `CWideChar` was incorrect on Windows and referred to a 32-bit type instead of a 16-bit type. This has been corrected, so we can use Swift's canonical name for the type instead of C's `wchar_t`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
