### PR TITLE
Revert "Adopt `Span`/`RawSpan` almost everywhere."

### DIFF
--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -14,7 +14,7 @@ private import Foundation
 extension ABI.Version {
   static func eventHandler(
     encodeAsJSONLines: Bool,
-    forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: borrowing RawSpan) -> Void
+    forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
   ) -> Event.Handler {
     // Encode as JSON Lines if requested.
     var eventHandlerCopy = eventHandler
@@ -44,7 +44,7 @@ extension ABI.Version {
 extension ABI.Xcode16 {
   static func eventHandler(
     encodeAsJSONLines: Bool,
-    forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: borrowing RawSpan) -> Void
+    forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
   ) -> Event.Handler {
     return { event, context in
       if case .testDiscovered = event.kind {
@@ -63,7 +63,9 @@ extension ABI.Xcode16 {
         eventContext: Event.Context.Snapshot(snapshotting: context)
       )
       try? JSON.withEncoding(of: snapshot) { eventAndContextJSON in
-        eventHandler(eventAndContextJSON)
+        eventAndContextJSON.withUnsafeBytes { eventAndContextJSON in
+          eventHandler(eventAndContextJSON)
+        }
       }
     }
   }

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -37,7 +37,7 @@ extension ABI {
     /// associated context is created and is passed to `eventHandler`.
     static func eventHandler(
       encodeAsJSONLines: Bool,
-      forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: borrowing RawSpan) -> Void
+      forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
     ) -> Event.Handler
 #endif
   }

--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -48,11 +48,9 @@ extension ABI.v0 {
   public static var entryPoint: EntryPoint {
     return { configurationJSON, recordHandler in
       let args = try configurationJSON.map { configurationJSON in
-        try JSON.decode(__CommandLineArguments_v0.self, from: configurationJSON.bytes)
+        try JSON.decode(__CommandLineArguments_v0.self, from: configurationJSON)
       }
-      let eventHandler = try eventHandlerForStreamingEvents(withVersionNumber: args?.eventStreamVersionNumber, encodeAsJSONLines: false) { recordJSON in
-        recordJSON.withUnsafeBytes(recordHandler)
-      }
+      let eventHandler = try eventHandlerForStreamingEvents(withVersionNumber: args?.eventStreamVersionNumber, encodeAsJSONLines: false, forwardingTo: recordHandler)
 
       switch await Testing.entryPoint(passing: args, eventHandler: eventHandler) {
       case EXIT_SUCCESS, EXIT_NO_TESTS_FOUND:

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -425,7 +425,9 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   if let path = args.argumentValue(forLabel: "--configuration-path") ?? args.argumentValue(forLabel: "--experimental-configuration-path") {
     let file = try FileHandle(forReadingAtPath: path)
     let configurationJSON = try file.readToEnd()
-    result = try JSON.decode(__CommandLineArguments_v0.self, from: configurationJSON.span.bytes)
+    result = try configurationJSON.withUnsafeBufferPointer { configurationJSON in
+      try JSON.decode(__CommandLineArguments_v0.self, from: .init(configurationJSON))
+    }
 
     // NOTE: We don't return early or block other arguments here: a caller is
     // allowed to pass a configuration AND e.g. "--verbose" and they'll both be
@@ -704,7 +706,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 func eventHandlerForStreamingEvents(
   withVersionNumber versionNumber: VersionNumber?,
   encodeAsJSONLines: Bool,
-  forwardingTo targetEventHandler: @escaping @Sendable (borrowing RawSpan) -> Void
+  forwardingTo targetEventHandler: @escaping @Sendable (UnsafeRawBufferPointer) -> Void
 ) throws -> Event.Handler {
   let versionNumber = versionNumber ?? ABI.CurrentVersion.versionNumber
   guard let abi = ABI.version(forVersionNumber: versionNumber) else {

--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -467,7 +467,7 @@ extension Attachment where AttachableValue: ~Copyable {
     // There should be no code path that leads to this call where the attachable
     // value is nil.
     try withUnsafeBytes { buffer in
-      try file!.write(buffer.bytes)
+      try file!.write(buffer)
     }
 
     return result

--- a/Sources/Testing/Events/Event+FallbackHandler.swift
+++ b/Sources/Testing/Events/Event+FallbackHandler.swift
@@ -12,26 +12,8 @@ private import _TestingInternals
 
 extension Event {
 #if compiler(>=6.3) && !SWT_NO_INTEROP
-  /// The installed fallback event handler.
   private static let _fallbackEventHandler: SWTFallbackEventHandler? = {
     _swift_testing_getFallbackEventHandler()
-  }()
-
-  /// Encode an event and pass it to the installed fallback event handler.
-  private static let _encodeAndInvoke: Event.Handler? = { [fallbackEventHandler = _fallbackEventHandler] in
-    guard let fallbackEventHandler else {
-      return nil
-    }
-    return ABI.CurrentVersion.eventHandler(encodeAsJSONLines: false) { recordJSON in
-      recordJSON.withUnsafeBytes { recordJSON in
-        fallbackEventHandler(
-          String(describing: ABI.CurrentVersion.versionNumber),
-          recordJSON.baseAddress!,
-          recordJSON.count,
-          nil
-        )
-      }
-    }
   }()
 #endif
 
@@ -45,12 +27,23 @@ extension Event {
   ///   `false`.
   borrowing func postToFallbackHandler(in context: borrowing Context) -> Bool {
 #if compiler(>=6.3) && !SWT_NO_INTEROP
-    // Encode the event as JSON and pass it to the handler.
-    if let encodeAndInvoke = Self._encodeAndInvoke {
-      encodeAndInvoke(self, context)
-      return true
+    guard let fallbackEventHandler = Self._fallbackEventHandler else {
+      return false
     }
-#endif
+
+    // Encode the event as JSON and pass it to the handler.
+    let encodeAndInvoke = ABI.CurrentVersion.eventHandler(encodeAsJSONLines: false) { recordJSON in
+      fallbackEventHandler(
+        String(describing: ABI.CurrentVersion.versionNumber),
+        recordJSON.baseAddress!,
+        recordJSON.count,
+        nil
+      )
+    }
+    encodeAndInvoke(self, context)
+    return true
+#else
     return false
+#endif
   }
 }

--- a/Sources/Testing/Support/Additions/ArrayAdditions.swift
+++ b/Sources/Testing/Support/Additions/ArrayAdditions.swift
@@ -67,52 +67,6 @@ extension Array {
   }
 }
 
-// MARK: - Span/RawSpan support
-
-extension Array where Element == UInt8 {
-  init(_ bytes: borrowing RawSpan) {
-    self = bytes.withUnsafeBytes { Array($0) }
-  }
-}
-
-#if SWT_TARGET_OS_APPLE
-extension Array {
-  /// The elements of this array as a span.
-  ///
-  /// This property is equivalent to the `span` property in the Swift standard
-  /// library, but is available on earlier Apple platforms.
-  ///
-  /// For arrays with contiguous storage, getting the value of this property is
-  /// an _O_(1) operation. For arrays with non-contiguous storage (i.e. bridged
-  /// from Objective-C), the operation may be up to _O_(_n_).
-  var span: Span<Element> {
-    @_lifetime(borrow self)
-    _read {
-      let slice = self[...]
-      yield slice.span
-    }
-  }
-}
-
-extension String.UTF8View {
-  /// A raw span representing this string as UTF-8, not including a trailing
-  /// null character.
-  ///
-  /// This property is equivalent to the `span` property in the Swift standard
-  /// library, but is available on earlier Apple platforms.
-  var span: Span<Element> {
-    @_lifetime(borrow self)
-    _read {
-      // This implementation incurs a copy even for native Swift strings. This
-      // isn't currently a hot path in the testing library though.
-      yield ContiguousArray(self).span
-    }
-  }
-}
-#endif
-
-// MARK: - Parameter pack additions
-
 /// Get the number of elements in a parameter pack.
 ///
 /// - Parameters:

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -29,7 +29,7 @@ enum JSON {
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body` or by the encoding process.
-  static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: any Sendable] = [:], _ body: (borrowing RawSpan) throws -> R) throws -> R {
+  static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: any Sendable] = [:], _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
 #if canImport(Foundation)
     let encoder = JSONEncoder()
 
@@ -44,7 +44,7 @@ enum JSON {
     encoder.userInfo.merge(userInfo, uniquingKeysWith: { _, rhs in rhs})
 
     let data = try encoder.encode(value)
-    return try body(data.bytes)
+    return try data.withUnsafeBytes(body)
 #else
     throw SystemError(description: "JSON encoding requires Foundation which is not available in this environment.")
 #endif
@@ -60,17 +60,14 @@ enum JSON {
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body`.
-  static func asJSONLine<R>(_ json: borrowing RawSpan, _ body: (borrowing RawSpan) throws -> R) rethrows -> R {
-    let containsASCIINewline = json.withUnsafeBytes { json in
-      json.contains(where: \.isASCIINewline)
-    }
-    if _slowPath(containsASCIINewline) {
+  static func asJSONLine<R>(_ json: UnsafeRawBufferPointer, _ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    if _slowPath(json.contains(where: \.isASCIINewline)) {
       // Remove the newline characters to conform to JSON lines specification.
       // This is not actually expected to happen in practice with Foundation's
       // JSON encoder.
       var json = Array(json)
       json.removeAll(where: \.isASCIINewline)
-      return try body(json.span.bytes)
+      return try json.withUnsafeBytes(body)
     } else {
       // No newlines found, no need to copy the buffer.
       return try body(json)
@@ -86,22 +83,20 @@ enum JSON {
   /// - Returns: An instance of `T` decoded from `jsonRepresentation`.
   ///
   /// - Throws: Whatever is thrown by the decoding process.
-  static func decode<T>(_ type: T.Type, from jsonRepresentation: borrowing RawSpan) throws -> T where T: Decodable {
+  static func decode<T>(_ type: T.Type, from jsonRepresentation: UnsafeRawBufferPointer) throws -> T where T: Decodable {
 #if canImport(Foundation)
     try withExtendedLifetime(jsonRepresentation) {
-      try jsonRepresentation.withUnsafeBytes { jsonRepresentation in
-        let byteCount = jsonRepresentation.count
-        let data = if byteCount > 0 {
-          Data(
-            bytesNoCopy: .init(mutating: jsonRepresentation.baseAddress!),
-            count: byteCount,
-            deallocator: .none
-          )
-        } else {
-          Data()
-        }
-        return try JSONDecoder().decode(type, from: data)
+      let byteCount = jsonRepresentation.count
+      let data = if byteCount > 0 {
+        Data(
+          bytesNoCopy: .init(mutating: jsonRepresentation.baseAddress!),
+          count: byteCount,
+          deallocator: .none
+        )
+      } else {
+        Data()
       }
+      return try JSONDecoder().decode(type, from: data)
     }
 #else
     throw SystemError(description: "JSON decoding requires Foundation which is not available in this environment.")

--- a/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
@@ -113,7 +113,9 @@ func loadTagColors(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String? 
   // nil is a valid decoded color value (representing "no color") that we can
   // use for merging tag color data from multiple sources, but it is not valid
   // as an actual tag color, so we have a step here that filters it.
-  return try JSON.decode([Tag: Tag.Color?].self, from: tagColorsData.span.bytes)
-    .compactMapValues { $0 }
+  return try tagColorsData.withUnsafeBytes { tagColorsData in
+    try JSON.decode([Tag: Tag.Color?].self, from: tagColorsData)
+      .compactMapValues { $0 }
+  }
 }
 #endif

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -77,10 +77,20 @@ struct FileHandleTests {
   func canWrite() throws {
     try withTemporaryPath { path in
       let fileHandle = try FileHandle(forWritingAtPath: path)
-      try fileHandle.write([0, 1, 2, 3, 4, 5].span.bytes)
+      try fileHandle.write([0, 1, 2, 3, 4, 5])
       try fileHandle.write("Hello world!")
     }
   }
+
+#if !SWT_NO_EXIT_TESTS
+  @Test("Writing requires contiguous storage")
+  func writeIsContiguous() async {
+    await #expect(processExitsWith: .failure) {
+      let fileHandle = try FileHandle.null(mode: "wb")
+      try fileHandle.write([1, 2, 3, 4, 5].lazy.filter { $0 == 1 })
+    }
+  }
+#endif
 
   @Test("Can read from a file")
   func canRead() throws {
@@ -90,7 +100,7 @@ struct FileHandleTests {
     try withTemporaryPath { path in
       do {
         let fileHandle = try FileHandle(forWritingAtPath: path)
-        try fileHandle.write(bytes.span.bytes)
+        try fileHandle.write(bytes)
       }
       let fileHandle = try FileHandle(forReadingAtPath: path)
       let bytes2 = try fileHandle.readToEnd()
@@ -102,7 +112,7 @@ struct FileHandleTests {
   func cannotWriteBytesToReadOnlyFile() throws {
     let fileHandle = try FileHandle.null(mode: "rb")
     #expect(throws: CError.self) {
-      try fileHandle.write([0, 1, 2, 3, 4, 5].span.bytes)
+      try fileHandle.write([0, 1, 2, 3, 4, 5])
     }
   }
 

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -26,7 +26,9 @@ private func decodedEventStreamRecords<V: ABI.Version>(fromPath filePath: String
   try FileHandle(forReadingAtPath: filePath).readToEnd()
     .split(whereSeparator: \.isASCIINewline)
     .map { line in
-      try JSON.decode(ABI.Record<V>.self, from: line.span.bytes)
+      try line.withUnsafeBytes { line in
+        return try JSON.decode(ABI.Record<V>.self, from: line)
+      }
     }
 }
 

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -38,7 +38,9 @@ struct Test_Case_Argument_IDTests {
     #expect(arguments.count == 1)
     let argument = try #require(arguments.first)
 #if canImport(Foundation)
-    let decodedArgument = try JSON.decode(MyCustomTestArgument.self, from: argument.id.bytes.span.bytes)
+    let decodedArgument = try argument.id.bytes.withUnsafeBufferPointer { argumentID in
+      try JSON.decode(MyCustomTestArgument.self, from: .init(argumentID))
+    }
     #expect(decodedArgument == MyCustomTestArgument(x: 123, y: "abc"))
 #endif
   }

--- a/Tests/TestingTests/Test.CaseTests.swift
+++ b/Tests/TestingTests/Test.CaseTests.swift
@@ -74,7 +74,7 @@ struct Test_CaseTests {
           {"bytes": [1]}
         ]}
         """.utf8)
-      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData.bytes)
+      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData)
       #expect(testCaseID.isStable)
 
       let argumentIDs = try #require(testCaseID.argumentIDs)
@@ -83,7 +83,7 @@ struct Test_CaseTests {
 
     @Test func legacyDecoding_nonStable() throws {
       let encodedData = Data("{}".utf8)
-      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData.bytes)
+      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData)
       #expect(!testCaseID.isStable)
 
       let argumentIDs = try #require(testCaseID.argumentIDs)
@@ -92,7 +92,7 @@ struct Test_CaseTests {
 
     @Test func legacyDecoding_nonParameterized() throws {
       let encodedData = Data(#"{"argumentIDs": []}"#.utf8)
-      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData.bytes)
+      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData)
       #expect(testCaseID.isStable)
       #expect(testCaseID.argumentIDs == nil)
       #expect(testCaseID.discriminator == nil)
@@ -100,7 +100,7 @@ struct Test_CaseTests {
 
     @Test func newDecoding_nonParameterized() throws {
       let encodedData = Data(#"{"isStable": true}"#.utf8)
-      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData.bytes)
+      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData)
       #expect(testCaseID.isStable)
       #expect(testCaseID.argumentIDs == nil)
       #expect(testCaseID.discriminator == nil)
@@ -116,7 +116,7 @@ struct Test_CaseTests {
           "discriminator": 0
         }
         """.utf8)
-      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData.bytes)
+      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData)
       #expect(testCaseID.isStable)
       #expect(testCaseID.argumentIDs?.count == 1)
       #expect(testCaseID.discriminator == 0)

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -412,6 +412,24 @@ extension JSON {
       try JSON.decode(T.self, from: data)
     }
   }
+
+#if canImport(Foundation)
+  /// Decode a value from JSON data.
+  ///
+  /// - Parameters:
+  ///   - type: The type of value to decode.
+  ///   - jsonRepresentation: Data of the JSON encoding of the value to decode.
+  ///
+  /// - Returns: An instance of `T` decoded from `jsonRepresentation`.
+  ///
+  /// - Throws: Whatever is thrown by the decoding process.
+  @_disfavoredOverload
+  static func decode<T>(_ type: T.Type, from jsonRepresentation: Data) throws -> T where T: Decodable {
+    try jsonRepresentation.withUnsafeBytes { bytes in
+      try JSON.decode(type, from: bytes)
+    }
+  }
+#endif
 }
 
 @available(_clockAPI, *)

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -127,7 +127,7 @@ struct TagListTests {
   func tagColorsReadFromDisk() throws {
     let tempDirPath = try temporaryDirectory()
     let jsonPath = appendPathComponent("tag-colors.json", to: tempDirPath)
-    let jsonContent = """
+    var jsonContent = """
     {
     "alpha": "red",
     "beta": "#00CCFF",
@@ -142,7 +142,7 @@ struct TagListTests {
     "encode purple": "purple"
     }
     """
-    do {
+    try jsonContent.withUTF8 { jsonContent in
       let fileHandle = try FileHandle(forWritingAtPath: jsonPath)
       try fileHandle.write(jsonContent)
     }
@@ -173,8 +173,11 @@ struct TagListTests {
 
   @Test("Invalid tag color decoding", arguments: [##""#NOTHEX""##, #""garbageColorName""#])
   func noTagColorsReadFromBadPath(tagColorJSON: String) throws {
-    _ = #expect(throws: (any Error).self) {
-      _ = try JSON.decode(Tag.Color.self, from: tagColorJSON.utf8.span.bytes)
+    var tagColorJSON = tagColorJSON
+    tagColorJSON.withUTF8 { tagColorJSON in
+      _ = #expect(throws: (any Error).self) {
+        _ = try JSON.decode(Tag.Color.self, from: .init(tagColorJSON))
+      }
     }
   }
 #endif


### PR DESCRIPTION
Reverts swiftlang/swift-testing#1500

Testing to see if this resolves CI failures, such as:

> https://ci.swift.org/job/swift-package-manager-PR-macos-smoke-test/8192/consoleText