### PR TITLE
Need to initialize os_unfair_lock guarding the fallback event handler

### DIFF
--- a/Sources/_TestingInterop/FallbackEventHandler.swift
+++ b/Sources/_TestingInterop/FallbackEventHandler.swift
@@ -22,7 +22,9 @@ private nonisolated(unsafe) let _fallbackEventHandler = {
     minimumCapacity: 1,
     makingHeaderWith: { _ in nil }
   )
-  result.withUnsafeMutablePointerToHeader { $0.initialize(to: nil) }
+  result.withUnsafeMutablePointerToElements { lock in
+    lock.initialize(to: .init())
+  }
   return result
 }()
 #else


### PR DESCRIPTION
Prior to this fix, we didn't have an explicit init which could lead to garbage values.

Resolves rdar://167861118

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
