### PR TITLE
Modify `boxCopyableValue(_:)` to take `~Escapable` values too.

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -173,7 +173,7 @@ extension Attachment: CustomStringConvertible where AttachableValue: ~Copyable {
   ///   @Available(Xcode, introduced: 26.0)
   /// }
   public var description: String {
-    if #available(_castingWithNonCopyableGenerics, *), let attachableValue = boxCopyableValue(attachableValue) {
+    if #available(_castingWithNonCopyableGenerics, *), let attachableValue = makeExistential(attachableValue) {
       return #""\#(preferredName)": \#(String(describingForTest: attachableValue))"#
     }
     let typeInfo = TypeInfo(describing: AttachableValue.self)

--- a/Sources/Testing/Support/Additions/CopyableAdditions.swift
+++ b/Sources/Testing/Support/Additions/CopyableAdditions.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2025–2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -9,22 +9,32 @@
 //
 
 #if !hasFeature(Embedded)
-/// A helper protocol for ``boxCopyableValue(_:)``.
-private protocol _CopyablePointer {
-  /// Load the value at this address into an existential box.
+/// A helper protocol for ``makeExistential(_:)``.
+private protocol _CopierProtocol<Referent> {
+  /// The type of value that a conforming type can copy.
+  associatedtype Referent
+
+  /// Cast the given value to `Any`.
   ///
-  /// - Returns: The value at this address.
-  func load() -> Any
+  /// - Parameters:
+  ///   - value: The value to cast.
+  ///
+  /// - Returns: `value` cast to `Any`.
+  static func cast(_ value: Referent) -> Any
 }
 
-extension UnsafePointer: _CopyablePointer where Pointee: Copyable {
-  func load() -> Any {
-    pointee
+/// A helper type for ``makeExistential(_:)``
+private struct _Copier<Referent> where Referent: ~Copyable & ~Escapable {}
+
+extension _Copier: _CopierProtocol where Referent: Copyable & Escapable {
+  static func cast(_ value: Referent) -> Any {
+    value
   }
 }
 #endif
 
-/// Copy a value to an existential box if its type conforms to `Copyable`.
+/// Copy a value to an existential box if its type conforms to `Copyable` and
+/// `Escapable`.
 ///
 /// - Parameters:
 ///   - value: The value to copy.
@@ -35,13 +45,14 @@ extension UnsafePointer: _CopyablePointer where Pointee: Copyable {
 /// When using Embedded Swift, this function always returns `nil`.
 #if !hasFeature(Embedded)
 @available(_castingWithNonCopyableGenerics, *)
-func boxCopyableValue(_ value: borrowing some ~Copyable) -> Any? {
-  withUnsafePointer(to: value) { address in
-    return (address as? any _CopyablePointer)?.load()
+func makeExistential<T>(_ value: borrowing T) -> Any? where T: ~Copyable & ~Escapable {
+  if let type = _Copier<T>.self as? any _CopierProtocol<T>.Type {
+    return type.cast(value)
   }
+  return nil
 }
 #else
-func boxCopyableValue(_ value: borrowing some ~Copyable) -> Void? {
+func makeExistential<T>(_ value: borrowing T) -> Void? where T: ~Copyable & ~Escapable {
   nil
 }
 #endif


### PR DESCRIPTION
This PR changes `boxCopyableValue(_:)` into `makeExistential(_:)` which can take values of types with suppressed conformances to `~Escapable`, not just `~Copyable`. The change also gets us away from using `UnsafePointer` as a helper type (this use of `UnsafePointer` isn't inherently unsafe, but still, the fewer pointers the better.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
