### PR TITLE
Use `String(describingForTest:)` to stringify most errors.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -131,7 +131,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
     }
   } catch {
 #if !SWT_NO_FILE_IO
-    try? FileHandle.stderr.write("\(error)\n")
+    try? FileHandle.stderr.write("\(String(describingForTest: error))\n")
 #endif
 
     exitCode.withLock { exitCode in

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1210,10 +1210,10 @@ public func __checkClosureCall<each T>(
 /// - Parameters:
 ///   - error: The error to describe.
 ///
-/// - Returns: A string equivalent to `String(describing: error)` with
+/// - Returns: A string equivalent to `String(describingForTest: error)` with
 ///   information about its type added if not already present.
 private func _description(of error: some Error) -> String {
-  let errorDescription = "\"\(error)\""
+  let errorDescription = "\"\(String(describingForTest: error))\""
   let errorType = type(of: error as Any)
   if #available(_regexAPI, *) {
     if errorDescription.contains(String(describing: errorType)) {

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -304,13 +304,13 @@ extension Issue.Kind: CustomStringConvertible {
       }
       return "Confirmation was confirmed \(actual.counting("time")), but expected to be confirmed \(String(describingForTest: expected)) time(s)"
     case let .errorCaught(error):
-      return "Caught error: \(error)"
+      return "Caught error: \(String(describingForTest: error))"
     case let .timeLimitExceeded(timeLimitComponents: timeLimitComponents):
       return "Time limit was exceeded: \(TimeValue(timeLimitComponents))"
     case .knownIssueNotRecorded:
       return "Known issue was not recorded"
     case let .valueAttachmentFailed(error):
-      return "Caught error while saving attachment: \(error)"
+      return "Caught error while saving attachment: \(String(describingForTest: error))"
     case .apiMisused:
       return "An API was misused"
     case .system:

--- a/Sources/Testing/Support/Environment.swift
+++ b/Sources/Testing/Support/Environment.swift
@@ -188,7 +188,7 @@ package enum Environment {
               return nil
             case let errorCode:
               let error = Win32Error(rawValue: errorCode)
-              fatalError("Unexpected error when getting environment variable '\(name)': \(error) (\(errorCode))")
+              fatalError("Unexpected error when getting environment variable '\(name)': \(String(describingForTest: error)) (\(errorCode))")
             }
           } else if count > buffer.count {
             // Try again with the larger count.

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1637,6 +1637,23 @@ final class IssueTests: XCTestCase {
 
     await fulfillment(of: [expectationFailed, apiMisused], timeout: 0.0)
   }
+
+  private struct ErrorWithTestDescription: Error, CustomStringConvertible, CustomTestStringConvertible {
+    var description: String {
+      XCTFail("Invoked .description instead of .testDescription")
+      return "WRONG"
+    }
+
+    var testDescription: String {
+      return "RIGHT"
+    }
+  }
+
+  func testErrorCaughtIssueUsesTestDescription() {
+    let error = ErrorWithTestDescription()
+    let issue = Issue(kind: .errorCaught(error), severity: .error, comments: [], sourceContext: .init())
+    #expect(String(describing: issue).contains("RIGHT"))
+  }
 }
 #endif
 


### PR DESCRIPTION
Instead of using `String(describing:)`, use `String(describingForTest:)` to allow for test-specific information capture.

Resolves #1453.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
