### PR TITLE
Remove workaround for `fatalError()` call in `Mutex` trylock function.

### DIFF
--- a/Sources/Testing/Support/Locked.swift
+++ b/Sources/Testing/Support/Locked.swift
@@ -28,14 +28,6 @@ struct Locked<T> {
   /// A type providing storage for the underlying lock and wrapped value.
 #if SWT_TARGET_OS_APPLE && !SWT_NO_OS_UNFAIR_LOCK
   private typealias _Storage = ManagedBuffer<T, os_unfair_lock_s>
-#elseif !SWT_FIXED_85448 && (os(Linux) || os(Android))
-  private final class _Storage: ManagedBuffer<T, pthread_mutex_t> {
-    deinit {
-      withUnsafeMutablePointerToElements { lock in
-        _ = pthread_mutex_destroy(lock)
-      }
-    }
-  }
 #elseif canImport(Synchronization)
   private final class _Storage {
     let mutex: Mutex<T>
@@ -60,11 +52,6 @@ extension Locked: RawRepresentable {
     _storage = .create(minimumCapacity: 1, makingHeaderWith: { _ in rawValue })
     _storage.withUnsafeMutablePointerToElements { lock in
       lock.initialize(to: .init())
-    }
-#elseif !SWT_FIXED_85448 && (os(Linux) || os(Android))
-    _storage = _Storage.create(minimumCapacity: 1, makingHeaderWith: { _ in rawValue }) as! _Storage
-    _storage.withUnsafeMutablePointerToElements { lock in
-      _ = pthread_mutex_init(lock, nil)
     }
 #elseif canImport(Synchronization)
     nonisolated(unsafe) let rawValue = rawValue
@@ -105,14 +92,6 @@ extension Locked {
       }
       return try body(&rawValue.pointee)
     }
-#elseif !SWT_FIXED_85448 && (os(Linux) || os(Android))
-     result = try _storage.withUnsafeMutablePointers { rawValue, lock in
-      pthread_mutex_lock(lock)
-      defer {
-        pthread_mutex_unlock(lock)
-      }
-      return try body(&rawValue.pointee)
-    }
 #elseif canImport(Synchronization)
     result = try _storage.mutex.withLock { rawValue in
       try body(&rawValue)
@@ -145,16 +124,6 @@ extension Locked {
       }
       defer {
         os_unfair_lock_unlock(lock)
-      }
-      return try body(&rawValue.pointee)
-    }
-#elseif !SWT_FIXED_85448 && (os(Linux) || os(Android))
-    result = try _storage.withUnsafeMutablePointers { rawValue, lock in
-      guard 0 == pthread_mutex_trylock(lock) else {
-        return nil
-      }
-      defer {
-        pthread_mutex_unlock(lock)
       }
       return try body(&rawValue.pointee)
     }


### PR DESCRIPTION
This PR removes a workaround for an errant `fatalError()` call in the Linux implementation of `Mutex.withLockIfAvailable()`. That call was removed by https://github.com/swiftlang/swift/pull/85448 which is in the Swift 6.3 and 6.4-dev (main) branches.

**Do not merge this PR to `release/6.3` as it will not work with the Swift 6.2 toolchain.**

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
