### PR TITLE
[6.3] Don't set `SWT_NO_INTEROP` on WASI.

### DIFF
--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -53,7 +53,7 @@ if(SWT_TESTING_LIBRARY_VERSION)
   add_compile_definitions("$<$<COMPILE_LANGUAGE:CXX>:SWT_TESTING_LIBRARY_VERSION=\"${SWT_TESTING_LIBRARY_VERSION}\">")
 endif()
 
-if((NOT BUILD_SHARED_LIBS) && (NOT CMAKE_SYSTEM_NAME STREQUAL WASI))
+if((NOT BUILD_SHARED_LIBS) AND (NOT CMAKE_SYSTEM_NAME STREQUAL WASI))
   # When building a static library, Interop is not supported at this time
   add_compile_definitions("SWT_NO_INTEROP")
 endif()


### PR DESCRIPTION
- **Explanation**: Fixes us incorrectly excluding the exported symbols from `_TestingInterop` on WASI/Wasm.
- **Scope**: WASI/Wasm toolchain
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1512
- **Risk**: No obvious risk, restores previous behaviour
- **Testing**: Manually tested CMake script at desk
- **Reviewers**: @jerryjrchen @stmontgomery