### PR TITLE
CMake: Add autolink entry for TestingInterop library

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -143,7 +143,8 @@ if(NOT BUILD_SHARED_LIBS)
   # libraries.
   target_compile_options(Testing PRIVATE
     "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestDiscovery"
-    "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestingInternals")
+    "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestingInternals"
+    "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestingInterop")
 endif()
 add_dependencies(Testing
   TestingMacros)


### PR DESCRIPTION
The `lib_TestingInterop.a` library should be autolinked when linking the Testing library in static builds.

### Motivation:

 This patch fixes the linkage issue on the latest main snapshot of Swift SDK for Wasm:

```
wasm-ld: error: path/to/swift_static/wasi/libTesting.a(ABIEntryPoint.swift.obj): undefined symbol: _swift_testing_getFallbackEventHandler
```

### Modifications:

Just declare `_TestingInterop` as an auto-linked library

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
