### PR TITLE
[CI] Update the github-workflows tag to 0.0.6 to support macOS Tahoe

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   create_merge_pr:
     name: Create PR to merge main into release branch
-    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.4
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.6
     with:
       head_branch: main
       base_branch: release/6.3

--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     with:
       linux_swift_versions: '["nightly-main"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     with:
       linux_swift_versions: '["nightly-6.2"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.3", "nightly-6.2"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
@@ -27,7 +27,7 @@ jobs:
       enable_android_sdk_build: true
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.3
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.6
     with:
       license_header_check_project_name: "Swift"
       docs_check_enabled: false


### PR DESCRIPTION
swiftlang’s self-hosted runners are now running on Tahoe