### PR TITLE
Remove `_SelfRemover` as obsolete.

### DIFF
--- a/Sources/TestingMacros/Support/AttributeDiscovery.swift
+++ b/Sources/TestingMacros/Support/AttributeDiscovery.swift
@@ -13,50 +13,6 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import SwiftParser
 
-/// A syntax rewriter that removes leading `Self.` tokens from member access
-/// expressions in a syntax tree.
-///
-/// If the developer specified Self.something as an argument to the `@Test` or
-/// `@Suite` attribute, we will currently incorrectly infer Self as equalling
-/// the container type that we emit rather than the type containing the test.
-/// This class strips off `Self.` wherever that occurs.
-///
-/// Note that this operation is technically incorrect if a subexpression of the
-/// attribute declares a type and refers to it with `Self`. We accept this
-/// constraint as it is unlikely to pose real-world issues and is generally
-/// solvable by using an explicit type name instead of `Self`.
-///
-/// This class should instead replace `Self` with the name of the containing
-/// type when rdar://105470382 is resolved.
-private final class _SelfRemover<C>: SyntaxRewriter where C: MacroExpansionContext {
-  /// The macro context in which the expression is being parsed.
-  let context: C
-
-  /// Initialize an instance of this class.
-  ///
-  /// - Parameters:
-  ///   - context: The macro context in which the expression is being parsed.
-  ///   - viewMode: The view mode to use when walking the syntax tree.
-  init(in context: C) {
-    self.context = context
-  }
-
-  override func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
-    if let base = node.base?.as(DeclReferenceExprSyntax.self) {
-      if base.baseName.tokenKind == .keyword(.Self) {
-        // We cannot currently correctly convert Self.self into the expected
-        // type name, but once rdar://105470382 is resolved we can replace the
-        // base expression with the typename here (at which point Self.self
-        // ceases to be an interesting case anyway.)
-        return ExprSyntax(node.declName)
-      }
-    } else if let base = node.base?.as(MemberAccessExprSyntax.self) {
-      return ExprSyntax(node.with(\.base, visit(base)))
-    }
-    return ExprSyntax(node)
-  }
-}
-
 /// A type describing information parsed from a `@Test` or `@Suite` attribute.
 struct AttributeInfo {
   /// The attribute node that was parsed to produce this instance.
@@ -158,19 +114,6 @@ struct AttributeInfo {
        let displayName, let displayNameArgument,
         displayName.representedLiteralValue?.isEmpty == true {
       context.diagnose(.declaration(namedDecl, hasEmptyDisplayName: displayName, fromArgument: displayNameArgument, using: attribute))
-    }
-
-    // Remove leading "Self." expressions from the arguments of the attribute.
-    // See _SelfRemover for more information. Rewriting a syntax tree discards
-    // location information from the copy, so only invoke the rewriter if the
-    // `Self` keyword is present somewhere.
-    nonDisplayNameArguments = nonDisplayNameArguments.map { argument in
-      var expr = argument.expression
-      if argument.expression.tokens(viewMode: .sourceAccurate).map(\.tokenKind).contains(.keyword(.Self)) {
-        let selfRemover = _SelfRemover(in: context)
-        expr = selfRemover.rewrite(Syntax(argument.expression)).cast(ExprSyntax.self)
-      }
-      return Argument(label: argument.label, expression: expr)
     }
 
     // Look for any traits in the remaining arguments and slice them off. Traits

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -486,14 +486,6 @@ struct TestDeclarationMacroTests {
     }
   }
 
-  @Test("Self. in @Test attribute is removed")
-  func removeSelfKeyword() throws {
-    let (output, _) = try parse("@Test(arguments: Self.nested.uniqueArgsName, NoTouching.thisOne) func f() {}")
-    #expect(output.contains("nested.uniqueArgsName"))
-    #expect(!output.contains("Self.nested.uniqueArgsName"))
-    #expect(output.contains("NoTouching.thisOne"))
-  }
-
   @Test("Display name is preserved",
     arguments: [
       #"@Test("Display Name") func f() {}"#,


### PR DESCRIPTION
The `_SelfRemover` syntax rewriter is used during expansion of `@Test` and `@Suite` to rewrite `Self` as the name of the enclosing type so that the nested helper type we generate doesn't interfere with resolution of said keyword. Because the helper type now only contains `__testContentRecord` (with the bulk of the macro expansion being direct peers of the `@Test` or `@Suite` macro), this work is now redundant, so we can remove it.

See `TestsWithStaticMemberAccessBySelfKeyword` for existing test coverage.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
