### PR TITLE
[6.3] CMake: Add autolink entry for TestingInterop library

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -141,7 +141,8 @@ if(NOT BUILD_SHARED_LIBS)
   # libraries.
   target_compile_options(Testing PRIVATE
     "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestDiscovery"
-    "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestingInternals")
+    "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestingInternals"
+    "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestingInterop")
 endif()
 add_dependencies(Testing
   TestingMacros)


### PR DESCRIPTION
- **Explanation**: Fixes the linkage issue by auto-linking the new interop library:.
- **Scope**: WASI/Wasm toolchain
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1516
- **Risk**: No obvious risk
- **Testing**: Manually tested CMake script at desk
- **Reviewers**: @jerryjrchen @stmontgomery