### PR TITLE
Conditionalize 'ExplicitSendable' warning group to 6.3 compilers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -369,7 +369,9 @@ extension Array where Element == PackageDescription.SwiftSetting {
   static var packageSettings: Self {
     var result = availabilityMacroSettings
 
+#if compiler(>=6.3)
     result.append(.treatWarning("ExplicitSendable", as: .warning))
+#endif
 
     if buildingForEmbedded {
       result.append(.enableExperimentalFeature("Embedded"))


### PR DESCRIPTION
This is a follow-up to the new warning group adopted in https://github.com/swiftlang/swift-testing/pull/1445, to limit its usage to 6.3 or later compilers since that diagnostic was added in 6.3.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
