### PR TITLE
Adjust compiler version checks around `WinSDK.GUID.Wrapper`.

### DIFF
--- a/Sources/Overlays/_Testing_WinSDK/Support/Additions/GUIDAdditions.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Support/Additions/GUIDAdditions.swift
@@ -46,10 +46,10 @@ extension GUID.Wrapper: Equatable, Hashable, CustomStringConvertible {
   func hash(into hasher: inout Hasher) {
     hasher.combine(_uint128Value)
   }
+#endif
 
   var description: String {
     String(describing: rawValue)
   }
-#endif
 }
 #endif


### PR DESCRIPTION
This PR ensures we don't start spuriously warning if Swift Testing is built as a package with the (eventual/hypothetical) Swift 6.3.1 toolchain, and uses the built-in `Equatable` and `Hashable` conformances on `GUID` when built with 6.3.0 (because those conformances have landed everywhere now.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
