### PR TITLE
Explicitly forbid tests/suites/exit tests in extensions to `InlineArray`.

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -632,12 +632,20 @@ extension ExitTestConditionMacro {
     // Disallow exit tests in generic types and functions as they cannot be
     // correctly expanded due to the use of a nested type with static members.
     for lexicalContext in context.lexicalContext {
-      if let lexicalContext = lexicalContext.asProtocol((any WithGenericParametersSyntax).self) {
-        if let genericClause = lexicalContext.genericParameterClause {
+      if let lexicalContext = lexicalContext.asProtocol((any DeclGroupSyntax).self) {
+        if let genericClause = lexicalContext.asProtocol((any WithGenericParametersSyntax).self)?.genericParameterClause {
           diagnostics.append(.expressionMacroUnsupported(macro, inGenericContextBecauseOf: genericClause, on: lexicalContext))
         } else if let whereClause = lexicalContext.genericWhereClause {
           diagnostics.append(.expressionMacroUnsupported(macro, inGenericContextBecauseOf: whereClause, on: lexicalContext))
-        } else if let functionDecl = lexicalContext.as(FunctionDeclSyntax.self) {
+        } else if [.arrayType, .dictionaryType, .optionalType, .implicitlyUnwrappedOptionalType, .inlineArrayType].contains(lexicalContext.type.kind) {
+          diagnostics.append(.expressionMacroUnsupported(macro, inGenericContextBecauseOf: lexicalContext.type, on: lexicalContext))
+        }
+      } else if let functionDecl = lexicalContext.as(FunctionDeclSyntax.self) {
+        if let genericClause = functionDecl.genericParameterClause {
+          diagnostics.append(.expressionMacroUnsupported(macro, inGenericContextBecauseOf: genericClause, on: functionDecl))
+        } else if let whereClause = functionDecl.genericWhereClause {
+          diagnostics.append(.expressionMacroUnsupported(macro, inGenericContextBecauseOf: whereClause, on: functionDecl))
+        } else {
           for parameter in functionDecl.signature.parameterClause.parameters {
             if parameter.type.isSome {
               diagnostics.append(.expressionMacroUnsupported(macro, inGenericContextBecauseOf: parameter, on: functionDecl))

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -189,10 +189,7 @@ func diagnoseIssuesWithLexicalContext(
     diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: genericClause, on: lexicalContext))
   } else if let whereClause = lexicalContext.genericWhereClause {
     diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: whereClause, on: lexicalContext))
-  } else if [.arrayType, .dictionaryType, .optionalType, .implicitlyUnwrappedOptionalType].contains(lexicalContext.type.kind) {
-    // These types are all syntactic sugar over generic types (Array<T>,
-    // Dictionary<T>, and Optional<T>) and are just as unsupported. T! is
-    // unsupported in this position, but it's still forbidden so don't even try!
+  } else if [.arrayType, .dictionaryType, .optionalType, .implicitlyUnwrappedOptionalType, .inlineArrayType].contains(lexicalContext.type.kind) {
     diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: lexicalContext.type, on: lexicalContext))
   }
 

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -438,8 +438,26 @@ struct ConditionMacroTests {
 
   @Test("#expect(processExitsWith:) diagnostics",
     arguments: [
+      "struct S<T> { func f() { #expectExitTest(processExitsWith: x) {} } }":
+        "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within generic structure 'S'",
+      "extension S where T: U { func f() { #expectExitTest(processExitsWith: x) {} } }":
+        "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within a generic declaration",
+      "extension [T] { func f() { #expectExitTest(processExitsWith: x) {} } }":
+        "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within a generic declaration",
+      "extension [T:U] { func f() { #expectExitTest(processExitsWith: x) {} } }":
+        "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within a generic declaration",
+      "extension T? { func f() { #expectExitTest(processExitsWith: x) {} } }":
+        "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within a generic declaration",
+      "extension T! { func f() { #expectExitTest(processExitsWith: x) {} } }":
+        "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within a generic declaration",
+      "extension [1 of T] { func f() { #expectExitTest(processExitsWith: x) {} } }":
+        "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within a generic declaration",
       "func f<T>() { #expectExitTest(processExitsWith: x) {} }":
         "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within generic function 'f()'",
+      "func f() where T: U { #expectExitTest(processExitsWith: x) {} }":
+        "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within generic function 'f()'",
+      "func f(_: some T) { #expectExitTest(processExitsWith: x) {} }":
+        "Cannot call macro ''#expectExitTest(processExitsWith:_:)'' within generic function 'f(_:)'",
     ]
   )
   func exitTestDiagnostics(input: String, expectedMessage: String) throws {

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -159,6 +159,10 @@ struct TestDeclarationMacroTests {
         "Attribute 'Test' cannot be applied to a function within a generic extension to type 'T!'",
       "extension T! { @Suite struct S {} }":
         "Attribute 'Suite' cannot be applied to a structure within a generic extension to type 'T!'",
+      "extension [1 of T] { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a generic extension to type '[1 of T]'",
+      "extension [1 of T] { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a generic extension to type '[1 of T]'",
     ]
   )
   func apiMisuseErrors(input: String, expectedMessage: String) throws {


### PR DESCRIPTION
This PR ensures we provide a reasonable diagnostic if `@Test`, `@Suite`, or `#expect(processExitsWith:)` is used within an extension to `InlineArray` that uses the sugared syntax `[n of T]`. We now emit a diagnostic like:

> Attribute 'Suite' cannot be applied to a structure within a generic extension to type '[1 of T]'

Without this change, compilation succeeds, but the test won't be runnable (this may change with #1408 though!)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
