### PR TITLE
Errors thrown while saving attachments should be recorded with warning severity.

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -307,7 +307,7 @@ extension Attachment where AttachableValue: ~Copyable {
       Attachment<Array>.record(bufferCopy, sourceLocation: sourceLocation)
     } catch {
       let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
-      Issue(kind: .valueAttachmentFailed(error), comments: [], sourceContext: sourceContext).record()
+      Issue(kind: .valueAttachmentFailed(error), severity: .warning, comments: [], sourceContext: sourceContext).record()
     }
   }
 
@@ -536,7 +536,7 @@ extension Configuration {
     } catch {
       // Record the error as an issue and suppress the event.
       let sourceContext = SourceContext(backtrace: .current(), sourceLocation: attachment.sourceLocation)
-      Issue(kind: .valueAttachmentFailed(error), comments: [], sourceContext: sourceContext).record(configuration: self)
+      Issue(kind: .valueAttachmentFailed(error), severity: .warning, comments: [], sourceContext: sourceContext).record(configuration: self)
       return false
     }
   }

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -254,6 +254,7 @@ struct AttachmentTests {
             valueAttached()
           } else if case let .issueRecorded(issue) = event.kind,
                     case let .valueAttachmentFailed(error) = issue.kind,
+                    issue.severity == .warning,
                     error is MyError {
             #expect(issue.sourceLocation?.fileID == #fileID)
             issueRecorded()


### PR DESCRIPTION
If an error is thrown while saving an attachment, Swift Testing fails the test whence the attachment was recorded. This is overly strict as the test itself may have run successfully. Developers who need those attachments will notice they're missing and be able to review the test log to see what went wrong.

Resolves rdar://169742988.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
