### PR TITLE
Diagnose more unsupported generic type patterns for suites.

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -634,7 +634,7 @@ extension ExitTestConditionMacro {
           diagnostics.append(.expressionMacroUnsupported(macro, inGenericContextBecauseOf: genericClause, on: lexicalContext))
         } else if let whereClause = lexicalContext.genericWhereClause {
           diagnostics.append(.expressionMacroUnsupported(macro, inGenericContextBecauseOf: whereClause, on: lexicalContext))
-        } else if [.arrayType, .dictionaryType, .optionalType, .implicitlyUnwrappedOptionalType, .inlineArrayType].contains(lexicalContext.type.kind) {
+        } else if lexicalContext.type.isExplicitlyGeneric {
           diagnostics.append(.expressionMacroUnsupported(macro, inGenericContextBecauseOf: lexicalContext.type, on: lexicalContext))
         }
       } else if let functionDecl = lexicalContext.as(FunctionDeclSyntax.self) {

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -189,7 +189,7 @@ func diagnoseIssuesWithLexicalContext(
     diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: genericClause, on: lexicalContext))
   } else if let whereClause = lexicalContext.genericWhereClause {
     diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: whereClause, on: lexicalContext))
-  } else if [.arrayType, .dictionaryType, .optionalType, .implicitlyUnwrappedOptionalType, .inlineArrayType].contains(lexicalContext.type.kind) {
+  } else if lexicalContext.type.isExplicitlyGeneric {
     diagnostics.append(.genericDeclarationNotSupported(decl, whenUsing: attribute, becauseOf: lexicalContext.type, on: lexicalContext))
   }
 

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -143,6 +143,14 @@ struct TestDeclarationMacroTests {
         "Attribute 'Test' cannot be applied to this function because it has been marked '@available(*, noasync)'",
       "@available(*, noasync) struct S { @Suite struct S {} }":
         "Attribute 'Suite' cannot be applied to this structure because it has been marked '@available(*, noasync)'",
+      "extension S<T> { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a generic extension to type 'S<T>'",
+      "extension S<T> { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a generic extension to type 'S<T>'",
+      "extension S<T>.U { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a generic extension to type 'S<T>.U'",
+      "extension S<T>.U { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a generic extension to type 'S<T>.U'",
       "extension [T] { @Test func f() {} }":
         "Attribute 'Test' cannot be applied to a function within a generic extension to type '[T]'",
       "extension [T] { @Suite struct S {} }":
@@ -163,6 +171,14 @@ struct TestDeclarationMacroTests {
         "Attribute 'Test' cannot be applied to a function within a generic extension to type '[1 of T]'",
       "extension [1 of T] { @Suite struct S {} }":
         "Attribute 'Suite' cannot be applied to a structure within a generic extension to type '[1 of T]'",
+      "extension (some T).S { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a generic extension to type '(some T).S'",
+      "extension (some T).S { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a generic extension to type '(some T).S'",
+      "extension (any T).S { @Test func f() {} }":
+        "Attribute 'Test' cannot be applied to a function within a generic extension to type '(any T).S'",
+      "extension (any T).S { @Suite struct S {} }":
+        "Attribute 'Suite' cannot be applied to a structure within a generic extension to type '(any T).S'",
     ]
   )
   func apiMisuseErrors(input: String, expectedMessage: String) throws {


### PR DESCRIPTION
Suites in Swift Testing cannot be generic. This PR "notices" more patterns indicating generic suite types and diagnoses them correctly.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
