### PR TITLE
[6.3] Interop: send events to fallback event handler if active configuration not present

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -142,9 +142,18 @@ let package = Package(
       exclude: ["CMakeLists.txt", "Testing.swiftcrossimport"],
       cxxSettings: .packageSettings,
       swiftSettings: .packageSettings + .enableLibraryEvolution() + .moduleABIName("Testing"),
-      linkerSettings: [
-        .linkedLibrary("execinfo", .when(platforms: [.custom("freebsd"), .openbsd]))
-      ]
+      linkerSettings: {
+        var result = [LinkerSetting]()
+        result += [
+          .linkedLibrary("execinfo", .when(platforms: [.custom("freebsd"), .openbsd]))
+        ]
+#if compiler(>=6.3)
+        result += [
+          .linkedLibrary("_TestingInterop"),
+        ]
+#endif
+        return result
+      }()
     ),
     .testTarget(
       name: "TestingTests",

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(Testing
   Attachments/Attachment.swift
   Events/Clock.swift
   Events/Event.swift
+  Events/Event+FallbackHandler.swift
   Events/Recorder/Event.AdvancedConsoleOutputRecorder.swift
   Events/Recorder/Event.ConsoleOutputRecorder.swift
   Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -121,7 +122,8 @@ add_library(Testing
   Traits/Trait.swift)
 target_link_libraries(Testing PRIVATE
   _TestDiscovery
-  _TestingInternals)
+  _TestingInternals
+  _TestingInterop)
 if(NOT APPLE)
   if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
     target_link_libraries(Testing PUBLIC

--- a/Sources/Testing/Events/Event+FallbackHandler.swift
+++ b/Sources/Testing/Events/Event+FallbackHandler.swift
@@ -1,0 +1,49 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+private import _TestingInternals
+
+extension Event {
+#if compiler(>=6.3) && !SWT_NO_INTEROP
+  private static let _fallbackEventHandler: SWTFallbackEventHandler? = {
+    _swift_testing_getFallbackEventHandler()
+  }()
+#endif
+
+  /// Post this event to the currently-installed fallback event handler.
+  ///
+  /// - Parameters:
+  ///   - context: The context associated with this event.
+  ///
+  /// - Returns: Whether or not the fallback event handler was invoked. If the
+  ///   currently-installed handler belongs to the testing library, returns
+  ///   `false`.
+  borrowing func postToFallbackHandler(in context: borrowing Context) -> Bool {
+#if compiler(>=6.3) && !SWT_NO_INTEROP
+    guard let fallbackEventHandler = Self._fallbackEventHandler else {
+      return false
+    }
+
+    // Encode the event as JSON and pass it to the handler.
+    let encodeAndInvoke = ABI.CurrentVersion.eventHandler(encodeAsJSONLines: false) { recordJSON in
+      fallbackEventHandler(
+        String(describing: ABI.CurrentVersion.versionNumber),
+        recordJSON.baseAddress!,
+        recordJSON.count,
+        nil
+      )
+    }
+    encodeAndInvoke(self, context)
+    return true
+#else
+    return false
+#endif
+  }
+}

--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -316,7 +316,10 @@ extension Event {
   /// `configuration` is not `nil`, `self` is passed to its
   /// ``Configuration/eventHandler`` property. If `configuration` is `nil`, and
   /// ``Configuration/current`` is _not_ `nil`, its event handler is used
-  /// instead. If there is no current configuration, the event is posted to
+  /// instead. If there is no current configuration, we try and post the event
+  /// to a fallback event handler, if one exists.
+  ///
+  /// If we still couldn't find somewhere to send the event, we then post it to
   /// the event handlers of all configurations set as current across all tasks
   /// in the process.
   private borrowing func _post(in context: borrowing Context, configuration: Configuration? = nil) {
@@ -326,6 +329,8 @@ extension Event {
       if configuration.eventHandlingOptions.shouldHandleEvent(self) {
         configuration.handleEvent(self, in: context)
       }
+    } else if postToFallbackHandler(in: context) {
+      // The fallback event handler handled this event.
     } else {
       // The current task does NOT have an associated configuration. This event
       // will be lost! Post it to every registered event handler to avoid that.

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -180,6 +180,31 @@ static int swt_setfdflags(int fd, int flags) {
 }
 #endif
 
+#if !SWT_NO_INTEROP
+
+/// A type describing a fallback event handler that testing API can invoke as an
+/// alternate method of reporting test events to the current test runner.
+/// Shadows the type with the same name in _TestingInterop.
+///
+/// - Parameters:
+///   - recordJSONSchemaVersionNumber: The JSON schema version used to encode
+///     the event record.
+///   - recordJSONBaseAddress: A pointer to the first byte of the encoded event.
+///   - recordJSONByteCount: The size of the encoded event in bytes.
+///   - reserved: Reserved for future use.
+typedef void (* SWTFallbackEventHandler)(const char *recordJSONSchemaVersionNumber,
+                                      const void *recordJSONBaseAddress,
+                                      size_t recordJSONByteCount,
+                                      const void *_Nullable reserved);
+
+/// Get the current fallback event handler.
+/// Shadows the function with the same name in _TestingInterop.
+///
+/// - Returns: The currently-set handler function, if any.
+SWT_EXTERN SWTFallbackEventHandler _Nullable _swift_testing_getFallbackEventHandler(void);
+
+#endif
+
 SWT_ASSUME_NONNULL_END
 
 #endif

--- a/Sources/_TestingInterop/FallbackEventHandler.swift
+++ b/Sources/_TestingInterop/FallbackEventHandler.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if !SWT_NO_INTEROP
+#if compiler(>=6.3) && !SWT_NO_INTEROP
 #if SWT_TARGET_OS_APPLE && !SWT_NO_OS_UNFAIR_LOCK && !hasFeature(Embedded)
 private import _TestingInternals
 #else

--- a/Tests/TestingTests/EventHandlingInteropTests.swift
+++ b/Tests/TestingTests/EventHandlingInteropTests.swift
@@ -1,0 +1,67 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+private import _TestingInternals
+@testable @_spi(ForToolsIntegrationOnly) import Testing
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+#if !SWT_NO_EXIT_TESTS && compiler(>=6.3) && !SWT_NO_INTEROP && canImport(Foundation)
+struct EventHandlingInteropTests {
+  private typealias InstallFallbackEventHandler =
+    @convention(c) (SWTFallbackEventHandler) -> CBool
+  private static let installer: InstallFallbackEventHandler? = {
+    symbol(named: "_swift_testing_installFallbackEventHandler").map {
+      castCFunction(at: $0, to: InstallFallbackEventHandler.self)
+    }
+  }()
+
+  static let handlerContents = Locked<(version: String, record: String?)?>(rawValue: nil)
+
+  private static let capturingHandler: SWTFallbackEventHandler = { schemaVersion, recordJSONBaseAddress, recordJSONByteCount, _ in
+    let version = String(cString: schemaVersion)
+    let record = String(
+      data: Data(bytes: recordJSONBaseAddress, count: recordJSONByteCount),
+      encoding: .utf8)
+    Self.handlerContents.withLock {
+      $0 = (version: version, record: record)
+    }
+  }
+
+  /// This uses an exit test to run in a clean process, ensuring that the
+  /// installed fallback event handler does not affect other tests.
+  ///
+  /// Note this test will no longer work once Swift Testing starts installing
+  /// its own fallback handler.
+  @Test func `Post event without config -> fallback handler`() async throws {
+    await #expect(processExitsWith: .success) {
+      let installer = try #require(Self.installer)
+      try #require(
+        installer(Self.capturingHandler), "Installation of fallback handler should succeed")
+
+      // The detached task forces the event to be posted when Configuration.current
+      // is nil and triggers the post to fallback handler path
+      await Task.detached {
+        Event.post(.issueRecorded(Issue(kind: .system)), configuration: nil)
+      }.value
+
+      // Assert that the expectation failure contents were sent to the fallback event handler
+      try Self.handlerContents.withLock {
+        let contents = try #require(
+          $0, "Fallback should have been called with non nil contents")
+        #expect(contents.version == "6.3")
+        #expect(contents.record?.contains("A system failure occurred") ?? false)
+      }
+    }
+  }
+}
+#endif

--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -52,3 +52,8 @@ if(SWT_TESTING_LIBRARY_VERSION)
   message(STATUS "Swift Testing version: ${SWT_TESTING_LIBRARY_VERSION}")
   add_compile_definitions("$<$<COMPILE_LANGUAGE:CXX>:SWT_TESTING_LIBRARY_VERSION=\"${SWT_TESTING_LIBRARY_VERSION}\">")
 endif()
+
+if(NOT BUILD_SHARED_LIBS)
+  # When building a static library, Interop is not supported at this time
+  add_compile_definitions("SWT_NO_INTEROP")
+endif()


### PR DESCRIPTION
- **Explanation**:
  Turn unhandled issues into events and sent to the fallback event handler if
  one has been installed.

- **Scope**:
  Users can only execute this new code path if:
  1. they install a fallback event handler and
  2. record an unhandled issue (e.g. `XCTAssert` in the body of a Swift Testing
     test case).

  Existing tests may satisfy condition 2, but neither swift-corelibs-xctest nor
  Swift Testing install a fallback event handler. When that happens, the
  interoperability functionality will initially be opt-in. Details about the
  phased rollout of interoperability are included in
  https://github.com/jerryjrchen/swift-evolution/blob/swt-xct-interop/proposals/testing/NNNN-targeted-interoperability-swift-testing-and-xctest.md#interoperability-modes

- **Issues**:
  n/a

- **Original PRs**:
  #1439

- **Risk**:
  Links a new dylib, _TestingInterop. Uses the fallback event handler getter
  from this library, but looks it up using dlsym/GetProcAddress to avoid crashing due to missing symbols at runtime.

- **Testing**:
  Validate in CI that we can link against _TestingInterop.
  Automated testing to validate that we are forwarding unhandled events to the
  new fallback event handler.

- **Reviewers**:
  @stmontgomery 

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
