### PR TITLE
Remove the separate `accessorDecl` declaration from macro expansions.

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -487,7 +487,17 @@ extension ExitTestConditionMacro {
         named: .identifier("testContentRecord"),
         in: TypeSyntax(IdentifierTypeSyntax(name: enumName)),
         ofKind: .exitTest,
-        accessingWith: .identifier("accessor"),
+        accessingWith: """
+        { outValue, type, hint, _ in
+          Testing.ExitTest.__store(
+            \(idExpr),
+            \(bodyThunkName),
+            into: outValue,
+            asTypeAt: type,
+            withHintAt: hint
+          )
+        }
+        """,
         in: context
       )
 
@@ -508,16 +518,6 @@ extension ExitTestConditionMacro {
         """
         @available(*, deprecated, message: "This type is an implementation detail of the testing library. Do not use it directly.")
         enum \(enumName) {
-          private nonisolated static let accessor: Testing.__TestContentRecordAccessor = { outValue, type, hint, _ in
-            Testing.ExitTest.__store(
-              \(idExpr),
-              \(bodyThunkName),
-              into: outValue,
-              asTypeAt: type,
-              withHintAt: hint
-            )
-          }
-
           \(testContentRecordDecl)
 
           \(recordDecl)

--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -134,23 +134,17 @@ public struct SuiteDeclarationMacro: PeerMacro, Sendable {
       """
     )
 
-    let accessorName = context.makeUniqueName("accessor")
-    result.append(
-      """
-      @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")
-      private nonisolated \(staticKeyword(for: containingType)) let \(accessorName): Testing.__TestContentRecordAccessor = { outValue, type, _, _ in
-        Testing.Test.__store(\(generatorName), into: outValue, asTypeAt: type)
-      }
-      """
-    )
-
     let testContentRecordName = context.makeUniqueName("testContentRecord")
     result.append(
       makeTestContentRecordDecl(
         named: testContentRecordName,
         in: containingType,
         ofKind: .testDeclaration,
-        accessingWith: accessorName,
+        accessingWith: """
+        { outValue, type, _, _ in
+            Testing.Test.__store(\(generatorName), into: outValue, asTypeAt: type)
+        }
+        """,
         context: attributeInfo.testContentRecordFlags,
         in: context
       )

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -48,8 +48,7 @@ enum TestContentKind: UInt32 {
 ///   - typeName: The name of the type enclosing the resulting declaration, or
 ///     `nil` if it will not be emitted into a type's scope.
 ///   - kind: The kind of test content record being emitted.
-///   - accessorName: The Swift name of an `@convention(c)` function to emit
-///     into the resulting record.
+///   - accessorExpr: An expression to use as the record's accessor function.
 ///   - contextFieldValue: A value to emit as the `context` field of the test
 ///     content record.
 ///   - context: The macro context in which the expression is being parsed.
@@ -57,7 +56,7 @@ enum TestContentKind: UInt32 {
 /// - Returns: A variable declaration that, when emitted into Swift source, will
 ///   cause the linker to emit data in a location that is discoverable at
 ///   runtime.
-func makeTestContentRecordDecl(named name: TokenSyntax, in typeName: TypeSyntax? = nil, ofKind kind: TestContentKind, accessingWith accessorName: TokenSyntax, context contextFieldValue: UInt32 = 0, in context: some MacroExpansionContext) -> DeclSyntax {
+func makeTestContentRecordDecl(named name: TokenSyntax, in typeName: TypeSyntax? = nil, ofKind kind: TestContentKind, accessingWith accessorExpr: ExprSyntax, context contextFieldValue: UInt32 = 0, in context: some MacroExpansionContext) -> DeclSyntax {
   let kindExpr = IntegerLiteralExprSyntax(kind.rawValue, radix: .hex)
   let contextExpr = if contextFieldValue == 0 {
     IntegerLiteralExprSyntax(0)
@@ -70,7 +69,7 @@ func makeTestContentRecordDecl(named name: TokenSyntax, in typeName: TypeSyntax?
   private nonisolated \(staticKeyword(for: typeName)) let \(name): Testing.__TestContentRecord = (
     \(kindExpr), \(kind.commentRepresentation)
     0,
-    { unsafe \(accessorName)($0, $1, $2, $3) },
+    \(accessorExpr),
     \(contextExpr),
     0
   )

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -466,23 +466,17 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
       """
     )
 
-    let accessorName = context.makeUniqueName(thunking: functionDecl, withPrefix: "accessor")
-    result.append(
-      """
-      @available(*, deprecated, message: "This property is an implementation detail of the testing library. Do not use it directly.")
-      private \(staticKeyword(for: typeName)) nonisolated let \(accessorName): Testing.__TestContentRecordAccessor = { outValue, type, _, _ in
-        Testing.Test.__store(\(generatorName), into: outValue, asTypeAt: type)
-      }
-      """
-    )
-
     let testContentRecordName = context.makeUniqueName(thunking: functionDecl, withPrefix: "testContentRecord")
     result.append(
       makeTestContentRecordDecl(
         named: testContentRecordName,
         in: typeName,
         ofKind: .testDeclaration,
-        accessingWith: accessorName,
+        accessingWith: """
+        { outValue, type, _, _ in
+          Testing.Test.__store(\(generatorName), into: outValue, asTypeAt: type)
+        }
+        """,
         context: attributeInfo.testContentRecordFlags,
         in: context
       )


### PR DESCRIPTION
When we create a test content record, we need to include an "accessor" function that loads the corresponding Swift value. That function is currently declared as separately from the test content record, then called with:

```swift
{ unsafe \(accessorName)($0, $1, $2, $3) }
```

This is an extra and now-unnecessary level of indirection that we can remove.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
