### PR TITLE
Avoid ObjC runtime warnings about duplicate class definitions for Serializer type

### DIFF
--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -77,7 +77,7 @@ extension Runner {
   /// type at runtime, it may be better-suited for ``Configuration`` instead.
   private struct _Context: Sendable {
     /// A serializer used to reduce parallelism among test cases.
-    var testCaseSerializer: Serializer?
+    var testCaseSerializer: Serializer<Void>?
   }
 
   /// Apply the custom scope for any test scope providers of the traits

--- a/Sources/Testing/Support/Serializer.swift
+++ b/Sources/Testing/Support/Serializer.swift
@@ -42,8 +42,13 @@ var defaultParallelizationWidth: Int {
 /// items do not start running; they must wait until the suspended work item
 /// either returns or throws an error.
 ///
+/// The generic type parameter `T` is unused. It avoids warnings when multiple
+/// copies of the testing library are loaded into a runner process on platforms
+/// which use the Objective-C runtime, due to non-generic actor types being
+/// implemented as classes there.
+///
 /// This type is not part of the public interface of the testing library.
-final actor Serializer {
+final actor Serializer<T> {
   /// The maximum number of work items that may run concurrently.
   nonisolated let maximumWidth: Int
 


### PR DESCRIPTION
This is a workaround meant to avoid Objective-C runtime warnings about duplicate classes stemming from our internal `Serializer` type which was added in #1390.

### Motivation:

In some usage scenarios there can be two or more copies of the testing library loaded into a runner process. When this happens on platforms such as Darwin which use the Objective-C runtime, this can cause duplicate class definition warnings logged to the console because class types and (non-generic) actor types are implemented within the Objective-C runtime as classes. This can look something like the following:

> objc[44611]: Class _TtC7Testing10Serializer is implemented in both ../path/to/libTesting.dylib (0x1011ac050) and path/to/swift-testing/.build/arm64-apple-macosx/debug/swift-testingPackageTests.xctest/Contents/MacOS/swift-testingPackageTests (0x10cc3ab88). This may cause spurious casting failures and mysterious crashes. One of the duplicates must be removed or renamed.

### Modifications:

I considered several potential fixes, but decided the simplest and most likely to work in all usage scenarios is to make the `Serializer` type generic by adding an unused generic type parameter `T`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
