### PR TITLE
Don't set `SWT_NO_INTEROP` on WASI.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -411,18 +411,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .define("SWT_NO_LIBDISPATCH", .whenEmbedded()),
     ]
 
-    // XCTest interop is not available in Embedded Swift. It is not (currently)
-    // available on WASI with the Swift 6.3 toolchain.
-#if compiler(>=6.4)
-    result += [
-      .define("SWT_NO_INTEROP", .whenEmbedded()),
-    ]
-#else
-    result += [
-      .define("SWT_NO_INTEROP", .whenEmbedded(or: .when(platforms: [.wasi]))),
-    ]
-#endif
-
     return result
   }
 
@@ -504,18 +492,6 @@ extension Array where Element == PackageDescription.CXXSetting {
       .define("SWT_NO_LEGACY_TEST_DISCOVERY", .whenEmbedded()),
       .define("SWT_NO_LIBDISPATCH", .whenEmbedded()),
     ]
-
-    // XCTest interop is not available in Embedded Swift. It is not (currently)
-    // available on WASI with the Swift 6.3 toolchain.
-#if compiler(>=6.4)
-    result += [
-      .define("SWT_NO_INTEROP", .whenEmbedded()),
-    ]
-#else
-    result += [
-      .define("SWT_NO_INTEROP", .whenEmbedded(or: .when(platforms: [.wasi]))),
-    ]
-#endif
 
     // Capture the testing library's commit info as C++ constants.
     if let git {

--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -53,7 +53,7 @@ if(SWT_TESTING_LIBRARY_VERSION)
   add_compile_definitions("$<$<COMPILE_LANGUAGE:CXX>:SWT_TESTING_LIBRARY_VERSION=\"${SWT_TESTING_LIBRARY_VERSION}\">")
 endif()
 
-if(NOT BUILD_SHARED_LIBS)
+if((NOT BUILD_SHARED_LIBS) && (NOT CMAKE_SYSTEM_NAME STREQUAL WASI))
   # When building a static library, Interop is not supported at this time
   add_compile_definitions("SWT_NO_INTEROP")
 endif()


### PR DESCRIPTION
The toolchain on the release/6.3 branch has regressed because we are inadvertently setting `SWT_NO_INTEROP` on WASI in the CMake build but not in the SwiftPM manifest. This change was unintentional.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
