### PR TITLE
Include the API level in the Android OS version.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -376,6 +376,9 @@ extension Event.HumanReadableOutputRecorder {
 #else
         comments.append("OS Version: \(operatingSystemVersion)")
 #endif
+#if os(Android)
+        comments.append("API Level: \(apiLevel)")
+#endif
       }
       return CollectionOfOne(
         Message(

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -58,10 +58,7 @@ let operatingSystemVersion: String = {
   }
 #elseif os(Android)
   if let version = systemProperty(named: "ro.build.version.release") {
-    let apiLevel = systemProperty(named: "ro.build.version.sdk").map { apiLevel in
-      " (API Level \(apiLevel))"
-    } ?? ""
-    return "Android \(version)\(apiLevel)"
+    return "Android \(version)"
   }
 #elseif os(Windows)
   // See if we can query the kernel directly, bypassing the fake-out logic added
@@ -121,6 +118,20 @@ let simulatorVersion: String = {
   default:
     return "\(productVersion) (\(buildNumber))"
   }
+}()
+#endif
+
+#if os(Android)
+/// A human-readable string describing the current device's supported Android
+/// API level.
+///
+/// This value's format is platform-specific and is not meant to be
+/// machine-readable. It is added to the output of a test run when using
+/// an event writer.
+///
+/// This value is not part of the public interface of the testing library.
+let apiLevel: String = {
+  systemProperty(named: "ro.build.version.sdk") ?? "unknown"
 }()
 #endif
 


### PR DESCRIPTION
When a test run starts, we emit some metadata including the OS version for diagnostic purposes. This PR adds Android's API level (SDK version) to the OS version info we emit on that platform. This is an Android-specific concept and is used in Swift for `{#,@}available(Android)` expressions and attributes.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
