### PR TITLE
[6.2.2] Enable GitHub Actions CI workflows for pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,35 @@
+name: Pull request
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Test
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      linux_swift_versions: '["nightly-6.2"]'
+      linux_os_versions: '["amazonlinux2", "jammy"]'
+      windows_swift_versions: '["nightly-6.2"]'
+      enable_macos_checks: true
+      macos_exclude_xcode_versions: '[{"xcode_version": "16.2"}, {"xcode_version": "16.3"}, {"xcode_version": "16.4"}]'
+      enable_ios_checks: true
+      ios_host_exclude_xcode_versions: '[{"xcode_version": "16.2"}, {"xcode_version": "16.3"}, {"xcode_version": "16.4"}]'
+      enable_wasm_sdk_build: true
+      enable_android_sdk_build: true
+  soundness:
+    name: Soundness
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    with:
+      license_header_check_project_name: "Swift"
+      docs_check_enabled: false
+      format_check_enabled: false
+      api_breakage_check_enabled: false


### PR DESCRIPTION
- **Explanation**: Adds the GHA workflow/YAML/script/job/program/configuration/whatever for PRs against release/6.2.2 (only building with the nightly 6.2 toolchain, not main).
- **Scope**: PRs targetting release/6.2.2
- **Issues**: N/A
- **Original PRs**: N/A
- **Risk**: N/A (?)
- **Testing**: N/A
- **Reviewers**: @stmontgomery @briancroom @jerryjrchen