### PR TITLE
Replace -require-explicit-sendable with 'ExplicitSendable' warning diagnostic group

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -369,9 +369,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
   static var packageSettings: Self {
     var result = availabilityMacroSettings
 
-    if buildingForDevelopment {
-      result.append(.unsafeFlags(["-require-explicit-sendable"]))
-    }
+    result.append(.treatWarning("ExplicitSendable", as: .warning))
 
     if buildingForEmbedded {
       result.append(.enableExperimentalFeature("Embedded"))


### PR DESCRIPTION
This replaces usage of the `-require-explicit-sendable` compiler flag with the new `ExplicitSendable` diagnostic group which was recently introduced in https://github.com/swiftlang/swift/pull/85319, with warning severity.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
