### PR TITLE
Add documentation to Parallelization.md describing how the `.serialized` trait can be applied to a test suite across different files.

### DIFF
--- a/Sources/Testing/Testing.docc/Parallelization.md
+++ b/Sources/Testing/Testing.docc/Parallelization.md
@@ -65,8 +65,8 @@ up a live database for integration testing. You may want to have a large suite
 of tests across many files use that same database, but concurrent access to the
 database could cause test failures. To achieve this, you can mark a test suite
 as ``Trait/serialized`` and extend that type across your various files.
-Furthermore, because ``Trait/serialized`` is applied recursively, you can even
-put your tests in sub-suites.
+Because the testing library recursively applies `Trait/serialized` to all test
+content within a suite, you can even put your tests in sub-suites.
 
 - `FoodTruckDatabaseTests.swift`
   ```swift


### PR DESCRIPTION
Add documentation to Parallelization.md describing how the `.serialized` trait can be applied to a test suite across different files.

Resolves #686

### Motivation:

After a discussion in #683, we decided it would be helpful for folks to see an example of how you can use the `.serialized` trait to split your serialized tests across multiple files.

### Modifications:

- Added a section to Parallelization.md to describe the `.serialized` trait's behavior when split across multiple files
- Update the title of another section in the same file to adhere to the [style guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
