### PR TITLE
Fix a typo in the attachments documentation.

### DIFF
--- a/Sources/Testing/Attachments/Images/AttachableAsImage.swift
+++ b/Sources/Testing/Attachments/Images/AttachableAsImage.swift
@@ -45,9 +45,9 @@
 /// Instead, the testing library provides additional initializers on [`Attachment`](https://developer.apple.com/documentation/testing/attachment)
 /// that take instances of such types and handle converting them to image data when needed.
 ///
-/// You do not generally need to add your own conformances to this protocol. If
-/// you have an image in another format that needs to be attached to a test,
-/// first convert it to an instance of one of the types above.
+/// You do not generally need to add your own conformances to this protocol. For
+/// a list of types that automatically conform to this protocol, see
+/// <doc:Attachments#Attach-images>.
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)


### PR DESCRIPTION
Following #1413, there's now a typo where we refer to a list of types "above" but the list has moved to another file. This PR fixes that error.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
