### PR TITLE
Move the check for `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH`.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -553,21 +553,13 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
   var configuration = Configuration()
 
   // Parallelization (on by default)
-  if let parallel = args.parallel, !parallel {
+  if let parallel = args.parallel {
     configuration.isParallelizationEnabled = parallel
-  } else {
-    var maximumParallelizationWidth = args.experimentalMaximumParallelizationWidth
-    if maximumParallelizationWidth == nil && Test.current == nil {
-      // Don't check the environment variable when a current test is set (which
-      // presumably means we're running our own unit tests).
-      maximumParallelizationWidth = Environment.variable(named: "SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH").flatMap(Int.init)
+  } else if let maximumParallelizationWidth = args.experimentalMaximumParallelizationWidth {
+    if maximumParallelizationWidth < 1 {
+      throw _EntryPointError.invalidArgument("--experimental-maximum-parallelization-width", value: String(describing: maximumParallelizationWidth))
     }
-    if let maximumParallelizationWidth {
-      if maximumParallelizationWidth < 1 {
-        throw _EntryPointError.invalidArgument("--experimental-maximum-parallelization-width", value: String(describing: maximumParallelizationWidth))
-      }
-      configuration.maximumParallelizationWidth = maximumParallelizationWidth
-    }
+    configuration.maximumParallelizationWidth = maximumParallelizationWidth
   }
 
   // Whether or not to symbolicate backtraces in the event stream.

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -28,7 +28,11 @@ public struct Configuration: Sendable {
       maximumParallelizationWidth > 1
     }
     set {
-      maximumParallelizationWidth = newValue ? defaultParallelizationWidth : 1
+      if newValue {
+        maximumParallelizationWidth = max(maximumParallelizationWidth, defaultParallelizationWidth)
+      } else {
+        maximumParallelizationWidth = 1
+      }
     }
   }
 

--- a/Sources/Testing/Support/Serializer.swift
+++ b/Sources/Testing/Support/Serializer.swift
@@ -30,10 +30,14 @@ private var _cpuCoreCount: Int? {
 #endif
 
 /// The default parallelization width when parallelized testing is enabled.
-var defaultParallelizationWidth: Int {
+let defaultParallelizationWidth: Int = {
   // _cpuCoreCount.map { max(1, $0) * 2 } ?? .max
-  .max
-}
+  if let environmentValue = Environment.variable(named: "SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH").flatMap(Int.init),
+     environmentValue > 0 {
+    return environmentValue
+  }
+  return .max
+}()
 
 /// A type whose instances can run a series of work items in strict order.
 ///


### PR DESCRIPTION
This PR moves the check for `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` to an earlier point during startup such that the default value of `Configuration.isParallelizationEnabled` is influenced by it. This ensures that we can respect this value even when not using the SwiftPM entry point.

Resolves rdar://168320560.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
