### PR TITLE
Start adoption of `@section` and `@used`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -385,11 +385,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
 
       .enableUpcomingFeature("MemberImportVisibility"),
 
-      // This setting is enabled in the package, but not in the toolchain build
-      // (via CMake). Enabling it is dependent on acceptance of the @section
-      // proposal via Swift Evolution.
-      .enableExperimentalFeature("SymbolLinkageMarkers"),
-
       .enableUpcomingFeature("InferIsolatedConformances"),
 
       // When building as a package, the macro plugin always builds as an
@@ -409,6 +404,21 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .define("SWT_NO_LEGACY_TEST_DISCOVERY", .whenEmbedded()),
       .define("SWT_NO_LIBDISPATCH", .whenEmbedded()),
     ]
+
+#if compiler(>=6.3)
+#if !SWT_FIXED_85411
+    // Work around https://github.com/swiftlang/swift/issues/85411
+    result += [
+      .enableExperimentalFeature("CompileTimeValuesPreview"),
+    ]
+#endif
+#else
+    // This setting is enabled in the package, but not in the toolchain build
+    // (via CMake). The @section attribute is formally supported in Swift 6.3.
+    result += [
+      .enableExperimentalFeature("SymbolLinkageMarkers"),
+    ]
+#endif
 
     return result
   }

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -13,8 +13,8 @@ public import SwiftSyntax
 import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 
-#if !hasFeature(SymbolLinkageMarkers) && SWT_NO_LEGACY_TEST_DISCOVERY
-#error("Platform-specific misconfiguration: either SymbolLinkageMarkers or legacy test discovery is required to expand #expect(processExitsWith:)")
+#if !((compiler(>=6.3) && hasFeature(CompileTimeValuesPreview)) || hasFeature(SymbolLinkageMarkers)) && SWT_NO_LEGACY_TEST_DISCOVERY
+#error("Platform-specific misconfiguration: either CompileTimeValuesPreview, SymbolLinkageMarkers, or legacy test discovery is required to expand #expect(processExitsWith:)")
 #endif
 
 /// A protocol containing the common implementation for the expansions of the

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -13,8 +13,8 @@ public import SwiftSyntax
 import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 
-#if !hasFeature(SymbolLinkageMarkers) && SWT_NO_LEGACY_TEST_DISCOVERY
-#error("Platform-specific misconfiguration: either SymbolLinkageMarkers or legacy test discovery is required to expand @Suite")
+#if !((compiler(>=6.3) && hasFeature(CompileTimeValuesPreview)) || hasFeature(SymbolLinkageMarkers)) && SWT_NO_LEGACY_TEST_DISCOVERY
+#error("Platform-specific misconfiguration: either CompileTimeValuesPreview, SymbolLinkageMarkers, or legacy test discovery is required to expand @Suite")
 #endif
 
 /// A type describing the expansion of the `@Suite` attribute macro.

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -74,7 +74,23 @@ func makeTestContentRecordDecl(named name: TokenSyntax, in typeName: TypeSyntax?
   )
   """
 
-#if hasFeature(SymbolLinkageMarkers)
+#if compiler(>=6.3) && hasFeature(CompileTimeValuesPreview)
+  result = """
+  #if compiler(>=6.3) && hasFeature(CompileTimeValuesPreview)
+  #if objectFormat(MachO)
+  @section("__DATA_CONST,__swift5_tests")
+  #elseif objectFormat(ELF) || objectFormat(Wasm)
+  @section("swift5_tests")
+  #elseif objectFormat(COFF)
+  @section(".sw5test$B")
+  #else
+  @Testing.__testing(warning: "Platform-specific implementation missing: object format unknown")
+  #endif
+  @used
+  #endif
+  \(result)
+  """
+#elseif hasFeature(SymbolLinkageMarkers)
   result = """
   #if hasFeature(SymbolLinkageMarkers)
   #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -13,8 +13,8 @@ public import SwiftSyntax
 import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
 
-#if !hasFeature(SymbolLinkageMarkers) && SWT_NO_LEGACY_TEST_DISCOVERY
-#error("Platform-specific misconfiguration: either SymbolLinkageMarkers or legacy test discovery is required to expand @Test")
+#if !((compiler(>=6.3) && hasFeature(CompileTimeValuesPreview)) || hasFeature(SymbolLinkageMarkers)) && SWT_NO_LEGACY_TEST_DISCOVERY
+#error("Platform-specific misconfiguration: either CompileTimeValuesPreview, SymbolLinkageMarkers, or legacy test discovery is required to expand @Test")
 #endif
 
 /// A type describing the expansion of the `@Test` attribute macro.

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -472,7 +472,9 @@ struct TestDeclarationMacroTests {
   func differentFunctionTypes(input: String, expectedTypeName: String?, otherCode: String?) throws {
     let (output, _) = try parse(input)
 
-#if hasFeature(SymbolLinkageMarkers)
+#if compiler(>=6.3) && hasFeature(CompileTimeValuesPreview)
+    #expect(output.contains("@section"))
+#elseif hasFeature(SymbolLinkageMarkers)
     #expect(output.contains("@_section"))
 #endif
 #if !SWT_NO_LEGACY_TEST_DISCOVERY

--- a/Tests/TestingTests/DiscoveryTests.swift
+++ b/Tests/TestingTests/DiscoveryTests.swift
@@ -58,7 +58,7 @@ struct DiscoveryTests {
   }
 #endif
 
-#if !SWT_NO_DYNAMIC_LINKING && hasFeature(SymbolLinkageMarkers)
+#if !SWT_NO_DYNAMIC_LINKING && ((compiler(>=6.3) && hasFeature(CompileTimeValuesPreview)) || hasFeature(SymbolLinkageMarkers))
   struct MyTestContent: DiscoverableAsTestContent {
     typealias TestContentAccessorHint = UInt32
 
@@ -80,6 +80,18 @@ struct DiscoveryTests {
       record.context
     }
 
+#if compiler(>=6.3) && hasFeature(CompileTimeValuesPreview)
+#if objectFormat(MachO)
+    @section("__DATA_CONST,__swift5_tests")
+#elseif objectFormat(ELF) || objectFormat(Wasm)
+    @section("swift5_tests")
+#elseif objectFormat(COFF)
+    @section(".sw5test$B")
+#else
+    @__testing(warning: "Platform-specific implementation missing: object format unknown")
+#endif
+    @used
+#else
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
     @_section("__DATA_CONST,__swift5_tests")
 #elseif os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android) || os(WASI)
@@ -90,6 +102,7 @@ struct DiscoveryTests {
     @__testing(warning: "Platform-specific implementation missing: test content section name unavailable")
 #endif
     @_used
+#endif
     private static let record: __TestContentRecord = (
       0xABCD1234,
       0,
@@ -144,7 +157,7 @@ struct DiscoveryTests {
   }
 #endif
 
-#if !SWT_NO_LEGACY_TEST_DISCOVERY && hasFeature(SymbolLinkageMarkers)
+#if !SWT_NO_LEGACY_TEST_DISCOVERY && ((compiler(>=6.3) && hasFeature(CompileTimeValuesPreview)) || hasFeature(SymbolLinkageMarkers))
   @Test("Legacy test discovery finds the same number of tests") func discoveredTestCount() async {
     let oldFlag = Environment.variable(named: "SWT_USE_LEGACY_TEST_DISCOVERY")
     defer {


### PR DESCRIPTION
This PR begins our migration to `@section` and `@used`. Because of a bug in the Swift compiler (https://github.com/swiftlang/swift/issues/85411), we still need to rely on an unsupported/experimental language feature (CompileTimeValuesPreview). When that bug is resolved, we can remove checks for CompileTimeValuesPreview and fully "activate" this new code path.

This PR has the immediate effect of suppressing compile-time warnings when building Swift Testing as a package.

Note that because of that bug, this PR does _not_ resolve 1371.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
