### PR TITLE
[6.2] Ensure `NonisolatedNonsendingByDefault` doesn't break exit tests

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -381,6 +381,7 @@ extension ExitTest {
 #if compiler(>=6.2)
   @safe
 #endif
+  @_disfavoredOverload
   public static func __store<T>(
     _ id: (UInt64, UInt64, UInt64, UInt64),
     _ body: T,


### PR DESCRIPTION
- **Explanation**: Adjust the (non-ABI-affecting) signature of an underlying function used by the expansion of the `#expect(processExitsWith:)` macro so that when Approachable Concurrency is enabled, we pick the correct overload of said function.
- **Scope**: Exit tests with Approachable Concurrency enabled.
- **Issues**: https://github.com/swiftlang/swift-testing/issues/1375
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1383, #1407
- **Risk**: Low
- **Testing**: Existing CI jobs and manual verification. It is not possible at this time to write a unit test for this fix due to https://github.com/swiftlang/swift-package-manager/issues/9293.
- **Reviewers**: @grynspan @briancroom @jerryjrchen
