### PR TITLE
Work around Swift compiler change on main.

### DIFF
--- a/Sources/Overlays/_Testing_AppKit/Attachments/NSImage+AttachableAsImage.swift
+++ b/Sources/Overlays/_Testing_AppKit/Attachments/NSImage+AttachableAsImage.swift
@@ -36,6 +36,7 @@ extension NSImageRep {
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
 /// }
+@available(_uttypesAPI, *)
 extension NSImage: AttachableAsImage, AttachableAsCGImage {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
@@ -56,6 +57,10 @@ extension NSImage: AttachableAsImage, AttachableAsCGImage {
       .filter { $0 > 0.0 }
       .max()
     return maxRepWidth ?? 1.0
+  }
+
+  public func withUnsafeBytes<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+    try withUnsafeBytesImpl(as: imageFormat, body)
   }
 
   public func _copyAttachableValue() -> Self {

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
@@ -74,7 +74,11 @@ extension AttachableAsCGImage {
     1.0
   }
 
-  public func withUnsafeBytes<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+  /// The shared implementation of ``AttachableAsImage/withUnsafeBytes(as:_:)``
+  /// used by types that conform to ``AttachableAsCGImage``.
+  ///
+  /// For documentation, see ``AttachableAsImage/withUnsafeBytes(as:_:)``.
+  package func withUnsafeBytesImpl<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     let data = NSMutableData()
 
     // Convert the image to a CGImage.

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/CGImage+AttachableAsImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/CGImage+AttachableAsImage.swift
@@ -14,12 +14,17 @@ public import CoreGraphics
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
 /// }
+@available(_uttypesAPI, *)
 extension CGImage: AttachableAsImage, AttachableAsCGImage {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
   /// }
   package var attachableCGImage: CGImage {
     self
+  }
+
+  public func withUnsafeBytes<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+    try withUnsafeBytesImpl(as: imageFormat, body)
   }
 }
 #endif

--- a/Sources/Overlays/_Testing_CoreImage/Attachments/CIImage+AttachableAsImage.swift
+++ b/Sources/Overlays/_Testing_CoreImage/Attachments/CIImage+AttachableAsImage.swift
@@ -15,6 +15,7 @@ public import _Testing_CoreGraphics
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
 /// }
+@available(_uttypesAPI, *)
 extension CIImage: AttachableAsImage, AttachableAsCGImage {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
@@ -26,6 +27,10 @@ extension CIImage: AttachableAsImage, AttachableAsCGImage {
       }
       return result
     }
+  }
+
+  public func withUnsafeBytes<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+    try withUnsafeBytesImpl(as: imageFormat, body)
   }
 
   public func _copyAttachableValue() -> Self {

--- a/Sources/Overlays/_Testing_UIKit/Attachments/UIImage+AttachableAsImage.swift
+++ b/Sources/Overlays/_Testing_UIKit/Attachments/UIImage+AttachableAsImage.swift
@@ -20,6 +20,7 @@ private import UIKitCore_Private
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
 /// }
+@available(_uttypesAPI, *)
 extension UIImage: AttachableAsImage, AttachableAsCGImage {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
@@ -65,6 +66,10 @@ extension UIImage: AttachableAsImage, AttachableAsCGImage {
 
   package var attachmentScaleFactor: CGFloat {
     scale
+  }
+
+  public func withUnsafeBytes<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+    try withUnsafeBytesImpl(as: imageFormat, body)
   }
 }
 #endif

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableAsIWICBitmapSource.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableAsIWICBitmapSource.swift
@@ -100,7 +100,11 @@ package protocol AttachableAsIWICBitmapSource: AttachableAsImage {
 }
 
 extension AttachableAsIWICBitmapSource {
-  public func withUnsafeBytes<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+  /// The shared implementation of ``AttachableAsImage/withUnsafeBytes(as:_:)``
+  /// used by types that conform to ``AttachableAsIWICBitmapSource``.
+  ///
+  /// For documentation, see ``AttachableAsImage/withUnsafeBytes(as:_:)``.
+  public func withUnsafeBytesImpl<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     // Create an in-memory stream to write the image data to. Note that Windows
     // documentation recommends SHCreateMemStream() instead, but that function
     // does not provide a mechanism to access the underlying memory directly.

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/UnsafeMutablePointer+AttachableAsIWICBitmapSource.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/UnsafeMutablePointer+AttachableAsIWICBitmapSource.swift
@@ -19,6 +19,10 @@ extension UnsafeMutablePointer: AttachableAsImage, AttachableAsIWICBitmapSource 
     try Pointee._copyAttachableIWICBitmapSource(from: self, using: factory)
   }
 
+  public func withUnsafeBytes<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+    try withUnsafeBytesImpl(as: imageFormat, body)
+  }
+
   public func _copyAttachableValue() -> Self {
     Pointee._copyAttachableValue(at: self)
   }


### PR DESCRIPTION
This PR silences a new warning from the Swift 6.4 compiler:

```
NSImage+AttachableAsImage.swift:40:1: warning: method 'withUnsafeBytes(as:_:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'AttachableAsImage'
38 | /// }
39 | @available(_uttypesAPI, *)
40 | extension NSImage: AttachableAsImage, AttachableAsCGImage {
   | `- warning: method 'withUnsafeBytes(as:_:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'AttachableAsImage'
41 |   /// @Metadata {
42 |   ///   @Available(Swift, introduced: 6.3)

AttachableAsCGImage.swift:77:15: note: mark the instance method as 'public' to satisfy the requirement
 75 |   }
 76 | 
 77 |   public func withUnsafeBytes<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
    |               `- note: mark the instance method as 'public' to satisfy the requirement
 78 |     let data = NSMutableData()
 79 | 
```

Per discussion in https://github.com/swiftlang/swift/issues/86279, this compiler change is intentional.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
