### PR TITLE
Prepare for potential nonisolated(nonsending) source break in stdlib

### DIFF
--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -203,7 +203,7 @@ extension Test {
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body`.
-  static func withCurrent<R>(_ test: Self, perform body: () async throws -> R) async rethrows -> R {
+  static nonisolated(nonsending) func withCurrent<R>(_ test: Self, perform body: nonisolated(nonsending) () async throws -> R) async rethrows -> R {
     var runtimeState = Runner.RuntimeState.current ?? .init()
     runtimeState.test = test
     runtimeState.testCase = nil
@@ -239,7 +239,7 @@ extension Test.Case {
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body`.
-  static func withCurrent<R>(_ testCase: Self, perform body: () async throws -> R) async rethrows -> R {
+  static func withCurrent<R>(_ testCase: Self, perform body: nonisolated(nonsending) () async throws -> R) async rethrows -> R {
     var runtimeState = Runner.RuntimeState.current ?? .init()
     runtimeState.testCase = testCase
     return try await Runner.RuntimeState.$current.withValue(runtimeState) {

--- a/Sources/Testing/Test+Cancellation.swift
+++ b/Sources/Testing/Test+Cancellation.swift
@@ -106,7 +106,7 @@ extension TestCancellable {
   /// This function sets up a task cancellation handler and calls `body`. If
   /// the current task, test, or test case is cancelled, it records a
   /// corresponding cancellation event.
-  func withCancellationHandling<R>(_ body: () async throws -> R) async rethrows -> R {
+  nonisolated(nonsending) func withCancellationHandling<R>(_ body: nonisolated(nonsending) () async throws -> R) async rethrows -> R {
     let taskCanceller = _TaskCanceller()
     var currentTaskCancellers = _currentTaskCancellers
     currentTaskCancellers[ObjectIdentifier(Self.self)] = taskCanceller

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -90,7 +90,9 @@ extension Test {
               await generator.rawValue()
             }
           }
-          result = await taskGroup.reduce(into: result) { $0.insert($1) }
+          for await task in taskGroup {
+            result.insert(task)
+          }
         }
       }
 
@@ -104,7 +106,10 @@ extension Test {
               await generator.rawValue()
             }
           }
-          result = await taskGroup.reduce(into: result) { $0.insert($1) }
+          // result = await taskGroup.reduce(into: result) { $0.insert($1) } // TODO: reduce is not usable since it sends taskGroup
+          for await task in taskGroup {
+            result.insert(task)
+          }
         }
       }
 #endif


### PR DESCRIPTION
We need to move all async "with..." methods in stdlib to nonisolated(nonsending), this turns out can cause source breakage...

These changes would have to be made in swift-testing for example 

See: https://github.com/swiftlang/swift/pull/80753