### PR TITLE
Always cast the `bsearch()` context argument to optional.

### DIFF
--- a/Sources/Testing/Support/Additions/ArrayAdditions.swift
+++ b/Sources/Testing/Support/Additions/ArrayAdditions.swift
@@ -54,9 +54,10 @@ extension Array {
       return withUnsafePointer(to: context) { context in
         self.withUnsafeBufferPointer { elements in
           let result = bsearch(context, elements.baseAddress!, elements.count, MemoryLayout<Element>.stride) { contextAddress, elementAddress in
-#if os(Android) || os(FreeBSD)
-            let contextAddress = contextAddress as UnsafeRawPointer?
-#endif
+            // Some platforms mark this argument `_Nonnull`, so unconditionally
+            // cast it to an optional before loading from it (the compiler will
+            // optimize this line away).
+            let contextAddress: UnsafeRawPointer? = contextAddress
             let context = contextAddress!.load(as: _BinarySearchContext.self)
             return context.compare(elementAddress)
           }


### PR DESCRIPTION
Different platforms assign different nullability to the `context` argument of `bsearch()`'s callback function. For consistency's sake and to avoid problems porting to future platforms, always cast the value to an optional before loading from it. The compiler is smart enough to eliminate the copy/cast, so this is ultimately a zero-cost no-op.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
