### PR TITLE
Make `IWICBitmapSourceProtocol` public (underscored) to suppress new compiler warning.

### DIFF
--- a/Sources/Overlays/_Testing_WinSDK/Attachments/IWICBitmapSource+AttachableAsIWICBitmapSource.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/IWICBitmapSource+AttachableAsIWICBitmapSource.swift
@@ -31,21 +31,21 @@ public import WinSDK
 ///
 /// This protocol is not part of the public interface of the testing library. It
 /// allows us to reuse code across all subclasses of `IWICBitmapSource`.
-protocol IWICBitmapSourceProtocol: _AttachableByAddressAsIWICBitmapSource {}
+public protocol _IWICBitmapSourceProtocol: _AttachableByAddressAsIWICBitmapSource {}
 
-extension IWICBitmapSource: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-extension IWICBitmap: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-extension IWICBitmapClipper: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-extension IWICBitmapFlipRotator: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-extension IWICBitmapFrameDecode: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-extension IWICBitmapScaler: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-extension IWICColorTransform: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-extension IWICFormatConverter: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
-extension IWICPlanarFormatConverter: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
+extension IWICBitmapSource: _AttachableByAddressAsIWICBitmapSource, _IWICBitmapSourceProtocol {}
+extension IWICBitmap: _AttachableByAddressAsIWICBitmapSource, _IWICBitmapSourceProtocol {}
+extension IWICBitmapClipper: _AttachableByAddressAsIWICBitmapSource, _IWICBitmapSourceProtocol {}
+extension IWICBitmapFlipRotator: _AttachableByAddressAsIWICBitmapSource, _IWICBitmapSourceProtocol {}
+extension IWICBitmapFrameDecode: _AttachableByAddressAsIWICBitmapSource, _IWICBitmapSourceProtocol {}
+extension IWICBitmapScaler: _AttachableByAddressAsIWICBitmapSource, _IWICBitmapSourceProtocol {}
+extension IWICColorTransform: _AttachableByAddressAsIWICBitmapSource, _IWICBitmapSourceProtocol {}
+extension IWICFormatConverter: _AttachableByAddressAsIWICBitmapSource, _IWICBitmapSourceProtocol {}
+extension IWICPlanarFormatConverter: _AttachableByAddressAsIWICBitmapSource, _IWICBitmapSourceProtocol {}
 
 // MARK: - Upcasting conveniences
 
-extension UnsafeMutablePointer where Pointee: IWICBitmapSourceProtocol {
+extension UnsafeMutablePointer where Pointee: _IWICBitmapSourceProtocol {
   /// Upcast this WIC bitmap to a WIC bitmap source (its parent type).
   ///
   /// - Returns: `self`, cast to the parent type via `QueryInterface()`. The
@@ -78,7 +78,7 @@ extension UnsafeMutablePointer where Pointee: IWICBitmapSourceProtocol {
 
 // MARK: - _AttachableByAddressAsIWICBitmapSource implementation
 
-extension IWICBitmapSourceProtocol {
+extension _IWICBitmapSourceProtocol {
   public static func _copyAttachableIWICBitmapSource(
     from imageAddress: UnsafeMutablePointer<Self>,
     using factory: UnsafeMutablePointer<IWICImagingFactory>


### PR DESCRIPTION
This PR renames `IWICBitmapSourceProtocol` to `_IWICBitmapSourceProtocol` and makes it `public` in order to silence warnings generated by https://github.com/swiftlang/swift/issues/86279. Namely:

```
43 | extension IWICFormatConverter: _AttachableByAddressAsIWICBitmapSource, IWICBitmapSourceProtocol {}
   | `- warning: method '_copyAttachableValue(at:)' must be as accessible as its enclosing type because it matches a requirement in protocol '_AttachableByAddressAsIWICBitmapSource'
89 |   public static func _copyAttachableValue(at imageAddress: UnsafeMutablePointer<Self>) -> UnsafeMutablePointer<Self> {
   |                      `- note: mark the static method as 'public' to satisfy the requirement
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
