### PR TITLE
Remove `@_spi(Experimental)` from `ABI.v6_3`.

### DIFF
--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -161,7 +161,6 @@ extension ABI {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
   /// }
-  @_spi(Experimental)
   public enum v6_3: Sendable, Version {
     static var versionNumber: VersionNumber {
       VersionNumber(6, 3)


### PR DESCRIPTION
This type is still guarded by `@_spi(ForToolsIntegrationOnly)`, but we have a dedicated `ABI.ExperimentalVersion` type for this stuff now and we're releasing 6.3 soonish.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
