### PR TITLE
[DNM, WIP] Introduce a macOS DocC soundness check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,9 +27,10 @@ jobs:
       enable_android_sdk_build: true
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.3
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.5
     with:
       license_header_check_project_name: "Swift"
       docs_check_enabled: false
+      docs_check_macos_enabled: true
       format_check_enabled: false
       api_breakage_check_enabled: false


### PR DESCRIPTION
WIP: Early work to validate the introduction of a macOS-specific DocC soundness check in CI.

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
