### PR TITLE
FreeBSD: bsearch pointer is Nonnull

### DIFF
--- a/Sources/Testing/Support/Additions/ArrayAdditions.swift
+++ b/Sources/Testing/Support/Additions/ArrayAdditions.swift
@@ -54,7 +54,7 @@ extension Array {
       return withUnsafePointer(to: context) { context in
         self.withUnsafeBufferPointer { elements in
           let result = bsearch(context, elements.baseAddress!, elements.count, MemoryLayout<Element>.stride) { contextAddress, elementAddress in
-#if os(Android)
+#if os(Android) || os(FreeBSD)
             let contextAddress = contextAddress as UnsafeRawPointer?
 #endif
             let context = contextAddress!.load(as: _BinarySearchContext.self)


### PR DESCRIPTION
The pointer passed into the compare function is marked Nonnull in the FreeBSD stdlib header. This causes a build failure due to the unwrap.

```
error: cannot force unwrap value of non-optional type 'UnsafeRawPointer'
```

Fixing it for FreeBSD.