### PR TITLE
[ST-0019] Augment JSON ABI

### DIFF
--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -160,10 +160,21 @@ additional `"testCases"` field describing the individual test cases.
   ["displayName": <string>,] ; the user-supplied custom display name
   "sourceLocation": <source-location>, ; where the test is defined
   "id": <test-id>,
-  "isParameterized": <bool> ; is this a parameterized test function or not?
+  "isParameterized": <bool>, ; is this a parameterized test function or not?
+  ["tags": <array:tag>,] ; the tags associated with this test function
+  ["bugs": <array:bug>,] ; the bugs associated with this test function
+  ["timeLimit": <number>] ; the time limit associated with this test function
 }
 
 <test-id> ::= <string> ; an opaque string representing the test case
+
+<tag> ::= <string> ; a string representation of a tag
+
+<bug> ::= {
+  ["url": <string>,] ; the bug URL
+  ["id": <string>,] ; the bug id
+  ["title": <string>] ; the human readable bug title
+}
 ```
 
 <!--

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -43,11 +43,11 @@ extension ABI {
   }
 
   /// The current supported ABI version (ignoring any experimental versions.)
-  typealias CurrentVersion = v6_3
+  typealias CurrentVersion = v6_4
 
   /// The highest defined and supported ABI version (including any experimental
   /// versions.)
-  typealias HighestVersion = v6_3
+  typealias HighestVersion = v6_4
 
 #if !hasFeature(Embedded)
   /// Get the type representing a given ABI version.
@@ -85,6 +85,8 @@ extension ABI {
     }
 
     return switch versionNumber {
+    case ABI.v6_4.versionNumber...:
+      ABI.v6_4.self
     case ABI.v6_3.versionNumber...:
       ABI.v6_3.self
     case ABI.v0.versionNumber...:
@@ -164,6 +166,18 @@ extension ABI {
   public enum v6_3: Sendable, Version {
     static var versionNumber: VersionNumber {
       VersionNumber(6, 3)
+    }
+  }
+
+  /// A namespace and type for ABI version 6.4 symbols.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.4).
+  /// }
+  @_spi(Experimental)
+  public enum v6_4: Sendable, Version {
+    static var versionNumber: VersionNumber {
+      VersionNumber(6, 4)
     }
   }
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2024-2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -73,10 +73,30 @@ extension ABI {
     /// is `nil`.
     var isParameterized: Bool?
 
+
+    /// An equivalent of ``tags`` that preserved ABIv6.3 support.
+    var _tags: [String]?
+
     /// The tags associated with the test.
     ///
-    /// - Warning: Tags are not yet part of the JSON schema.
-    var _tags: [String]?
+    /// @Metadata {
+    ///   @Available(Swift, introduced: 6.4)
+    /// }
+    var tags: [String]?
+
+    /// The bugs associated with the test.
+    ///
+    /// @Metadata {
+    ///   @Available(Swift, introduced: 6.4)
+    /// }
+    var bugs: [Bug]?
+
+    /// The time limits associated with the test.
+    ///
+    /// @Metadata {
+    ///   @Available(Swift, introduced: 6.4)
+    /// }
+    var timeLimit: Double?
 
     init(encoding test: borrowing Test) {
       if test.isSuite {
@@ -95,11 +115,25 @@ extension ABI {
         if isParameterized == true {
           _testCases = test.uncheckedTestCases?.map(EncodedTestCase.init(encoding:))
         }
-
         let tags = test.tags
         if !tags.isEmpty {
-          _tags = tags.map(String.init(describing:))
+          self._tags = tags.map(String.init(describing:))
         }
+      }
+
+      if V.versionNumber >= ABI.v6_4.versionNumber {
+        self.tags = test.tags.sorted().map { tag in
+          switch tag.kind {
+            case .staticMember(let value): value
+          }
+        }
+        let bugs = test.associatedBugs
+        if !bugs.isEmpty {
+          self.bugs = bugs
+        }
+        self.timeLimit = test.timeLimit
+          .map(TimeValue.init)
+          .map(Double.init)
       }
     }
   }

--- a/Tests/TestingTests/EventHandlingInteropTests.swift
+++ b/Tests/TestingTests/EventHandlingInteropTests.swift
@@ -63,7 +63,7 @@ struct EventHandlingInteropTests {
       try Self.handlerContents.withLock {
         let contents = try #require(
           $0, "Fallback should have been called with non nil contents")
-        #expect(contents.version == "6.3")
+        #expect(contents.version == "\(ABI.CurrentVersion.versionNumber)")
         #expect(contents.record?.contains("A system failure occurred") ?? false)
       }
     }


### PR DESCRIPTION
Enhance Swift Testing's JSON event ABI by exposing test metadata that is currently unavailable to external tools. By including test tags, bug associations, and time limits in the JSON output, this allows third-party tools to provide richer insights and more sophisticated test management capabilities.


## Motivation:

Swift Testing's JSON event stream provides data for external tooling, enabling developers to build test analysis and reporting tools. However, the current implementation lacks access to some test metadata that developers may want to use to organize and manage their test suites.

Currently missing from the JSON output are:
  - **Test tags**: Used for categorization
  - **Bug associations**: Tracks bugs associated with tests
  - **Time limits**: Useful for performance monitoring and timeout management

This missing metadata limits the capabilities of external tools. For example:
  - IDE extensions cannot provide tag-based test filtering
  - CI/CD systems cannot generate reports grouped by test categories
  - Performance monitoring tools cannot track tests with specific time constraints
  - Bug tracking integrations cannot correlate test failures with known issues

### Modifications:

Modify the event JSON to include the `tags`, `bugs` and `timeLimit` traits if version 6.4 and above.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
