### PR TITLE
Move test repetition down to the test case level

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -117,10 +117,18 @@ extension ABI {
       case .testStarted:
         kind = .testStarted
       case .testCaseStarted:
+        // For non-parameterized tests, we elide `testCaseStarted` calls because it would be
+        // redundant. However, for multiple iterations of a test case within a non-parameterized
+        // function, we need to emit another `testStarted` event.
         if eventContext.test?.isParameterized == false {
-          return nil
+          if let iteration = eventContext.iteration, iteration > 1 {
+            kind = .testStarted
+          } else {
+            return nil
+          }
+        } else {
+          kind = .testCaseStarted
         }
-        kind = .testCaseStarted
       case let .issueRecorded(recordedIssue):
         kind = .issueRecorded
         issue = EncodedIssue(encoding: recordedIssue, in: eventContext)
@@ -129,9 +137,14 @@ extension ABI {
         self.attachment = EncodedAttachment(encoding: attachment)
       case .testCaseEnded:
         if eventContext.test?.isParameterized == false {
-          return nil
+          if let iteration = eventContext.iteration, iteration > 1 {
+            kind = .testEnded
+          } else {
+            return nil
+          }
+        } else {
+          kind = .testCaseEnded
         }
-        kind = .testCaseEnded
       case .testCaseCancelled:
         kind = .testCaseCancelled
       case .testEnded:
@@ -164,6 +177,7 @@ extension ABI {
           let .testCancelled(skipInfo):
           _comments = Array(skipInfo.comment).map(\.rawValue)
           _sourceLocation = skipInfo.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
+          _iteration = eventContext.iteration
         default:
           break
         }

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -333,6 +333,9 @@ public struct __CommandLineArguments_v0: Sendable {
   /// The value of the `--repeat-until` argument.
   public var repeatUntil: String?
 
+  /// Whether or not to use the per-test-case repetition mode.
+  var usePerTestCaseRepetition: Bool = false
+
   /// The value of the `--attachments-path` argument.
   public var attachmentsPath: String?
 }
@@ -537,6 +540,9 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   if let repeatUntil = args.argumentValue(forLabel: "--repeat-until") {
     result.repeatUntil = repeatUntil
   }
+  if args.contains("--experimental-per-test-case-repetition") {
+    result.usePerTestCaseRepetition = true
+  }
 
   return result
 }
@@ -664,6 +670,9 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     }
   }
   configuration.repetitionPolicy = repetitionPolicy
+
+  // Opt in to per-test-case repetition
+  configuration.shouldUseLegacyPlanLevelRepetition = !args.usePerTestCaseRepetition
 
 #if !SWT_NO_EXIT_TESTS
   // Enable exit test handling via __swiftPMEntryPoint().

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(Testing
   Running/Runner.Plan+Dumping.swift
   Running/Runner.RuntimeState.swift
   Running/Runner.swift
+  Running/Runner+Repetition.swift
   Running/SkipInfo.swift
   SourceAttribution/Backtrace.swift
   SourceAttribution/Backtrace+Symbolication.swift

--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -238,7 +238,6 @@ public struct Event: Sendable {
   static func post(
     _ kind: Kind,
     for testAndTestCase: (Test?, Test.Case?) = currentTestAndTestCase(),
-    iteration: Int? = nil,
     instant: Test.Clock.Instant = .now,
     configuration: Configuration? = nil
   ) {
@@ -262,7 +261,12 @@ public struct Event: Sendable {
       }
     }
     let event = Event(kind, testID: test?.id, testCaseID: testCase?.id, instant: instant)
-    let context = Event.Context(test: test, testCase: testCase, iteration: iteration, configuration: nil)
+    let context = Event.Context(
+      test: test,
+      testCase: testCase,
+      iteration: Test.currentIteration,
+      configuration: nil
+    )
     event._post(in: context, configuration: configuration)
   }
 }
@@ -327,8 +331,6 @@ extension Event {
       iteration: Int?,
       configuration: Configuration?
     ) {
-      // Ensure that if `iteration` is specified, the test is also specified.
-      precondition(iteration == nil || (iteration != nil && test != nil))
       self.test = test
       self.testCase = testCase
       self.iteration = iteration

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -365,6 +365,10 @@ extension Event.HumanReadableOutputRecorder {
       String(describing: TimeValue(rawValue: end.suspending.rawValue - start.suspending.rawValue))
     }
 
+    func testStartedMessage(for test: Test) -> String {
+      "\(_capitalizedTitle(for: test)) \(testName) started"
+    }
+
     // Finally, produce any messages for the event.
     switch event.kind {
     case .testDiscovered:
@@ -425,7 +429,7 @@ extension Event.HumanReadableOutputRecorder {
       return [
         Message(
           symbol: .default,
-          stringValue: "\(_capitalizedTitle(for: test)) \(testName) started."
+          stringValue: "\(testStartedMessage(for: test))."
         )
       ]
 
@@ -565,15 +569,26 @@ extension Event.HumanReadableOutputRecorder {
       return result
 
     case .testCaseStarted:
-      guard let testCase, testCase.isParameterized, let arguments = testCase.arguments else {
+      guard let test, let testCase else { break }
+      let iteration = eventContext.iteration ?? 1
+
+      var message: String
+      if testCase.isParameterized, let arguments = testCase.arguments {
+        message = "Test case passing \(arguments.count.counting("argument")) \(testCase.labeledArguments(includingQualifiedTypeNames: verbosity > 0)) to \(testName) started"
+      } else if iteration > 1 {
+        message = testStartedMessage(for: test)
+      } else {
         break
       }
 
+      if iteration > 1 {
+        message += " (repetition \(iteration))"
+      }
+
+      message += "."
+
       return [
-        Message(
-          symbol: .default,
-          stringValue: "Test case passing \(arguments.count.counting("argument")) \(testCase.labeledArguments(includingQualifiedTypeNames: verbosity > 0)) to \(testName) started."
-        )
+        Message(symbol: .default, stringValue: message)
       ]
 
     case .testCaseEnded:

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -132,6 +132,11 @@ public struct Configuration: Sendable {
     }
   }
 
+  /// Whether to perform test repetition at the plan level or on a per-test-
+  /// case basis.
+  @_spi(Experimental)
+  public var shouldUseLegacyPlanLevelRepetition: Bool = true
+
   /// Whether or not, and how, to iterate the test plan repeatedly.
   ///
   /// By default, the value of this property allows for a single iteration.

--- a/Sources/Testing/Running/Runner+Repetition.swift
+++ b/Sources/Testing/Running/Runner+Repetition.swift
@@ -8,6 +8,10 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if canImport(Synchronization)
+private import Synchronization
+#endif
+
 extension Runner {
   /// A thread-safe set of test+case IDs that have recorded issues.
   /// This keeps track of tests that recorded an issue during a test repetition

--- a/Sources/Testing/Running/Runner+Repetition.swift
+++ b/Sources/Testing/Running/Runner+Repetition.swift
@@ -18,11 +18,11 @@ extension Runner {
   /// and is used by the repetition machinery to determine if an issue was recorded
   /// during a run.
   final class TestIssueRecorder: Sendable {
-    struct ID: Hashable {
+    private struct ID: Hashable {
       var testID: Test.ID
       var testCaseID: Test.Case.ID
     }
-    let ids = Mutex<Set<ID>>([])
+    private let ids = Mutex<Set<ID>>([])
 
     var hasIssues: Bool {
       ids.withLock { !$0.isEmpty }

--- a/Sources/Testing/Running/Runner+Repetition.swift
+++ b/Sources/Testing/Running/Runner+Repetition.swift
@@ -1,0 +1,92 @@
+//
+//  Runner+Repetition.swift
+//  swift-testing
+//
+//  Created by Harlan Haskins on 5/5/26.
+//
+
+extension Runner {
+  /// A thread-safe set of test+case IDs that have recorded issues.
+  /// This keeps track of tests that recorded an issue during a test repetition
+  /// and is used by the repetition machinery to determine if an issue was recorded
+  /// during a run.
+  final class TestIssueRecorder: Sendable {
+    struct ID: Hashable {
+      var testID: Test.ID
+      var testCaseID: Test.Case.ID
+    }
+    let ids = Mutex<Set<ID>>([])
+
+    var hasIssues: Bool {
+      ids.withLock { !$0.isEmpty }
+    }
+
+    func recordIssue(for test: Test.ID, testCase: Test.Case.ID) {
+      ids.withLock {
+        _ = $0.insert(ID(testID: test, testCaseID: testCase))
+      }
+    }
+
+    func consumeIssue(for test: Test.ID, testCase: Test.Case.ID) -> Bool {
+      ids.withLock {
+        $0.remove(ID(testID: test, testCaseID: testCase)) != nil
+      }
+    }
+
+    func clear() {
+      ids.withLock { $0.removeAll() }
+    }
+  }
+
+  /// Applies the repetition policy specified in the current configuration by running the provided test case
+  /// repeatedly until the continuation condition is satisfied.
+  ///
+  /// - Parameters:
+  ///   - body: The actual body of the function which must ultimately call into the test function.
+  ///   - didRecordIssue: A closure passed by the caller to determine if an issue was recorded during
+  ///   the test run.
+  static func _applyRepetitionPolicy(
+    _ policy: Configuration.RepetitionPolicy,
+    perform body: () async -> Void,
+    didRecordIssue: () -> Bool
+  ) async {
+    for iteration in 1...policy.maximumIterationCount {
+      await Test.withCurrentIteration(iteration) {
+        await body()
+      }
+
+      let recordedIssue = didRecordIssue()
+
+      // Determine if the test plan should iterate again.
+      let shouldContinue = switch policy.continuationCondition {
+      case nil:
+        true
+      case .untilIssueRecorded:
+        !recordedIssue
+      case .whileIssueRecorded:
+        recordedIssue
+      }
+      guard shouldContinue else {
+        break
+      }
+    }
+  }
+
+  mutating func configureIssueRecordingEventHandling(testIssueRecorder: TestIssueRecorder) {
+    configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
+      defer {
+        oldEventHandler(event, context)
+      }
+
+      guard
+        case .issueRecorded = event.kind,
+        let testID = event.testID,
+        let testCaseID = event.testCaseID
+      else {
+        return
+      }
+
+      testIssueRecorder.recordIssue(for: testID, testCase: testCaseID)
+    }
+  }
+}

--- a/Sources/Testing/Running/Runner+Repetition.swift
+++ b/Sources/Testing/Running/Runner+Repetition.swift
@@ -81,19 +81,11 @@ extension Runner {
 
   mutating func configureIssueRecordingEventHandling(testIssueRecorder: TestIssueRecorder) {
     configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
-      defer {
-        oldEventHandler(event, context)
+      if case .issueRecorded = event.kind, let testID = event.testID, let testCaseID = event.testCaseID {
+        testIssueRecorder.recordIssue(for: testID, testCase: testCaseID)
       }
 
-      guard
-        case .issueRecorded = event.kind,
-        let testID = event.testID,
-        let testCaseID = event.testCaseID
-      else {
-        return
-      }
-
-      testIssueRecorder.recordIssue(for: testID, testCase: testCaseID)
+      oldEventHandler(event, context)
     }
   }
 }

--- a/Sources/Testing/Running/Runner+Repetition.swift
+++ b/Sources/Testing/Running/Runner+Repetition.swift
@@ -1,8 +1,11 @@
 //
-//  Runner+Repetition.swift
-//  swift-testing
+// This source file is part of the Swift.org open source project
 //
-//  Created by Harlan Haskins on 5/5/26.
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
 extension Runner {

--- a/Sources/Testing/Running/Runner+Repetition.swift
+++ b/Sources/Testing/Running/Runner+Repetition.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -18,40 +18,59 @@ extension Runner {
   /// and is used by the repetition machinery to determine if an issue was recorded
   /// during a run.
   final class TestIssueRecorder: Sendable {
-    private struct ID: Hashable {
+    /// A composite identifier uniquely naming a test case within a test.
+    private struct _ID: Hashable {
       var testID: Test.ID
       var testCaseID: Test.Case.ID
     }
-    private let ids = Mutex<Set<ID>>([])
 
+    /// The set of recorded issue identifiers, protected by a mutex.
+    private let _ids = Mutex<Set<_ID>>([])
+
+    /// Whether any issue has been recorded since the recorder was last cleared.
     var hasIssues: Bool {
-      ids.withLock { !$0.isEmpty }
+      _ids.withLock { !$0.isEmpty }
     }
 
+    /// Record that an issue was observed for a given test case.
+    ///
+    /// - Parameters:
+    ///   - test: The ID of the test whose case recorded the issue.
+    ///   - testCase: The ID of the test case which recorded the issue.
     func recordIssue(for test: Test.ID, testCase: Test.Case.ID) {
-      ids.withLock {
-        _ = $0.insert(ID(testID: test, testCaseID: testCase))
+      _ids.withLock {
+        _ = $0.insert(_ID(testID: test, testCaseID: testCase))
       }
     }
 
+    /// Remove a recorded issue for a given test case, returning whether one was present.
+    ///
+    /// - Parameters:
+    ///   - test: The ID of the test whose case should be consumed.
+    ///   - testCase: The ID of the test case to consume.
+    ///
+    /// - Returns: `true` if an issue had been recorded for the specified test case
+    ///   since the recorder was last cleared; otherwise `false`.
     func consumeIssue(for test: Test.ID, testCase: Test.Case.ID) -> Bool {
-      ids.withLock {
-        $0.remove(ID(testID: test, testCaseID: testCase)) != nil
+      _ids.withLock {
+        $0.remove(_ID(testID: test, testCaseID: testCase)) != nil
       }
     }
 
+    /// Remove all recorded issues from this recorder.
     func clear() {
-      ids.withLock { $0.removeAll() }
+      _ids.withLock { $0.removeAll() }
     }
   }
 
-  /// Applies the repetition policy specified in the current configuration by running the provided test case
-  /// repeatedly until the continuation condition is satisfied.
+  /// Applies a repetition policy by running the provided body repeatedly until its
+  /// continuation condition is satisfied.
   ///
   /// - Parameters:
+  ///   - policy: The repetition policy to apply.
   ///   - body: The actual body of the function which must ultimately call into the test function.
   ///   - didRecordIssue: A closure passed by the caller to determine if an issue was recorded during
-  ///   the test run.
+  ///     the test run.
   static func _applyRepetitionPolicy(
     _ policy: Configuration.RepetitionPolicy,
     perform body: () async -> Void,
@@ -79,6 +98,11 @@ extension Runner {
     }
   }
 
+  /// Wire this runner's configuration event handler through the given issue recorder
+  /// so that recorded issues are tracked during a run.
+  ///
+  /// - Parameters:
+  ///   - testIssueRecorder: The recorder to notify of any recorded issues.
   mutating func configureIssueRecordingEventHandling(testIssueRecorder: TestIssueRecorder) {
     configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
       if case .issueRecorded = event.kind, let testID = event.testID, let testCaseID = event.testCaseID {

--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -29,6 +29,9 @@ extension Runner {
     /// The test case that is running on the current task, if any.
     var testCase: Test.Case?
 
+    /// The current iteration of the test repetition policy, if any.
+    var iteration: Int?
+
     /// The runtime state related to the runner running on the current task,
     /// if any.
     @TaskLocal
@@ -198,7 +201,7 @@ extension Configuration {
   }
 }
 
-// MARK: - Current test and test case
+// MARK: - Current test, test case, and iteration
 
 extension Test {
   /// The test that is running on the current task, if any.
@@ -231,6 +234,28 @@ extension Test {
     runtimeState.testCase = nil
     return try await Runner.RuntimeState.$current.withValue(runtimeState) {
       try await test.withCancellationHandling(body)
+    }
+  }
+
+  /// The current iteration of the currently-running test case, if any.
+  static var currentIteration: Int? {
+    Runner.RuntimeState.current?.iteration
+  }
+
+  /// Call a function while the value of ``Test/currentIteration`` is set.
+  ///
+  /// - Parameters:
+  ///   - iteration: The new value to set for ``Test/currentIteration``.
+  ///   - body: A function to call.
+  ///
+  /// - Returns: Whatever is returned by `body`.
+  ///
+  /// - Throws: Whatever is thrown by `body`.
+  static func withCurrentIteration<R>(_ iteration: Int?, perform body: () async throws -> R) async rethrows -> R {
+    var runtimeState = Runner.RuntimeState.current ?? .init()
+    runtimeState.iteration = iteration
+    return try await Runner.RuntimeState.$current.withValue(runtimeState) {
+      try await body()
     }
   }
 }

--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -74,15 +74,22 @@ extension Configuration {
   ///
   /// - Parameters:
   ///   - configuration: The new value to set for ``Configuration/current``.
+  ///   - addingToAll: Whether to add this configuration to the set of implicitly-tracked ``Configuration``s that are told about detached Issues.
   ///   - body: A function to call.
   ///
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body`.
-  static func withCurrent<R>(_ configuration: Self, perform body: () throws -> R) rethrows -> R {
-    let id = configuration._addToAll()
+  static func withCurrent<R>(
+    _ configuration: Self,
+    addingToAll: Bool = true,
+    perform body: () throws -> R
+  ) rethrows -> R {
+    let id = addingToAll ? configuration._addToAll() : nil
     defer {
-      configuration._removeFromAll(identifiedBy: id)
+      if let id {
+        configuration._removeFromAll(identifiedBy: id)
+      }
     }
 
     var runtimeState = Runner.RuntimeState.current ?? .init()
@@ -95,15 +102,22 @@ extension Configuration {
   ///
   /// - Parameters:
   ///   - configuration: The new value to set for ``Configuration/current``.
+  ///   - addingToAll: Whether to add this configuration to the set of implicitly-tracked ``Configuration``s that are told about detached Issues.
   ///   - body: A function to call.
   ///
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body`.
-  static func withCurrent<R>(_ configuration: Self, perform body: () async throws -> R) async rethrows -> R {
-    let id = configuration._addToAll()
+  static func withCurrent<R>(
+    _ configuration: Self,
+    addingToAll: Bool = true,
+    perform body: () async throws -> R
+  ) async rethrows -> R {
+    let id = addingToAll ? configuration._addToAll() : nil
     defer {
-      configuration._removeFromAll(identifiedBy: id)
+      if let id {
+        configuration._removeFromAll(identifiedBy: id)
+      }
     }
 
     var runtimeState = Runner.RuntimeState.current ?? .init()

--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -74,7 +74,6 @@ extension Configuration {
   ///
   /// - Parameters:
   ///   - configuration: The new value to set for ``Configuration/current``.
-  ///   - addingToAll: Whether to add this configuration to the set of implicitly-tracked ``Configuration``s that are told about detached Issues.
   ///   - body: A function to call.
   ///
   /// - Returns: Whatever is returned by `body`.
@@ -82,14 +81,11 @@ extension Configuration {
   /// - Throws: Whatever is thrown by `body`.
   static func withCurrent<R>(
     _ configuration: Self,
-    addingToAll: Bool = true,
     perform body: () throws -> R
   ) rethrows -> R {
-    let id = addingToAll ? configuration._addToAll() : nil
+    let id = configuration._addToAll()
     defer {
-      if let id {
-        configuration._removeFromAll(identifiedBy: id)
-      }
+      configuration._removeFromAll(identifiedBy: id)
     }
 
     var runtimeState = Runner.RuntimeState.current ?? .init()
@@ -102,7 +98,6 @@ extension Configuration {
   ///
   /// - Parameters:
   ///   - configuration: The new value to set for ``Configuration/current``.
-  ///   - addingToAll: Whether to add this configuration to the set of implicitly-tracked ``Configuration``s that are told about detached Issues.
   ///   - body: A function to call.
   ///
   /// - Returns: Whatever is returned by `body`.
@@ -110,14 +105,11 @@ extension Configuration {
   /// - Throws: Whatever is thrown by `body`.
   static func withCurrent<R>(
     _ configuration: Self,
-    addingToAll: Bool = true,
     perform body: () async throws -> R
   ) async rethrows -> R {
-    let id = addingToAll ? configuration._addToAll() : nil
+    let id = configuration._addToAll()
     defer {
-      if let id {
-        configuration._removeFromAll(identifiedBy: id)
-      }
+      configuration._removeFromAll(identifiedBy: id)
     }
 
     var runtimeState = Runner.RuntimeState.current ?? .init()

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -226,10 +226,10 @@ extension Runner {
     // Determine what kind of event to send for this step based on its action.
     switch step.action {
     case .run:
-      Event.post(.testStarted, for: (step.test, nil), iteration: context.iteration, configuration: configuration)
+      Event.post(.testStarted, for: (step.test, nil), configuration: configuration)
       shouldSendTestEnded = true
     case let .skip(skipInfo):
-      Event.post(.testSkipped(skipInfo), for: (step.test, nil), iteration: context.iteration, configuration: configuration)
+      Event.post(.testSkipped(skipInfo), for: (step.test, nil), configuration: configuration)
       shouldSendTestEnded = false
     case let .recordIssue(issue):
       // Scope posting the issue recorded event such that issue handling
@@ -247,7 +247,7 @@ extension Runner {
     }
     defer {
       if shouldSendTestEnded {
-        Event.post(.testEnded, for: (step.test, nil), iteration: context.iteration, configuration: configuration)
+        Event.post(.testEnded, for: (step.test, nil), configuration: configuration)
       }
     }
 
@@ -506,7 +506,7 @@ extension Runner {
       }
 
       await Test.withCurrentIteration(iteration) {
-        await Configuration.withCurrent(config) {
+        await Configuration.withCurrent(config, addingToAll: false) {
           await body()
         }
       }

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -82,9 +82,6 @@ extension Runner {
   private struct _Context: Sendable {
     /// A serializer used to reduce parallelism among test cases.
     var testCaseSerializer: Serializer<Void>?
-
-    /// Which iteration of the test plan is being executed.
-    var iteration: Int
   }
 
   /// Apply the custom scope for any test scope providers of the traits
@@ -422,9 +419,9 @@ extension Runner {
       if let testCaseSerializer = context.testCaseSerializer {
         // Note that if .serialized is applied to an inner scope, we still use
         // this serializer (if set) so that we don't overcommit.
-        await testCaseSerializer.run { await _runTestCase(testCase, within: step, context: context) }
+        await testCaseSerializer.run { await _runTestCase(testCase, within: step) }
       } else {
-        await _runTestCase(testCase, within: step, context: context)
+        await _runTestCase(testCase, within: step)
       }
     }
   }
@@ -434,16 +431,36 @@ extension Runner {
   /// - Parameters:
   ///   - testCase: The test case to run.
   ///   - step: The runner plan step associated with this test case.
-  ///   - context: Context for the test run.
   ///
   /// This function sets ``Test/Case/current``, then invokes the test case's
   /// body closure.
-  private static func _runTestCase(_ testCase: Test.Case, within step: Plan.Step, context: _Context) async {
+  private static func _runTestCase(
+    _ testCase: Test.Case,
+    within step: Plan.Step
+  ) async {
+    if _configuration.shouldUseLegacyPlanLevelRepetition {
+      await _runSingleTestCaseIteration(testCase, within: step)
+    } else {
+      await _applyRepetitionPolicy {
+        await _runSingleTestCaseIteration(testCase, within: step)
+      }
+    }
+  }
+
+  /// Run a single iteration of a test case.
+  ///
+  /// - Parameters:
+  ///   - testCase: The test case to run.
+  ///   - step: The runner plan step associated with this test case.
+  ///
+  /// This function sets ``Test/Case/current``, then invokes the test case's
+  /// body closure.
+  private static func _runSingleTestCaseIteration(_ testCase: Test.Case, within step: Plan.Step) async {
     let configuration = _configuration
 
-    Event.post(.testCaseStarted, for: (step.test, testCase), iteration: context.iteration, configuration: configuration)
+    Event.post(.testCaseStarted, for: (step.test, testCase), configuration: configuration)
     defer {
-      Event.post(.testCaseEnded, for: (step.test, testCase), iteration: context.iteration, configuration: configuration)
+      Event.post(.testCaseEnded, for: (step.test, testCase), configuration: configuration)
     }
 
     await Test.Case.withCurrent(testCase) {
@@ -468,6 +485,47 @@ extension Runner {
     }
   }
 
+  /// Applies the repetition policy specified in the current configuration by running the provided test case
+  /// repeatedly until the continuation condition is satisfied.
+  ///
+  /// - Parameters:
+  ///   - body: The actual body of the function which must ultimately call into the test function.
+  ///
+  /// - Note: This function updates ``Configuration/current`` before invoking the test body.
+  private static func _applyRepetitionPolicy(
+    perform body: () async -> Void
+  ) async {
+    for iteration in 1..._configuration.repetitionPolicy.maximumIterationCount {
+      let issueRecorded = Atomic(false)
+      var config = _configuration
+      config.eventHandler = { [eventHandler = config.eventHandler] event, context in
+        if case let .issueRecorded(issue) = event.kind, !issue.isKnown {
+          issueRecorded.store(true, ordering: .sequentiallyConsistent)
+        }
+        eventHandler(event, context)
+      }
+
+      await Test.withCurrentIteration(iteration) {
+        await Configuration.withCurrent(config) {
+          await body()
+        }
+      }
+
+      // Determine if the test plan should iterate again.
+      let shouldContinue = switch config.repetitionPolicy.continuationCondition {
+      case nil:
+        true
+      case .untilIssueRecorded:
+        !issueRecorded.load(ordering: .sequentiallyConsistent)
+      case .whileIssueRecorded:
+        issueRecorded.load(ordering: .sequentiallyConsistent)
+      }
+      guard shouldContinue else {
+        break
+      }
+    }
+  }
+
   /// Run the tests in this runner's plan.
   public func run() async {
     await Self._run(self)
@@ -488,21 +546,12 @@ extension Runner {
 #endif
     _ = Event.installFallbackEventHandler()
 
-    // Track whether or not any issues were recorded across the entire run.
-    let issueRecorded = Atomic(false)
-    runner.configuration.eventHandler = { [eventHandler = runner.configuration.eventHandler] event, context in
-      if case let .issueRecorded(issue) = event.kind, !issue.isKnown {
-        issueRecorded.store(true, ordering: .sequentiallyConsistent)
-      }
-      eventHandler(event, context)
-    }
-
     // Context to pass into the test run. We intentionally don't pass the Runner
     // itself (implicitly as `self` nor as an argument) because we don't want to
     // accidentally depend on e.g. the `configuration` property rather than the
     // current configuration.
     let context: _Context = {
-      var context = _Context(iteration: 0)
+      var context = _Context()
 
       let maximumParallelizationWidth = runner.configuration.maximumParallelizationWidth
       if maximumParallelizationWidth > 1 && maximumParallelizationWidth < .max {
@@ -526,45 +575,30 @@ extension Runner {
         Event.post(.runEnded, for: (nil, nil), configuration: runner.configuration)
       }
 
-      let repetitionPolicy = runner.configuration.repetitionPolicy
-      let iterationCount = repetitionPolicy.maximumIterationCount
-      for iterationIndex in 0 ..< iterationCount {
-        Event.post(.iterationStarted(iterationIndex), for: (nil, nil), configuration: runner.configuration)
-        defer {
-          Event.post(.iterationEnded(iterationIndex), for: (nil, nil), configuration: runner.configuration)
-        }
+      if runner.configuration.shouldUseLegacyPlanLevelRepetition {
+        await _applyRepetitionPolicy { [runner] in
+          let iteration = Test.currentIteration ?? 1
 
-        await withTaskGroup { [runner] taskGroup in
-          var taskAction: String?
-          if iterationCount > 1 {
-            taskAction = "running iteration #\(iterationIndex + 1)"
+          // Legacy clients expect these values to be zero-indexed.
+          let iterationIndex = iteration - 1
+          Event.post(.iterationStarted(iterationIndex), configuration: runner.configuration)
+          defer {
+            Event.post(.iterationEnded(iterationIndex), configuration: runner.configuration)
           }
-          _ = taskGroup.addTaskUnlessCancelled(name: decorateTaskName("test run", withAction: taskAction)) {
-            var iterationContext = context
-            // `iteration` is one-indexed, so offset that here.
-            iterationContext.iteration = iterationIndex + 1
-            try? await _runStep(atRootOf: runner.plan.stepGraph, context: iterationContext)
-          }
-          await taskGroup.waitForAll()
+          await runner._runAllTests(context: context)
         }
-
-        // Determine if the test plan should iterate again. (The iteration count
-        // is handled by the outer for-loop.)
-        let shouldContinue = switch repetitionPolicy.continuationCondition {
-        case nil:
-          true
-        case .untilIssueRecorded:
-          !issueRecorded.load(ordering: .sequentiallyConsistent)
-        case .whileIssueRecorded:
-          issueRecorded.load(ordering: .sequentiallyConsistent)
-        }
-        guard shouldContinue else {
-          break
-        }
-
-        // Reset the run-wide "issue was recorded" flag for this iteration.
-        issueRecorded.store(false, ordering: .sequentiallyConsistent)
+      } else {
+        await runner._runAllTests(context: context)
       }
+    }
+  }
+
+  private func _runAllTests(context: _Context) async {
+    await withTaskGroup { taskGroup in
+      _ = taskGroup.addTaskUnlessCancelled(name: decorateTaskName("test run", withAction: nil)) {
+        try? await Self._runStep(atRootOf: plan.stepGraph, context: context)
+      }
+      await taskGroup.waitForAll()
     }
   }
 }

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -424,9 +424,9 @@ extension Runner {
       if let testCaseSerializer = context.testCaseSerializer {
         // Note that if .serialized is applied to an inner scope, we still use
         // this serializer (if set) so that we don't overcommit.
-        await testCaseSerializer.run { await _runTestCase(testCase, in: context, within: step) }
+        await testCaseSerializer.run { await _runTestCase(testCase, within: step, in: context) }
       } else {
-        await _runTestCase(testCase, in: context, within: step)
+        await _runTestCase(testCase, within: step, in: context)
       }
     }
   }
@@ -435,15 +435,15 @@ extension Runner {
   ///
   /// - Parameters:
   ///   - testCase: The test case to run.
-  ///   - context: Context for the test run.
   ///   - step: The runner plan step associated with this test case.
+  ///   - context: Context for the test run.
   ///
   /// This function sets ``Test/Case/current``, then invokes the test case's
   /// body closure.
   private static func _runTestCase(
     _ testCase: Test.Case,
-    in context: _Context,
     within step: Plan.Step,
+    in context: _Context,
   ) async {
     if _configuration.shouldUseLegacyPlanLevelRepetition {
       await _runSingleTestCaseIteration(testCase, within: step)

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -83,8 +83,9 @@ extension Runner {
     /// A serializer used to reduce parallelism among test cases.
     var testCaseSerializer: Serializer<Void>?
 
-    /// A set of test+case IDs that have recorded at least one issue during a test run.
-    /// This is consumed
+    /// A set of test+case IDs that have recorded at least one issue during a
+    /// test run. This is consumed by the per-test-case repetition machinery to
+    /// determine whether a test case's iteration recorded an issue.
     let testIssueRecorder = TestIssueRecorder()
   }
 
@@ -434,6 +435,7 @@ extension Runner {
   ///
   /// - Parameters:
   ///   - testCase: The test case to run.
+  ///   - context: Context for the test run.
   ///   - step: The runner plan step associated with this test case.
   ///
   /// This function sets ``Test/Case/current``, then invokes the test case's
@@ -566,6 +568,10 @@ extension Runner {
     }
   }
 
+  /// Run every test in this runner's plan.
+  ///
+  /// - Parameters:
+  ///   - context: Context for the test run.
   private func _runAllTests(context: _Context) async {
     await withTaskGroup { taskGroup in
       _ = taskGroup.addTaskUnlessCancelled(name: decorateTaskName("test run", withAction: nil)) {

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -82,6 +82,10 @@ extension Runner {
   private struct _Context: Sendable {
     /// A serializer used to reduce parallelism among test cases.
     var testCaseSerializer: Serializer<Void>?
+
+    /// A set of test+case IDs that have recorded at least one issue during a test run.
+    /// This is consumed
+    let testIssueRecorder = TestIssueRecorder()
   }
 
   /// Apply the custom scope for any test scope providers of the traits
@@ -419,9 +423,9 @@ extension Runner {
       if let testCaseSerializer = context.testCaseSerializer {
         // Note that if .serialized is applied to an inner scope, we still use
         // this serializer (if set) so that we don't overcommit.
-        await testCaseSerializer.run { await _runTestCase(testCase, within: step) }
+        await testCaseSerializer.run { await _runTestCase(testCase, in: context, within: step) }
       } else {
-        await _runTestCase(testCase, within: step)
+        await _runTestCase(testCase, in: context, within: step)
       }
     }
   }
@@ -436,13 +440,16 @@ extension Runner {
   /// body closure.
   private static func _runTestCase(
     _ testCase: Test.Case,
-    within step: Plan.Step
+    in context: _Context,
+    within step: Plan.Step,
   ) async {
     if _configuration.shouldUseLegacyPlanLevelRepetition {
       await _runSingleTestCaseIteration(testCase, within: step)
     } else {
-      await _applyRepetitionPolicy {
+      await _applyRepetitionPolicy(_configuration.repetitionPolicy) {
         await _runSingleTestCaseIteration(testCase, within: step)
+      } didRecordIssue: {
+        context.testIssueRecorder.consumeIssue(for: step.test.id, testCase: testCase.id)
       }
     }
   }
@@ -485,47 +492,6 @@ extension Runner {
     }
   }
 
-  /// Applies the repetition policy specified in the current configuration by running the provided test case
-  /// repeatedly until the continuation condition is satisfied.
-  ///
-  /// - Parameters:
-  ///   - body: The actual body of the function which must ultimately call into the test function.
-  ///
-  /// - Note: This function updates ``Configuration/current`` before invoking the test body.
-  private static func _applyRepetitionPolicy(
-    perform body: () async -> Void
-  ) async {
-    for iteration in 1..._configuration.repetitionPolicy.maximumIterationCount {
-      let issueRecorded = Atomic(false)
-      var config = _configuration
-      config.eventHandler = { [eventHandler = config.eventHandler] event, context in
-        if case let .issueRecorded(issue) = event.kind, !issue.isKnown {
-          issueRecorded.store(true, ordering: .sequentiallyConsistent)
-        }
-        eventHandler(event, context)
-      }
-
-      await Test.withCurrentIteration(iteration) {
-        await Configuration.withCurrent(config, addingToAll: false) {
-          await body()
-        }
-      }
-
-      // Determine if the test plan should iterate again.
-      let shouldContinue = switch config.repetitionPolicy.continuationCondition {
-      case nil:
-        true
-      case .untilIssueRecorded:
-        !issueRecorded.load(ordering: .sequentiallyConsistent)
-      case .whileIssueRecorded:
-        issueRecorded.load(ordering: .sequentiallyConsistent)
-      }
-      guard shouldContinue else {
-        break
-      }
-    }
-  }
-
   /// Run the tests in this runner's plan.
   public func run() async {
     await Self._run(self)
@@ -561,6 +527,8 @@ extension Runner {
       return context
     }()
 
+    runner.configureIssueRecordingEventHandling(testIssueRecorder: context.testIssueRecorder)
+
     await Configuration.withCurrent(runner.configuration) {
       // Post an event for every test in the test plan being run. These events
       // are turned into JSON objects if JSON output is enabled.
@@ -576,7 +544,9 @@ extension Runner {
       }
 
       if runner.configuration.shouldUseLegacyPlanLevelRepetition {
-        await _applyRepetitionPolicy { [runner] in
+        await _applyRepetitionPolicy(runner.configuration.repetitionPolicy) { [runner] in
+          context.testIssueRecorder.clear()
+
           let iteration = Test.currentIteration ?? 1
 
           // Legacy clients expect these values to be zero-indexed.
@@ -585,7 +555,10 @@ extension Runner {
           defer {
             Event.post(.iterationEnded(iterationIndex), configuration: runner.configuration)
           }
+
           await runner._runAllTests(context: context)
+        } didRecordIssue: {
+          context.testIssueRecorder.hasIssues
         }
       } else {
         await runner._runAllTests(context: context)

--- a/Tests/TestingTests/EventIterationTests.swift
+++ b/Tests/TestingTests/EventIterationTests.swift
@@ -44,7 +44,7 @@ struct EventIterationTests {
 
       // Verify all expected iterations were recorded
       let iteration = recordedIteration.load(ordering: .sequentiallyConsistent)
-      #expect(iteration == expectedIterations, "Final observed iteration did not match expected number of iterations", sourceLocation: location)
+      #expect(iteration == expectedIterations, sourceLocation: location)
     }
   }
 
@@ -57,17 +57,6 @@ struct EventIterationTests {
       return true
     default:
       return false
-    }
-  }
-
-  @Test
-  func `testStarted and testEnded events include iteration in context`() async {
-    await verifyIterations(
-      for: [.testStarted, .testEnded],
-      repetitionPolicy: .once,
-      expectedIterations: 1
-    ) { _ in
-      // Do nothing, just pass
     }
   }
 
@@ -96,9 +85,7 @@ struct EventIterationTests {
       repetitionPolicy: policy,
       expectedIterations: expectedIterations
     ) { iteration in
-      if iteration < 3 {
-        Issue.record("Failure")
-      }
+      #expect(iteration >= 3)
     }
   }
 }

--- a/Tests/TestingTests/LegacyPlanIterationTests.swift
+++ b/Tests/TestingTests/LegacyPlanIterationTests.swift
@@ -1,0 +1,132 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+#if !SWT_TARGET_OS_APPLE && canImport(Synchronization)
+import Synchronization
+#endif
+
+@Suite
+struct LegacyPlanIterationTests {
+  @Test("One iteration (default behavior)")
+  func oneIteration() async {
+    await confirmation("N iterations started") { started in
+      await confirmation("N iterations ended") { ended in
+        var configuration = Configuration()
+        configuration.eventHandler = { event, _ in
+          if case .iterationStarted = event.kind {
+            started()
+          } else if case .iterationEnded = event.kind {
+            ended()
+          }
+        }
+        configuration.repetitionPolicy = .once
+
+        await Test {
+        }.run(configuration: configuration)
+      }
+    }
+  }
+
+  @Test("Unconditional iteration")
+  func unconditionalIteration() async {
+    let iterationCount = 10
+    await confirmation("N iterations started", expectedCount: iterationCount) { started in
+      await confirmation("N iterations ended", expectedCount: iterationCount) { ended in
+        var configuration = Configuration()
+        configuration.eventHandler = { event, _ in
+          if case .iterationStarted = event.kind {
+            started()
+          } else if case .iterationEnded = event.kind {
+            ended()
+          }
+        }
+        configuration.repetitionPolicy = .repeating(maximumIterationCount: iterationCount)
+
+        await Test {
+          if Bool.random() {
+            #expect(Bool(false))
+          }
+        }.run(configuration: configuration)
+      }
+    }
+  }
+
+  @Test("Iteration until issue recorded")
+  func iterationUntilIssueRecorded() async {
+    let iterationIndex = Atomic(0)
+    let iterationCount = 10
+    let iterationWithIssue = 5
+    await confirmation("N iterations started", expectedCount: iterationWithIssue + 1) { started in
+      await confirmation("N iterations ended", expectedCount: iterationWithIssue + 1) { ended in
+        var configuration = Configuration()
+        configuration.eventHandler = { event, _ in
+          if case let .iterationStarted(index) = event.kind {
+            iterationIndex.store(index, ordering: .sequentiallyConsistent)
+            started()
+          } else if case .iterationEnded = event.kind {
+            ended()
+          }
+        }
+        configuration.repetitionPolicy = .repeating(.untilIssueRecorded, maximumIterationCount: iterationCount)
+
+        await Test {
+          let iterationIndex = iterationIndex.load(ordering: .sequentiallyConsistent)
+          if iterationIndex == iterationWithIssue {
+            #expect(Bool(false))
+          }
+        }.run(configuration: configuration)
+      }
+    }
+  }
+
+  @Test("Iteration while issue recorded")
+  func iterationWhileIssueRecorded() async {
+    let iterationIndex = Atomic(0)
+    let iterationCount = 10
+    let iterationWithoutIssue = 5
+    await confirmation("N iterations started", expectedCount: iterationWithoutIssue + 1) { started in
+      await confirmation("N iterations ended", expectedCount: iterationWithoutIssue + 1) { ended in
+        var configuration = Configuration()
+        configuration.eventHandler = { event, _ in
+          if case let .iterationStarted(index) = event.kind {
+            iterationIndex.store(index, ordering: .sequentiallyConsistent)
+            started()
+          } else if case .iterationEnded = event.kind {
+            ended()
+          }
+        }
+        configuration.repetitionPolicy = .repeating(.whileIssueRecorded, maximumIterationCount: iterationCount)
+
+        await Test {
+          let iterationIndex = iterationIndex.load(ordering: .sequentiallyConsistent)
+          if iterationIndex < iterationWithoutIssue {
+            #expect(Bool(false))
+          }
+        }.run(configuration: configuration)
+      }
+    }
+  }
+
+#if !SWT_NO_EXIT_TESTS
+  @Test("Iteration count must be positive")
+  func positiveIterationCount() async {
+    await #expect(processExitsWith: .failure) {
+      var configuration = Configuration()
+      configuration.repetitionPolicy.maximumIterationCount = 0
+    }
+    await #expect(processExitsWith: .failure) {
+      var configuration = Configuration()
+      configuration.repetitionPolicy.maximumIterationCount = -1
+    }
+  }
+#endif
+}

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -511,6 +511,15 @@ struct SwiftPMTests {
     #expect(configuration.repetitionPolicy.continuationCondition == .whileIssueRecorded)
   }
 
+  @Test("--experimental-per-test-case-repetition")
+  func experimentalPerTestCaseRepetition() throws {
+    let defaultConfig = try configurationForEntryPoint(withArguments: ["PATH"])
+    #expect(defaultConfig.shouldUseLegacyPlanLevelRepetition)
+
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--experimental-per-test-case-repetition"])
+    #expect(!configuration.shouldUseLegacyPlanLevelRepetition)
+  }
+
   @Test("list subcommand")
   func list() async throws {
     do {

--- a/Tests/TestingTests/TestCaseIterationTests.swift
+++ b/Tests/TestingTests/TestCaseIterationTests.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -14,17 +14,18 @@
 import Synchronization
 #endif
 
-@Suite("Configuration.RepetitionPolicy Tests")
-struct PlanIterationTests {
+@Suite
+struct TestCaseIterationTests {
   @Test("One iteration (default behavior)")
   func oneIteration() async {
     await confirmation("N iterations started") { started in
       await confirmation("N iterations ended") { ended in
         var configuration = Configuration()
+        configuration.shouldUseLegacyPlanLevelRepetition = false
         configuration.eventHandler = { event, _ in
-          if case .iterationStarted = event.kind {
+          if case .testCaseStarted = event.kind {
             started()
-          } else if case .iterationEnded = event.kind {
+          } else if case .testCaseEnded = event.kind {
             ended()
           }
         }
@@ -42,10 +43,11 @@ struct PlanIterationTests {
     await confirmation("N iterations started", expectedCount: iterationCount) { started in
       await confirmation("N iterations ended", expectedCount: iterationCount) { ended in
         var configuration = Configuration()
+        configuration.shouldUseLegacyPlanLevelRepetition = false
         configuration.eventHandler = { event, _ in
-          if case .iterationStarted = event.kind {
+          if case .testCaseStarted = event.kind {
             started()
-          } else if case .iterationEnded = event.kind {
+          } else if case .testCaseEnded = event.kind {
             ended()
           }
         }
@@ -62,27 +64,27 @@ struct PlanIterationTests {
 
   @Test("Iteration until issue recorded")
   func iterationUntilIssueRecorded() async {
-    let iterationIndex = Atomic(0)
+    let iterations = Atomic(0)
     let iterationCount = 10
     let iterationWithIssue = 5
-    await confirmation("N iterations started", expectedCount: iterationWithIssue + 1) { started in
-      await confirmation("N iterations ended", expectedCount: iterationWithIssue + 1) { ended in
+    await confirmation("N iterations started", expectedCount: iterationWithIssue) { started in
+      await confirmation("N iterations ended", expectedCount: iterationWithIssue) { ended in
         var configuration = Configuration()
-        configuration.eventHandler = { event, _ in
-          if case let .iterationStarted(index) = event.kind {
-            iterationIndex.store(index, ordering: .sequentiallyConsistent)
+        configuration.shouldUseLegacyPlanLevelRepetition = false
+        configuration.eventHandler = { event, context in
+          guard let iteration = context.iteration else { return }
+          if case .testCaseStarted = event.kind {
+            iterations.store(iteration, ordering: .sequentiallyConsistent)
             started()
-          } else if case .iterationEnded = event.kind {
+          } else if case .testCaseEnded = event.kind {
             ended()
           }
         }
         configuration.repetitionPolicy = .repeating(.untilIssueRecorded, maximumIterationCount: iterationCount)
 
         await Test {
-          let iterationIndex = iterationIndex.load(ordering: .sequentiallyConsistent)
-          if iterationIndex == iterationWithIssue {
-            #expect(Bool(false))
-          }
+          let iterations = iterations.load(ordering: .sequentiallyConsistent)
+          #expect(iterations < iterationWithIssue)
         }.run(configuration: configuration)
       }
     }
@@ -90,43 +92,31 @@ struct PlanIterationTests {
 
   @Test("Iteration while issue recorded")
   func iterationWhileIssueRecorded() async {
-    let iterationIndex = Atomic(0)
+    let iterations = Atomic(0)
     let iterationCount = 10
     let iterationWithoutIssue = 5
-    await confirmation("N iterations started", expectedCount: iterationWithoutIssue + 1) { started in
-      await confirmation("N iterations ended", expectedCount: iterationWithoutIssue + 1) { ended in
+    await confirmation("N iterations started", expectedCount: iterationWithoutIssue) { started in
+      await confirmation("N iterations ended", expectedCount: iterationWithoutIssue) { ended in
         var configuration = Configuration()
-        configuration.eventHandler = { event, _ in
-          if case let .iterationStarted(index) = event.kind {
-            iterationIndex.store(index, ordering: .sequentiallyConsistent)
+        configuration.shouldUseLegacyPlanLevelRepetition = false
+        configuration.eventHandler = { event, context in
+          guard let iteration = context.iteration else { return }
+          if case .testCaseStarted = event.kind {
+            iterations.store(iteration, ordering: .sequentiallyConsistent)
             started()
-          } else if case .iterationEnded = event.kind {
+          } else if case .testCaseEnded = event.kind {
             ended()
           }
         }
         configuration.repetitionPolicy = .repeating(.whileIssueRecorded, maximumIterationCount: iterationCount)
 
         await Test {
-          let iterationIndex = iterationIndex.load(ordering: .sequentiallyConsistent)
-          if iterationIndex < iterationWithoutIssue {
+          let iterations = iterations.load(ordering: .sequentiallyConsistent)
+          if iterations < iterationWithoutIssue {
             #expect(Bool(false))
           }
         }.run(configuration: configuration)
       }
     }
   }
-
-#if !SWT_NO_EXIT_TESTS
-  @Test("Iteration count must be positive")
-  func positiveIterationCount() async {
-    await #expect(processExitsWith: .failure) {
-      var configuration = Configuration()
-      configuration.repetitionPolicy.maximumIterationCount = 0
-    }
-    await #expect(processExitsWith: .failure) {
-      var configuration = Configuration()
-      configuration.repetitionPolicy.maximumIterationCount = -1
-    }
-  }
-#endif
 }


### PR DESCRIPTION
This changes the runner such that "repeat until success" or the other repetition policies repeat only the affected test case, rather than repeating the entire test plan.

Fixes #1392
Fixes rdar://130508488

### Motivation:

The previous behavior was unexpected and does not match the behavior of XCTest. This changes the behavior to align the behaviors (in the way that users expect).

### Modifications:

- Adds a configuration option requiring clients to opt in to this behavior (for now, until we change the default).
- Updates the Runner to move the iteration into a helper function
- Adds this helper function within _runTestCase (if opted in)
- Replaces the plan-level iteration with the helper function (if opted out)
- Mirrors the plan-level iteration tests to test-case level iteration tests that test the same conditions with the new behavior

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
