### PR TITLE
Remove `@_spi` on `encoderCLSID` (take 2)

### DIFF
--- a/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
@@ -195,9 +195,6 @@ extension AttachableImageFormat {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
   /// }
-#if compiler(>=6.3) && canImport(_GUID)
-  @_spi(_)
-#endif
   public var encoderCLSID: CLSID {
     kind.encoderCLSID
   }
@@ -223,9 +220,6 @@ extension AttachableImageFormat {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
   /// }
-#if compiler(>=6.3) && canImport(_GUID)
-  @_spi(_)
-#endif
   public init(encoderCLSID: CLSID, encodingQuality: Float = 1.0) {
     let encoderCLSID = CLSID.Wrapper(encoderCLSID)
     let kind: Kind = if encoderCLSID == CLSID.Wrapper(CLSID_WICPngEncoder) {


### PR DESCRIPTION
What it says on the tin. The CI toolchain has been updated.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
