### PR TITLE
Add qualification status for supported platforms in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,23 @@ Swift.
 The table below describes the current level of support that Swift Testing has
 for various platforms:
 
-| **Platform** | **Support Status** |
-|-|-|
-| Apple platforms | Supported |
-| Linux | Supported |
-| Windows | Supported |
-| FreeBSD, OpenBSD | Experimental |
-| Wasm | Experimental |
-| Android | Experimental |
+| **Platform**     | **Support Status** | **Qualification[^1]**  |
+| ---------------- | ------------------ | ---------------------- |
+| Apple platforms  | Supported          | Automated              |
+| Linux            | Supported          | Automated              |
+| Windows          | Supported          | Automated              |
+| Wasm             | Experimental       | Automated (Build Only) |
+| Android          | Experimental       | Automated (Build Only) |
+| FreeBSD, OpenBSD | Experimental       | Manual                 |
+
+[^1]:
+    Most platforms have "Automated" qualification, where continuous integration
+    automatically verifies that the project builds and passes all tests. This
+    ensures that any changes meet our highest quality standards, so it is our
+    goal for all supported platforms.
+
+    Presently, some platforms rely on manual test ("Automated (Build Only)"
+    qualification) or manual build and test ("Manual" qualification).
 
 ### Works with XCTest
 
@@ -127,7 +136,7 @@ Detailed documentation for Swift Testing can be found on the
 [Swift Package Index](https://swiftpackageindex.com/swiftlang/swift-testing/main/documentation/testing).
 There, you can delve into comprehensive guides, tutorials, and API references to
 make the most out of this package. Swift Testing is included with the Swift 6
-toolchain and Xcode 16.  You do not need to add it as a package dependency to
+toolchain and Xcode 16. You do not need to add it as a package dependency to
 your Swift package or Xcode project.
 
 > [!IMPORTANT]
@@ -136,5 +145,5 @@ your Swift package or Xcode project.
 > repository requires a recent **main-branch development snapshot** toolchain.
 
 Other documentation resources for this project can be found in the
-[README](https://github.com/swiftlang/swift-testing/blob/main/Documentation/README.md) 
+[README](https://github.com/swiftlang/swift-testing/blob/main/Documentation/README.md)
 of the `Documentation/` subdirectory.


### PR DESCRIPTION
Add qualification status for supported platforms in the README. You can preview the README here: https://github.com/jerryjrchen/swift-testing/blob/push-pzlprwkunsly/README.md#cross-platform-support

<img width="889" height="442" alt="image" src="https://github.com/user-attachments/assets/948a3c8a-5aa6-4d1b-93d2-26f3e3d3edf7" />


### Motivation:

We've been able to build for more platforms in our CI, so update the README to reflect this triumph. Explain how the different qualification levels differ, and focus on build + test for all platforms in the future.

Move some platforms from Experimental -> Supported, although not with full CI build + test yet.

### Modifications:

- Update platform support table
- Remove misc extra spaces in the README (I ran `prettier` over it)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
