### PR TITLE
Expose Attachment.sourceLocation as tools integration SPI

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -104,7 +104,8 @@ public struct Attachment<AttachableValue> where AttachableValue: Attachable & ~C
   ///
   /// The value of this property is used when recording issues associated with
   /// the attachment.
-  var sourceLocation: SourceLocation
+  @_spi(ForToolsIntegrationOnly)
+  public internal(set) var sourceLocation: SourceLocation
 }
 
 extension Attachment: Sendable where AttachableValue: Sendable {}


### PR DESCRIPTION
This exposes the `Attachment.sourceLocation` property getter as `@_spi(ForToolsIntegrationOnly)`.

### Motivation:

Having this property be accessible as SPI will allow integrated tools to access the source location where an attachment was recorded to provide useful context in the results about where an attachment originated.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
