### PR TITLE
Add ability to filter/skip by tags using a special `tag:` prefix

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -696,8 +696,8 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     // otherwise we construct it with the provided tags
     let tagFilter: Configuration.TestFilter = switch (membership, tagPatterns.isEmpty) {
       case (_, true): .unfiltered
-      case (.including, false): Configuration.TestFilter(includingTagsMatching: tagPatterns)
-      case (.excluding, false): Configuration.TestFilter(excludingTagsMatching: tagPatterns)
+      case (.including, false): try Configuration.TestFilter(includingTagsMatching: tagPatterns)
+      case (.excluding, false): try Configuration.TestFilter(excludingTagsMatching: tagPatterns)
     }
 
     guard !idPatterns.isEmpty else {

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -658,8 +658,39 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 
     return try Configuration.TestFilter(membership: membership, matchingAnyOf: regexes)
   }
-  filters.append(try testFilter(forRegularExpressions: args.filter, label: "--filter", membership: .including))
-  filters.append(try testFilter(forRegularExpressions: args.skip, label: "--skip", membership: .excluding))
+
+  // Extract any filters or skips without the `tag:` prefix; those will be treated as normal regexes.
+  let tagPrefix = "tag:"
+  let escapedTagPrefix = "tag\\:"
+  var nonTagFilterRegexes: [String] = []
+  var nonTagSkipRegexes: [String] = []
+
+  for var filter in args.filter ?? [] {
+    if filter.hasPrefix(tagPrefix) {
+      filters.append(Configuration.TestFilter(includingAnyOf: [Tag(userProvidedStringValue: String(filter.dropFirst(4)))]))
+    } else {
+      // If we run into the escaped tag prefix, we need to to remove the escape character before adding it as a regex filter
+      if filter.hasPrefix(escapedTagPrefix) {
+        filter.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
+      }
+      nonTagFilterRegexes.append(filter)
+    }
+  }
+
+  for var skip in args.skip ?? [] {
+    if skip.hasPrefix(tagPrefix) {
+      filters.append(Configuration.TestFilter(includingAnyOf: [Tag(userProvidedStringValue: String(skip.dropFirst(4)))]))
+    } else {
+      // If we run into the escaped tag prefix, we need to to remove the escape character before adding it as a regex filter
+      if skip.hasPrefix(escapedTagPrefix) {
+        skip.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
+      }
+      nonTagSkipRegexes.append(skip)
+    }
+  }
+
+  filters.append(try testFilter(forRegularExpressions: nonTagFilterRegexes, label: "--filter", membership: .including))
+  filters.append(try testFilter(forRegularExpressions: nonTagSkipRegexes, label: "--skip", membership: .excluding))
 
   configuration.testFilter = filters.reduce(.unfiltered) { $0.combining(with: $1) }
   if args.includeHiddenTests == true {

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -686,8 +686,9 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     }
 
     guard !regexes.isEmpty else {
-      // Return early with just the tag filter, even though the `reduce` logic
-      // below can handle this case, in order to avoid the `#available` guard.
+      // Return early with just the tag filter, otherwise we try to match
+      // against an empty array of regular expressions which is _not_
+      // equivalent to `.unfiltered`.
       return [tagFilter]
     }
 

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -648,51 +648,51 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 
 #if canImport(_StringProcessing)
   // Filtering
+
+  // Filters currently come in two flavors: those with a prefix and those
+  // without. Those without a prefix are treated the same as those with an
+  // "id:" prefix.
+  enum FilterPrefix: String, CaseIterable {
+    case id = "id:"
+    case tag = "tag:"
+  }
   var filters = [Configuration.TestFilter]()
   func testFilters(forOptionArguments optionArguments: [String]?, label: String, membership: Configuration.TestFilter.Membership) throws -> [Configuration.TestFilter] {
-
-    // Filters will come in two flavors: those with `tag:` as a prefix, and
-    // those without. We split them into two collections, taking care to handle
-    // an escaped colon, treating it as a pseudo-operator.
-    let tagPrefix = "tag:"
-    let escapedTagPrefix = #"tag\:"#
-    var tags = [Tag]()
-    var regexes = [String]()
+    var tagPatterns = [String]()
+    var idPatterns = [String]()
 
     // Loop through all the option arguments, separating tags from regex filters
     for var optionArg in optionArguments ?? [] {
-      if optionArg.hasPrefix(tagPrefix) {
-        // Running into the `tag:` prefix means we should strip it and use the
-        // actual tag name the user has provided
-        let tagStringWithoutPrefix = String(optionArg.dropFirst(tagPrefix.count))
-        tags.append(Tag(userProvidedStringValue: tagStringWithoutPrefix))
-      } else {
-        // If we run into the escaped tag prefix, the user has indicated they
-        // want to us to treat it as a regex filter. We need to to unescape it
-        // before adding it as a regex filter
-        if optionArg.hasPrefix(escapedTagPrefix) {
-          optionArg.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
+      if let prefix = FilterPrefix.allCases.first(where: { optionArg.hasPrefix($0.rawValue) }) {
+        // We have encountered a prefix, so trim it off and add the supplied
+        // argument to the appropriate filter list
+        optionArg.trimPrefix(prefix.rawValue)
+        switch prefix {
+          case .id: idPatterns.append(optionArg)
+          case .tag: tagPatterns.append(optionArg)
         }
-        regexes.append(optionArg)
+      } else {
+        // No prefix was detected, so we treat this as a regex matching a test ID.
+        idPatterns.append(optionArg)
       }
     }
 
     // If we didn't find any tags, the tagFilter should be .unfiltered,
     // otherwise we construct it with the provided tags
-    let tagFilter: Configuration.TestFilter = switch (membership, tags.isEmpty) {
+    let tagFilter: Configuration.TestFilter = switch (membership, tagPatterns.isEmpty) {
       case (_, true): .unfiltered
-      case (.including, false): Configuration.TestFilter(includingAnyOf: tags)
-      case (.excluding, false): Configuration.TestFilter(excludingAnyOf: tags)
+      case (.including, false): Configuration.TestFilter(includingTagsMatching: tagPatterns)
+      case (.excluding, false): Configuration.TestFilter(excludingTagsMatching: tagPatterns)
     }
 
-    guard !regexes.isEmpty else {
+    guard !idPatterns.isEmpty else {
       // Return early with just the tag filter, otherwise we try to match
       // against an empty array of regular expressions which is _not_
       // equivalent to `.unfiltered`.
       return [tagFilter]
     }
 
-    return [try Configuration.TestFilter(membership: membership, matchingAnyOf: regexes), tagFilter]
+    return [try Configuration.TestFilter(membership: membership, matchingAnyOf: idPatterns), tagFilter]
   }
 
   filters += try testFilters(forOptionArguments: args.filter, label: "--filter", membership: .including)

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -649,48 +649,53 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 #if canImport(_StringProcessing)
   // Filtering
   var filters = [Configuration.TestFilter]()
-  func testFilter(forRegularExpressions regexes: [String]?, label: String, membership: Configuration.TestFilter.Membership) throws -> Configuration.TestFilter {
-    guard let regexes, !regexes.isEmpty else {
-      // Return early if empty, even though the `reduce` logic below can handle
-      // this case, in order to avoid the `#available` guard.
-      return .unfiltered
-    }
+  func testFilters(forOptionArguments optionArguments: [String]?, label: String, membership: Configuration.TestFilter.Membership) throws -> [Configuration.TestFilter] {
 
-    return try Configuration.TestFilter(membership: membership, matchingAnyOf: regexes)
-  }
+    // Filters will come in two flavors: those with `tag:` as a prefix, and
+    // those without. We split them into two collections, taking care to handle
+    // an escaped colon, treating it as a pseudo-operator.
+    let tagPrefix = "tag:"
+    let escapedTagPrefix = #"tag\:"#
+    var tags = [Tag]()
+    var regexes = [String]()
 
-  // Extract any filters or skips without the `tag:` prefix; those will be treated as normal regexes.
-  let tagPrefix = "tag:"
-  let escapedTagPrefix = "tag\\:"
-  var nonTagFilterRegexes: [String] = []
-  var nonTagSkipRegexes: [String] = []
-
-  for var filter in args.filter ?? [] {
-    if filter.hasPrefix(tagPrefix) {
-      filters.append(Configuration.TestFilter(includingAnyOf: [Tag(userProvidedStringValue: String(filter.dropFirst(4)))]))
-    } else {
-      // If we run into the escaped tag prefix, we need to to remove the escape character before adding it as a regex filter
-      if filter.hasPrefix(escapedTagPrefix) {
-        filter.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
+    // Loop through all the option arguments, separating tags from regex filters
+    for var optionArg in optionArguments ?? [] {
+      if optionArg.hasPrefix(tagPrefix) {
+        // Running into the `tag:` prefix means we should strip it and use the
+        // actual tag name the user has provided
+        let tagStringWithoutPrefix = String(optionArg.dropFirst(tagPrefix.count))
+        tags.append(Tag(userProvidedStringValue: tagStringWithoutPrefix))
+      } else {
+        // If we run into the escaped tag prefix, the user has indicated they
+        // want to us to treat it as a regex filter. We need to to unescape it
+        // before adding it as a regex filter
+        if optionArg.hasPrefix(escapedTagPrefix) {
+          optionArg.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
+        }
+        regexes.append(optionArg)
       }
-      nonTagFilterRegexes.append(filter)
     }
+
+    // If we didn't find any tags, the tagFilter should be .unfiltered,
+    // otherwise we construct it with the provided tags
+    let tagFilter: Configuration.TestFilter = switch (membership, tags.isEmpty) {
+      case (_, true): .unfiltered
+      case (.including, false): Configuration.TestFilter(includingAnyOf: tags)
+      case (.excluding, false): Configuration.TestFilter(excludingAnyOf: tags)
+    }
+
+    guard !regexes.isEmpty else {
+      // Return early with just the tag filter, even though the `reduce` logic
+      // below can handle this case, in order to avoid the `#available` guard.
+      return [tagFilter]
+    }
+
+    return [try Configuration.TestFilter(membership: membership, matchingAnyOf: regexes), tagFilter]
   }
 
-  for var skip in args.skip ?? [] {
-    if skip.hasPrefix(tagPrefix) {
-      filters.append(Configuration.TestFilter(includingAnyOf: [Tag(userProvidedStringValue: String(skip.dropFirst(4)))]))
-    } else {
-      // If we run into the escaped tag prefix, we need to to remove the escape character before adding it as a regex filter
-      if skip.hasPrefix(escapedTagPrefix) {
-        skip.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
-      }
-      nonTagSkipRegexes.append(skip)
-    }
-  }
-
-  filters.append(try testFilter(forRegularExpressions: nonTagFilterRegexes, label: "--filter", membership: .including))
-  filters.append(try testFilter(forRegularExpressions: nonTagSkipRegexes, label: "--skip", membership: .excluding))
+  filters += try testFilters(forOptionArguments: args.filter, label: "--filter", membership: .including)
+  filters += try testFilters(forOptionArguments: args.skip, label: "--skip", membership: .excluding)
 
   configuration.testFilter = filters.reduce(.unfiltered) { $0.combining(with: $1) }
   if args.includeHiddenTests == true {

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -661,18 +661,33 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     var tagPatterns = [String]()
     var idPatterns = [String]()
 
+    // If one of the patterns we encounter is surrounded by backticks, we can
+    // surmize the user intended to express a Swift raw identifier. In that
+    // case, we should alert the user that it's not going to match what the
+    // user expects and strip the backticks for them.
+    func stripBackticksAndAlertIfEncountered(string: inout String) {
+      let backtickRegex = /^`[^`]*`$/
+      if string.contains(backtickRegex) {
+        let originalString = string
+        string = String(string.dropFirst().dropLast())
+        try? FileHandle.stderr.write("Backticks aren't a valid part of a Swift symbol. Replacing '\(originalString)' with '\(string)'.\n")
+      }
+    }
+
     // Loop through all the option arguments, separating tags from regex filters
     for var optionArg in optionArguments ?? [] {
       if let prefix = FilterPrefix.allCases.first(where: { optionArg.hasPrefix($0.rawValue) }) {
         // We have encountered a prefix, so trim it off and add the supplied
         // argument to the appropriate filter list
         optionArg.trimPrefix(prefix.rawValue)
+        stripBackticksAndAlertIfEncountered(string: &optionArg)
         switch prefix {
           case .id: idPatterns.append(optionArg)
           case .tag: tagPatterns.append(optionArg)
         }
       } else {
         // No prefix was detected, so we treat this as a regex matching a test ID.
+        stripBackticksAndAlertIfEncountered(string: &optionArg)
         idPatterns.append(optionArg)
       }
     }

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -641,8 +641,39 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 
     return try Configuration.TestFilter(membership: membership, matchingAnyOf: regexes)
   }
-  filters.append(try testFilter(forRegularExpressions: args.filter, label: "--filter", membership: .including))
-  filters.append(try testFilter(forRegularExpressions: args.skip, label: "--skip", membership: .excluding))
+
+  // Extract any filters or skips without the `tag:` prefix; those will be treated as normal regexes.
+  let tagPrefix = "tag:"
+  let escapedTagPrefix = "tag\\:"
+  var nonTagFilterRegexes: [String] = []
+  var nonTagSkipRegexes: [String] = []
+
+  for var filter in args.filter ?? [] {
+    if filter.hasPrefix(tagPrefix) {
+      filters.append(Configuration.TestFilter(includingAnyOf: [Tag(userProvidedStringValue: String(filter.dropFirst(4)))]))
+    } else {
+      // If we run into the escaped tag prefix, we need to to remove the escape character before adding it as a regex filter
+      if filter.hasPrefix(escapedTagPrefix) {
+        filter.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
+      }
+      nonTagFilterRegexes.append(filter)
+    }
+  }
+
+  for var skip in args.skip ?? [] {
+    if skip.hasPrefix(tagPrefix) {
+      filters.append(Configuration.TestFilter(includingAnyOf: [Tag(userProvidedStringValue: String(skip.dropFirst(4)))]))
+    } else {
+      // If we run into the escaped tag prefix, we need to to remove the escape character before adding it as a regex filter
+      if skip.hasPrefix(escapedTagPrefix) {
+        skip.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
+      }
+      nonTagSkipRegexes.append(skip)
+    }
+  }
+
+  filters.append(try testFilter(forRegularExpressions: nonTagFilterRegexes, label: "--filter", membership: .including))
+  filters.append(try testFilter(forRegularExpressions: nonTagSkipRegexes, label: "--skip", membership: .excluding))
 
   configuration.testFilter = filters.reduce(.unfiltered) { $0.combining(with: $1) }
   if args.includeHiddenTests == true {

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -644,18 +644,33 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     var tagPatterns = [String]()
     var idPatterns = [String]()
 
+    // If one of the patterns we encounter is surrounded by backticks, we can
+    // surmize the user intended to express a Swift raw identifier. In that
+    // case, we should alert the user that it's not going to match what the
+    // user expects and strip the backticks for them.
+    func stripBackticksAndAlertIfEncountered(string: inout String) {
+      let backtickRegex = /^`[^`]*`$/
+      if string.contains(backtickRegex) {
+        let originalString = string
+        string = String(string.dropFirst().dropLast())
+        try? FileHandle.stderr.write("Backticks aren't a valid part of a Swift symbol. Replacing '\(originalString)' with '\(string)'.\n")
+      }
+    }
+
     // Loop through all the option arguments, separating tags from regex filters
     for var optionArg in optionArguments ?? [] {
       if let prefix = FilterPrefix.allCases.first(where: { optionArg.hasPrefix($0.rawValue) }) {
         // We have encountered a prefix, so trim it off and add the supplied
         // argument to the appropriate filter list
         optionArg.trimPrefix(prefix.rawValue)
+        stripBackticksAndAlertIfEncountered(string: &optionArg)
         switch prefix {
           case .id: idPatterns.append(optionArg)
           case .tag: tagPatterns.append(optionArg)
         }
       } else {
         // No prefix was detected, so we treat this as a regex matching a test ID.
+        stripBackticksAndAlertIfEncountered(string: &optionArg)
         idPatterns.append(optionArg)
       }
     }

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -669,8 +669,9 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     }
 
     guard !regexes.isEmpty else {
-      // Return early with just the tag filter, even though the `reduce` logic
-      // below can handle this case, in order to avoid the `#available` guard.
+      // Return early with just the tag filter, otherwise we try to match
+      // against an empty array of regular expressions which is _not_
+      // equivalent to `.unfiltered`.
       return [tagFilter]
     }
 

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -631,51 +631,51 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 
 #if canImport(_StringProcessing)
   // Filtering
+
+  // Filters currently come in two flavors: those with a prefix and those
+  // without. Those without a prefix are treated the same as those with an
+  // "id:" prefix.
+  enum FilterPrefix: String, CaseIterable {
+    case id = "id:"
+    case tag = "tag:"
+  }
   var filters = [Configuration.TestFilter]()
   func testFilters(forOptionArguments optionArguments: [String]?, label: String, membership: Configuration.TestFilter.Membership) throws -> [Configuration.TestFilter] {
-
-    // Filters will come in two flavors: those with `tag:` as a prefix, and
-    // those without. We split them into two collections, taking care to handle
-    // an escaped colon, treating it as a pseudo-operator.
-    let tagPrefix = "tag:"
-    let escapedTagPrefix = #"tag\:"#
-    var tags = [Tag]()
-    var regexes = [String]()
+    var tagPatterns = [String]()
+    var idPatterns = [String]()
 
     // Loop through all the option arguments, separating tags from regex filters
     for var optionArg in optionArguments ?? [] {
-      if optionArg.hasPrefix(tagPrefix) {
-        // Running into the `tag:` prefix means we should strip it and use the
-        // actual tag name the user has provided
-        let tagStringWithoutPrefix = String(optionArg.dropFirst(tagPrefix.count))
-        tags.append(Tag(userProvidedStringValue: tagStringWithoutPrefix))
-      } else {
-        // If we run into the escaped tag prefix, the user has indicated they
-        // want to us to treat it as a regex filter. We need to to unescape it
-        // before adding it as a regex filter
-        if optionArg.hasPrefix(escapedTagPrefix) {
-          optionArg.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
+      if let prefix = FilterPrefix.allCases.first(where: { optionArg.hasPrefix($0.rawValue) }) {
+        // We have encountered a prefix, so trim it off and add the supplied
+        // argument to the appropriate filter list
+        optionArg.trimPrefix(prefix.rawValue)
+        switch prefix {
+          case .id: idPatterns.append(optionArg)
+          case .tag: tagPatterns.append(optionArg)
         }
-        regexes.append(optionArg)
+      } else {
+        // No prefix was detected, so we treat this as a regex matching a test ID.
+        idPatterns.append(optionArg)
       }
     }
 
     // If we didn't find any tags, the tagFilter should be .unfiltered,
     // otherwise we construct it with the provided tags
-    let tagFilter: Configuration.TestFilter = switch (membership, tags.isEmpty) {
+    let tagFilter: Configuration.TestFilter = switch (membership, tagPatterns.isEmpty) {
       case (_, true): .unfiltered
-      case (.including, false): Configuration.TestFilter(includingAnyOf: tags)
-      case (.excluding, false): Configuration.TestFilter(excludingAnyOf: tags)
+      case (.including, false): Configuration.TestFilter(includingTagsMatching: tagPatterns)
+      case (.excluding, false): Configuration.TestFilter(excludingTagsMatching: tagPatterns)
     }
 
-    guard !regexes.isEmpty else {
+    guard !idPatterns.isEmpty else {
       // Return early with just the tag filter, otherwise we try to match
       // against an empty array of regular expressions which is _not_
       // equivalent to `.unfiltered`.
       return [tagFilter]
     }
 
-    return [try Configuration.TestFilter(membership: membership, matchingAnyOf: regexes), tagFilter]
+    return [try Configuration.TestFilter(membership: membership, matchingAnyOf: idPatterns), tagFilter]
   }
 
   filters += try testFilters(forOptionArguments: args.filter, label: "--filter", membership: .including)

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -632,48 +632,53 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 #if canImport(_StringProcessing)
   // Filtering
   var filters = [Configuration.TestFilter]()
-  func testFilter(forRegularExpressions regexes: [String]?, label: String, membership: Configuration.TestFilter.Membership) throws -> Configuration.TestFilter {
-    guard let regexes, !regexes.isEmpty else {
-      // Return early if empty, even though the `reduce` logic below can handle
-      // this case, in order to avoid the `#available` guard.
-      return .unfiltered
-    }
+  func testFilters(forOptionArguments optionArguments: [String]?, label: String, membership: Configuration.TestFilter.Membership) throws -> [Configuration.TestFilter] {
 
-    return try Configuration.TestFilter(membership: membership, matchingAnyOf: regexes)
-  }
+    // Filters will come in two flavors: those with `tag:` as a prefix, and
+    // those without. We split them into two collections, taking care to handle
+    // an escaped colon, treating it as a pseudo-operator.
+    let tagPrefix = "tag:"
+    let escapedTagPrefix = #"tag\:"#
+    var tags = [Tag]()
+    var regexes = [String]()
 
-  // Extract any filters or skips without the `tag:` prefix; those will be treated as normal regexes.
-  let tagPrefix = "tag:"
-  let escapedTagPrefix = "tag\\:"
-  var nonTagFilterRegexes: [String] = []
-  var nonTagSkipRegexes: [String] = []
-
-  for var filter in args.filter ?? [] {
-    if filter.hasPrefix(tagPrefix) {
-      filters.append(Configuration.TestFilter(includingAnyOf: [Tag(userProvidedStringValue: String(filter.dropFirst(4)))]))
-    } else {
-      // If we run into the escaped tag prefix, we need to to remove the escape character before adding it as a regex filter
-      if filter.hasPrefix(escapedTagPrefix) {
-        filter.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
+    // Loop through all the option arguments, separating tags from regex filters
+    for var optionArg in optionArguments ?? [] {
+      if optionArg.hasPrefix(tagPrefix) {
+        // Running into the `tag:` prefix means we should strip it and use the
+        // actual tag name the user has provided
+        let tagStringWithoutPrefix = String(optionArg.dropFirst(tagPrefix.count))
+        tags.append(Tag(userProvidedStringValue: tagStringWithoutPrefix))
+      } else {
+        // If we run into the escaped tag prefix, the user has indicated they
+        // want to us to treat it as a regex filter. We need to to unescape it
+        // before adding it as a regex filter
+        if optionArg.hasPrefix(escapedTagPrefix) {
+          optionArg.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
+        }
+        regexes.append(optionArg)
       }
-      nonTagFilterRegexes.append(filter)
     }
+
+    // If we didn't find any tags, the tagFilter should be .unfiltered,
+    // otherwise we construct it with the provided tags
+    let tagFilter: Configuration.TestFilter = switch (membership, tags.isEmpty) {
+      case (_, true): .unfiltered
+      case (.including, false): Configuration.TestFilter(includingAnyOf: tags)
+      case (.excluding, false): Configuration.TestFilter(excludingAnyOf: tags)
+    }
+
+    guard !regexes.isEmpty else {
+      // Return early with just the tag filter, even though the `reduce` logic
+      // below can handle this case, in order to avoid the `#available` guard.
+      return [tagFilter]
+    }
+
+    return [try Configuration.TestFilter(membership: membership, matchingAnyOf: regexes), tagFilter]
   }
 
-  for var skip in args.skip ?? [] {
-    if skip.hasPrefix(tagPrefix) {
-      filters.append(Configuration.TestFilter(includingAnyOf: [Tag(userProvidedStringValue: String(skip.dropFirst(4)))]))
-    } else {
-      // If we run into the escaped tag prefix, we need to to remove the escape character before adding it as a regex filter
-      if skip.hasPrefix(escapedTagPrefix) {
-        skip.replaceSubrange(escapedTagPrefix.startIndex..<escapedTagPrefix.endIndex, with: tagPrefix)
-      }
-      nonTagSkipRegexes.append(skip)
-    }
-  }
-
-  filters.append(try testFilter(forRegularExpressions: nonTagFilterRegexes, label: "--filter", membership: .including))
-  filters.append(try testFilter(forRegularExpressions: nonTagSkipRegexes, label: "--skip", membership: .excluding))
+  filters += try testFilters(forOptionArguments: args.filter, label: "--filter", membership: .including)
+  filters += try testFilters(forOptionArguments: args.skip, label: "--skip", membership: .excluding)
 
   configuration.testFilter = filters.reduce(.unfiltered) { $0.combining(with: $1) }
   if args.includeHiddenTests == true {

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -679,8 +679,8 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     // otherwise we construct it with the provided tags
     let tagFilter: Configuration.TestFilter = switch (membership, tagPatterns.isEmpty) {
       case (_, true): .unfiltered
-      case (.including, false): Configuration.TestFilter(includingTagsMatching: tagPatterns)
-      case (.excluding, false): Configuration.TestFilter(excludingTagsMatching: tagPatterns)
+      case (.including, false): try Configuration.TestFilter(includingTagsMatching: tagPatterns)
+      case (.excluding, false): try Configuration.TestFilter(excludingTagsMatching: tagPatterns)
     }
 
     guard !idPatterns.isEmpty else {

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -694,10 +694,13 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 
     // If we didn't find any tags, the tagFilter should be .unfiltered,
     // otherwise we construct it with the provided tags
-    let tagFilter: Configuration.TestFilter = switch (membership, tagPatterns.isEmpty) {
-      case (_, true): .unfiltered
-      case (.including, false): try Configuration.TestFilter(includingTagsMatching: tagPatterns)
-      case (.excluding, false): try Configuration.TestFilter(excludingTagsMatching: tagPatterns)
+    let tagFilter: Configuration.TestFilter = if tagPatterns.isEmpty {
+      .unfiltered
+    } else {
+      switch membership {
+        case .including: try Configuration.TestFilter(includingTagsMatching: tagPatterns)
+        case .excluding: try Configuration.TestFilter(excludingTagsMatching: tagPatterns)
+      }
     }
 
     guard !idPatterns.isEmpty else {

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -657,7 +657,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     case tag = "tag:"
   }
   var filters = [Configuration.TestFilter]()
-  func testFilters(forOptionArguments optionArguments: [String]?, label: String, membership: Configuration.TestFilter.Membership) throws -> [Configuration.TestFilter] {
+  func testFilter(forOptionArguments optionArguments: [String]?, label: String, membership: Configuration.TestFilter.Membership) throws -> Configuration.TestFilter {
     var tagPatterns = [String]()
     var idPatterns = [String]()
 
@@ -703,18 +703,29 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
       }
     }
 
-    guard !idPatterns.isEmpty else {
-      // Return early with just the tag filter, otherwise we try to match
-      // against an empty array of regular expressions which is _not_
-      // equivalent to `.unfiltered`.
-      return [tagFilter]
+    // If we didn't find any ID patterns, the idFilter should be .unfiltered
+    // (similar to above). Note that constructing it with an empty array of
+    // patterns is _not_ equivalent to `.unfiltered`.
+    let idFilter: Configuration.TestFilter = if idPatterns.isEmpty {
+      .unfiltered
+    } else {
+      try Configuration.TestFilter(membership: membership, matchingAnyOf: idPatterns)
     }
 
-    return [try Configuration.TestFilter(membership: membership, matchingAnyOf: idPatterns), tagFilter]
+    // Passing an option more than once is an "or" operation. A test is included
+    // if it matches any --filter argument, and skipped if it matches any --skip
+    // argument. For --filter, `.or` expresses that directly. For --skip, the
+    // operator we want is `.and`, because an excluding filter keeps the tests
+    // it did _not_ match: by De Morgan's law, !(A || B) is equivalent to
+    // !A && !B, so `.and` skips a test that matches either the tag or the ID.
+    return switch membership {
+      case .including: idFilter.combining(with: tagFilter, using: .or)
+      case .excluding: idFilter.combining(with: tagFilter, using: .and)
+    }
   }
 
-  filters += try testFilters(forOptionArguments: args.filter, label: "--filter", membership: .including)
-  filters += try testFilters(forOptionArguments: args.skip, label: "--skip", membership: .excluding)
+  filters.append(try testFilter(forOptionArguments: args.filter, label: "--filter", membership: .including))
+  filters.append(try testFilter(forOptionArguments: args.skip, label: "--skip", membership: .excluding))
 
   configuration.testFilter = filters.reduce(.unfiltered) { $0.combining(with: $1) }
   if args.includeHiddenTests == true {

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -665,7 +665,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     // surmise the user intended to express a Swift raw identifier. In that
     // case, we should alert the user that it's not going to match what the
     // user expects and strip the backticks for them.
-    func stripBackticksAndAlertIfEncountered(string: inout String) {
+    func stripBackticksAndReportIfEncountered(string: inout String) {
       let backtickRegex = /^`[^`]*`$/
       if string.contains(backtickRegex) {
         let originalString = string
@@ -680,14 +680,14 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
         // We have encountered a prefix, so trim it off and add the supplied
         // argument to the appropriate filter list
         optionArg.trimPrefix(prefix.rawValue)
-        stripBackticksAndAlertIfEncountered(string: &optionArg)
+        stripBackticksAndReportIfEncountered(string: &optionArg)
         switch prefix {
           case .id: idPatterns.append(optionArg)
           case .tag: tagPatterns.append(optionArg)
         }
       } else {
         // No prefix was detected, so we treat this as a regex matching a test ID.
-        stripBackticksAndAlertIfEncountered(string: &optionArg)
+        stripBackticksAndReportIfEncountered(string: &optionArg)
         idPatterns.append(optionArg)
       }
     }

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -662,7 +662,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     var idPatterns = [String]()
 
     // If one of the patterns we encounter is surrounded by backticks, we can
-    // surmize the user intended to express a Swift raw identifier. In that
+    // surmise the user intended to express a Swift raw identifier. In that
     // case, we should alert the user that it's not going to match what the
     // user expects and strip the backticks for them.
     func stripBackticksAndAlertIfEncountered(string: inout String) {

--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -52,6 +52,13 @@ extension Configuration {
       case tags(_ tags: Set<Tag>, anyOf: Bool, membership: Membership)
 
 #if canImport(_StringProcessing)
+      /// The test filter contains a pattern to predicate test tags against.
+      ///
+      /// - Parameters:
+      ///   - patterns: The patterns to predicate test tags against.
+      ///   - membership: How to interpret the result when predicating tests.
+      case tagPatterns(_ tagPatterns: [String], membership: Membership)
+
       /// The test filter contains a pattern to predicate test IDs against.
       ///
       /// - Parameters:
@@ -187,6 +194,14 @@ extension Configuration.TestFilter {
   public init(excludingAllOf tags: some Collection<Tag>) {
     self.init(_kind: .tags(Set(tags), anyOf: false, membership: .excluding))
   }
+
+  public init(includingTagsMatching tagPatterns: [String]) {
+    self.init(_kind: .tagPatterns(tagPatterns, membership: .including))
+  }
+
+  public init(excludingTagsMatching tagPatterns: [String]) {
+    self.init(_kind: .tagPatterns(tagPatterns, membership: .excluding))
+  }
 }
 
 // MARK: - Operations
@@ -252,6 +267,20 @@ extension Configuration.TestFilter.Kind {
       }
       return .function(predicate, membership: membership)
 #if canImport(_StringProcessing)
+    case let .tagPatterns(tagPatterns, membership):
+      nonisolated(unsafe) let regexes = try tagPatterns.map(Regex.init)
+      return .function({ item in
+        let tagNames = item.tags.map { tag in
+          switch tag.kind {
+          case let .staticMember(tagName): tagName
+          }
+        }
+        return tagNames.contains(where: { tagName in
+          regexes.contains(where: { regex in
+            tagName.contains(regex)
+          })
+        })
+      }, membership: membership)
     case let .patterns(patterns, membership):
       nonisolated(unsafe) let regexes = try patterns.map(Regex.init)
       return .function({ item in
@@ -505,7 +534,9 @@ extension Configuration.TestFilter.Kind {
       false
 #if canImport(_StringProcessing)
     case .patterns:
-      false
+        false
+    case .tagPatterns:
+        true
 #endif
     case .tags:
       true

--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -55,7 +55,7 @@ extension Configuration {
       /// The test filter contains a pattern to predicate test tags against.
       ///
       /// - Parameters:
-      ///   - patterns: The patterns to predicate test tags against.
+      ///   - tagPatterns: The patterns to predicate test tags against
       ///   - membership: How to interpret the result when predicating tests.
       case tagPatterns(_ tagPatterns: [String], membership: Membership)
 
@@ -195,10 +195,20 @@ extension Configuration.TestFilter {
     self.init(_kind: .tags(Set(tags), anyOf: false, membership: .excluding))
   }
 
+  /// Initialize this instance to include tests with tags matching a pattern.
+  ///
+  /// - Parameters:
+  ///   - tagPatterns: The patterns, expressed as a `Regex`-compatible regular
+  ///     expressions, to match test tags against.
   public init(includingTagsMatching tagPatterns: [String]) {
     self.init(_kind: .tagPatterns(tagPatterns, membership: .including))
   }
 
+  /// Initialize this instance to exclude tests with tags matching a pattern.
+  ///
+  /// - Parameters:
+  ///   - tagPatterns: The patterns, expressed as a `Regex`-compatible regular
+  ///     expressions, to match test tags against.
   public init(excludingTagsMatching tagPatterns: [String]) {
     self.init(_kind: .tagPatterns(tagPatterns, membership: .excluding))
   }

--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -200,7 +200,11 @@ extension Configuration.TestFilter {
   /// - Parameters:
   ///   - tagPatterns: The patterns, expressed as a `Regex`-compatible regular
   ///     expressions, to match test tags against.
-  public init(includingTagsMatching tagPatterns: [String]) {
+  public init(includingTagsMatching tagPatterns: [String]) throws {
+    // See the comment above in init(membership:matchingAnyOf:) to understand why we construct regexes here.
+    for pattern in tagPatterns {
+      _ = try Regex(pattern)
+    }
     self.init(_kind: .tagPatterns(tagPatterns, membership: .including))
   }
 
@@ -209,7 +213,11 @@ extension Configuration.TestFilter {
   /// - Parameters:
   ///   - tagPatterns: The patterns, expressed as a `Regex`-compatible regular
   ///     expressions, to match test tags against.
-  public init(excludingTagsMatching tagPatterns: [String]) {
+  public init(excludingTagsMatching tagPatterns: [String]) throws {
+    // See the comment above in init(membership:matchingAnyOf:) to understand why we construct regexes here.
+    for pattern in tagPatterns {
+      _ = try Regex(pattern)
+    }
     self.init(_kind: .tagPatterns(tagPatterns, membership: .excluding))
   }
 }

--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -55,9 +55,9 @@ extension Configuration {
       /// The test filter contains a pattern to predicate test IDs against.
       ///
       /// - Parameters:
-      ///   - patterns: The patterns to predicate test IDs against.
+      ///   - idPatterns: The idPatterns to predicate test IDs against.
       ///   - membership: How to interpret the result when predicating tests.
-      case patterns(_ patterns: [String], membership: Membership)
+      case idPatterns(_ idPatterns: [String], membership: Membership)
 
       /// The test filter contains a pattern to predicate test tags against.
       ///
@@ -136,9 +136,9 @@ extension Configuration.TestFilter {
   ///
   /// - Parameters:
   ///   - membership: How to interpret the result when predicating tests.
-  ///   - patterns: The patterns, expressed as a `Regex`-compatible regular
+  ///   - idPatterns: The patterns, expressed as a `Regex`-compatible regular
   ///     expressions, to match test IDs against.
-  init(membership: Membership, matchingAnyOf patterns: some Sequence<String>) throws {
+  init(membership: Membership, matchingAnyOf idPatterns: some Sequence<String>) throws {
     // Validate each regular expression by attempting to initialize a `Regex`
     // representing it, but do not preserve it. This type only represents
     // the pattern in the abstract, and is not responsible for actually
@@ -147,11 +147,11 @@ extension Configuration.TestFilter {
     // Performing this validation here currently makes such errors easier to
     // surface when using the SwiftPM entry point. But longer-term, we should
     // make the planning phase throwing and propagate errors from there instead.
-    for pattern in patterns {
+    for pattern in idPatterns {
       _ = try Regex(pattern)
     }
 
-    self.init(_kind: .patterns(Array(patterns), membership: membership))
+    self.init(_kind: .idPatterns(Array(idPatterns), membership: membership))
   }
 
   /// Initialize this instance to include tests with tags matching a pattern.
@@ -285,8 +285,8 @@ extension Configuration.TestFilter.Kind {
       }
       return .function(predicate, membership: membership)
 #if canImport(_StringProcessing)
-    case let .patterns(patterns, membership):
-      nonisolated(unsafe) let regexes = try patterns.map(Regex.init)
+    case let .idPatterns(idPatterns, membership):
+      nonisolated(unsafe) let regexes = try idPatterns.map(Regex.init)
       return .function({ item in
         let id = String(describing: item.test.id)
         return regexes.contains { id.contains($0) }
@@ -551,10 +551,10 @@ extension Configuration.TestFilter.Kind {
     case .unfiltered, .testIDs:
       false
 #if canImport(_StringProcessing)
-    case .patterns:
-        false
+    case .idPatterns:
+      false
     case .tagPatterns:
-        true
+      true
 #endif
     case .tags:
       true

--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -52,19 +52,19 @@ extension Configuration {
       case tags(_ tags: Set<Tag>, anyOf: Bool, membership: Membership)
 
 #if canImport(_StringProcessing)
-      /// The test filter contains a pattern to predicate test tags against.
-      ///
-      /// - Parameters:
-      ///   - tagPatterns: The patterns to predicate test tags against
-      ///   - membership: How to interpret the result when predicating tests.
-      case tagPatterns(_ tagPatterns: [String], membership: Membership)
-
       /// The test filter contains a pattern to predicate test IDs against.
       ///
       /// - Parameters:
       ///   - patterns: The patterns to predicate test IDs against.
       ///   - membership: How to interpret the result when predicating tests.
       case patterns(_ patterns: [String], membership: Membership)
+
+      /// The test filter contains a pattern to predicate test tags against.
+      ///
+      /// - Parameters:
+      ///   - tagPatterns: The patterns to predicate test tags against
+      ///   - membership: How to interpret the result when predicating tests.
+      case tagPatterns(_ tagPatterns: [String], membership: Membership)
 #endif
 
       /// The test filter is a combination of other test filter kinds.
@@ -153,6 +153,32 @@ extension Configuration.TestFilter {
 
     self.init(_kind: .patterns(Array(patterns), membership: membership))
   }
+
+  /// Initialize this instance to include tests with tags matching a pattern.
+  ///
+  /// - Parameters:
+  ///   - tagPatterns: The patterns, expressed as a `Regex`-compatible regular
+  ///     expressions, to match test tags against.
+  public init(includingTagsMatching tagPatterns: [String]) throws {
+    // See the comment above in init(membership:matchingAnyOf:) to understand why we construct regexes here.
+    for pattern in tagPatterns {
+      _ = try Regex(pattern)
+    }
+    self.init(_kind: .tagPatterns(tagPatterns, membership: .including))
+  }
+
+  /// Initialize this instance to exclude tests with tags matching a pattern.
+  ///
+  /// - Parameters:
+  ///   - tagPatterns: The patterns, expressed as a `Regex`-compatible regular
+  ///     expressions, to match test tags against.
+  public init(excludingTagsMatching tagPatterns: [String]) throws {
+    // See the comment above in init(membership:matchingAnyOf:) to understand why we construct regexes here.
+    for pattern in tagPatterns {
+      _ = try Regex(pattern)
+    }
+    self.init(_kind: .tagPatterns(tagPatterns, membership: .excluding))
+  }
 #endif
 
   /// Initialize this instance to include tests with a given set of tags.
@@ -193,32 +219,6 @@ extension Configuration.TestFilter {
   /// Matching tests have had _all_ of the tags in `tags` added to them.
   public init(excludingAllOf tags: some Collection<Tag>) {
     self.init(_kind: .tags(Set(tags), anyOf: false, membership: .excluding))
-  }
-
-  /// Initialize this instance to include tests with tags matching a pattern.
-  ///
-  /// - Parameters:
-  ///   - tagPatterns: The patterns, expressed as a `Regex`-compatible regular
-  ///     expressions, to match test tags against.
-  public init(includingTagsMatching tagPatterns: [String]) throws {
-    // See the comment above in init(membership:matchingAnyOf:) to understand why we construct regexes here.
-    for pattern in tagPatterns {
-      _ = try Regex(pattern)
-    }
-    self.init(_kind: .tagPatterns(tagPatterns, membership: .including))
-  }
-
-  /// Initialize this instance to exclude tests with tags matching a pattern.
-  ///
-  /// - Parameters:
-  ///   - tagPatterns: The patterns, expressed as a `Regex`-compatible regular
-  ///     expressions, to match test tags against.
-  public init(excludingTagsMatching tagPatterns: [String]) throws {
-    // See the comment above in init(membership:matchingAnyOf:) to understand why we construct regexes here.
-    for pattern in tagPatterns {
-      _ = try Regex(pattern)
-    }
-    self.init(_kind: .tagPatterns(tagPatterns, membership: .excluding))
   }
 }
 
@@ -285,6 +285,12 @@ extension Configuration.TestFilter.Kind {
       }
       return .function(predicate, membership: membership)
 #if canImport(_StringProcessing)
+    case let .patterns(patterns, membership):
+      nonisolated(unsafe) let regexes = try patterns.map(Regex.init)
+      return .function({ item in
+        let id = String(describing: item.test.id)
+        return regexes.contains { id.contains($0) }
+      }, membership: membership)
     case let .tagPatterns(tagPatterns, membership):
       nonisolated(unsafe) let regexes = try tagPatterns.map(Regex.init)
       return .function({ item in
@@ -298,12 +304,6 @@ extension Configuration.TestFilter.Kind {
             tagName.contains(regex)
           })
         })
-      }, membership: membership)
-    case let .patterns(patterns, membership):
-      nonisolated(unsafe) let regexes = try patterns.map(Regex.init)
-      return .function({ item in
-        let id = String(describing: item.test.id)
-        return regexes.contains { id.contains($0) }
       }, membership: membership)
 #endif
     case let .combination(lhs, rhs, op):

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -17,6 +17,10 @@ private func configurationForEntryPoint(withArguments args: [String]) throws -> 
 }
 
 #if !SWT_NO_CODABLE
+
+private extension Tag {
+  @Tag static var testTag: Self
+}
 /// Reads event stream output from the provided file matching event stream
 /// version `V`.
 private func decodedEventStreamRecords<V: ABI.Version>(fromPath filePath: String) throws -> [ABI.Record<V>] {
@@ -114,6 +118,18 @@ struct SwiftPMTests {
     #expect(!planTests.contains(test2))
   }
 
+
+  @Test("--filter argument with tag: prefix")
+  func filterByTag() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:testTag"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+  }
+
   @Test("Multiple --filter arguments")
   func multipleFilter() async throws {
     let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "hello", "--filter", "sorry"])
@@ -150,6 +166,17 @@ struct SwiftPMTests {
   func skip() async throws {
     let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--skip", "hello"])
     let test1 = Test(name: "hello") {}
+    let test2 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(!planTests.contains(test1))
+    #expect(planTests.contains(test2))
+  }
+
+  @Test("--skip argument with tag: prefix")
+  func skipByTag() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--skip", "tag:testTag"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
     let test2 = Test(name: "goodbye") {}
     let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
     let planTests = plan.steps.map(\.test)

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -20,6 +20,8 @@ private func configurationForEntryPoint(withArguments args: [String]) throws -> 
 
 private extension Tag {
   @Tag static var testTag: Self
+  @Tag static var testTagOther: Self
+  @Tag static var unrelatedTag: Self
 }
 /// Reads event stream output from the provided file matching event stream
 /// version `V`.
@@ -182,6 +184,83 @@ struct SwiftPMTests {
     let planTests = plan.steps.map(\.test)
     #expect(!planTests.contains(test1))
     #expect(planTests.contains(test2))
+  }
+
+  @Test("--filter argument with tag: prefix supports regex patterns")
+  func filterByTagRegex() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:testTag.*"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(.tags(.testTagOther), name: "hi") {}
+    let test3 = Test(.tags(.unrelatedTag), name: "goodbye") {}
+    let test4 = Test(name: "untagged") {}
+    let plan = await Runner.Plan(tests: [test1, test2, test3, test4], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(planTests.contains(test2))
+    #expect(!planTests.contains(test3))
+    #expect(!planTests.contains(test4))
+  }
+
+  @Test("--filter tag: argument strips backticks around tag names")
+  func filterByTagStripsBackticks() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:`testTag`"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+  }
+
+  @Test("--filter combining tag: and id: patterns AND's them together")
+  func mixedPrefixedAndUnprefixedFilters() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:testTag", "--filter", "hello"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(.tags(.testTag), name: "goodbye") {}
+    let test3 = Test(name: "hello") {}
+    let test4 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2, test3, test4], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+    #expect(!planTests.contains(test3))
+    #expect(!planTests.contains(test4))
+  }
+
+  @Test("--filter argument with explicit id: prefix")
+  func filterByExplicitIdPrefix() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "id:hello"])
+    let test1 = Test(name: "hello") {}
+    let test2 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+  }
+
+  @Test("--filter tag: combined with --skip id: in the same execution")
+  func filterByTagAndSkipById() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:testTag", "--skip", "id:goodbye"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(.tags(.testTag), name: "goodbye") {}
+    let test3 = Test(.tags(.unrelatedTag), name: "hello") {}
+    let test4 = Test(name: "untagged") {}
+    let plan = await Runner.Plan(tests: [test1, test2, test3, test4], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+    #expect(!planTests.contains(test3))
+    #expect(!planTests.contains(test4))
+  }
+
+  @Test("--filter or --skip tag: argument with bad regex")
+  func filterByTagWithBadRegex() throws {
+    #expect(throws: (any Error).self) {
+      _ = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:("])
+    }
+    #expect(throws: (any Error).self) {
+      _ = try configurationForEntryPoint(withArguments: ["PATH", "--skip", "tag:)"])
+    }
   }
 
   @Test("--filter or --skip argument as last argument")

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -17,6 +17,11 @@ private func configurationForEntryPoint(withArguments args: [String]) throws -> 
 }
 
 #if !SWT_NO_ABI_JSON_SCHEMA
+
+private extension Tag {
+  @Tag static var testTag: Self
+}
+
 /// Reads event stream output from the provided file matching event stream
 /// version `V`.
 private func decodedEventStreamRecords<V: ABI.Version>(fromPath filePath: String) throws -> [ABI.Record<V>] {
@@ -114,6 +119,18 @@ struct SwiftPMTests {
     #expect(!planTests.contains(test2))
   }
 
+
+  @Test("--filter argument with tag: prefix")
+  func filterByTag() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:testTag"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+  }
+
   @Test("Multiple --filter arguments")
   func multipleFilter() async throws {
     let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "hello", "--filter", "sorry"])
@@ -150,6 +167,17 @@ struct SwiftPMTests {
   func skip() async throws {
     let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--skip", "hello"])
     let test1 = Test(name: "hello") {}
+    let test2 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(!planTests.contains(test1))
+    #expect(planTests.contains(test2))
+  }
+
+  @Test("--skip argument with tag: prefix")
+  func skipByTag() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--skip", "tag:testTag"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
     let test2 = Test(name: "goodbye") {}
     let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
     let planTests = plan.steps.map(\.test)

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -20,6 +20,8 @@ private func configurationForEntryPoint(withArguments args: [String]) throws -> 
 
 private extension Tag {
   @Tag static var testTag: Self
+  @Tag static var testTagOther: Self
+  @Tag static var unrelatedTag: Self
 }
 
 /// Reads event stream output from the provided file matching event stream
@@ -183,6 +185,83 @@ struct SwiftPMTests {
     let planTests = plan.steps.map(\.test)
     #expect(!planTests.contains(test1))
     #expect(planTests.contains(test2))
+  }
+
+  @Test("--filter argument with tag: prefix supports regex patterns")
+  func filterByTagRegex() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:testTag.*"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(.tags(.testTagOther), name: "hi") {}
+    let test3 = Test(.tags(.unrelatedTag), name: "goodbye") {}
+    let test4 = Test(name: "untagged") {}
+    let plan = await Runner.Plan(tests: [test1, test2, test3, test4], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(planTests.contains(test2))
+    #expect(!planTests.contains(test3))
+    #expect(!planTests.contains(test4))
+  }
+
+  @Test("--filter tag: argument strips backticks around tag names")
+  func filterByTagStripsBackticks() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:`testTag`"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+  }
+
+  @Test("--filter combining tag: and id: patterns AND's them together")
+  func mixedPrefixedAndUnprefixedFilters() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:testTag", "--filter", "hello"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(.tags(.testTag), name: "goodbye") {}
+    let test3 = Test(name: "hello") {}
+    let test4 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2, test3, test4], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+    #expect(!planTests.contains(test3))
+    #expect(!planTests.contains(test4))
+  }
+
+  @Test("--filter argument with explicit id: prefix")
+  func filterByExplicitIdPrefix() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "id:hello"])
+    let test1 = Test(name: "hello") {}
+    let test2 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+  }
+
+  @Test("--filter tag: combined with --skip id: in the same execution")
+  func filterByTagAndSkipById() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:testTag", "--skip", "id:goodbye"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(.tags(.testTag), name: "goodbye") {}
+    let test3 = Test(.tags(.unrelatedTag), name: "hello") {}
+    let test4 = Test(name: "untagged") {}
+    let plan = await Runner.Plan(tests: [test1, test2, test3, test4], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+    #expect(!planTests.contains(test3))
+    #expect(!planTests.contains(test4))
+  }
+
+  @Test("--filter or --skip tag: argument with bad regex")
+  func filterByTagWithBadRegex() throws {
+    #expect(throws: (any Error).self) {
+      _ = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:("])
+    }
+    #expect(throws: (any Error).self) {
+      _ = try configurationForEntryPoint(withArguments: ["PATH", "--skip", "tag:)"])
+    }
   }
 
   @Test("--filter or --skip argument as last argument")

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -213,7 +213,7 @@ struct SwiftPMTests {
     #expect(!planTests.contains(test2))
   }
 
-  @Test("--filter combining tag: and id: patterns AND's them together")
+  @Test("--filter combining tag: and id: patterns OR's them together")
   func mixedPrefixedAndUnprefixedFilters() async throws {
     let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:testTag", "--filter", "hello"])
     let test1 = Test(.tags(.testTag), name: "hello") {}
@@ -223,9 +223,37 @@ struct SwiftPMTests {
     let plan = await Runner.Plan(tests: [test1, test2, test3, test4], configuration: configuration)
     let planTests = plan.steps.map(\.test)
     #expect(planTests.contains(test1))
+    #expect(planTests.contains(test2))
+    #expect(planTests.contains(test3))
+    #expect(!planTests.contains(test4))
+  }
+
+  @Test("--skip combining tag: and id: patterns OR's them together")
+  func mixedPrefixedAndUnprefixedSkips() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--skip", "tag:testTag", "--skip", "hello"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(.tags(.testTag), name: "goodbye") {}
+    let test3 = Test(name: "hello") {}
+    let test4 = Test(name: "goodbye") {}
+    let plan = await Runner.Plan(tests: [test1, test2, test3, test4], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(!planTests.contains(test1))
     #expect(!planTests.contains(test2))
     #expect(!planTests.contains(test3))
-    #expect(!planTests.contains(test4))
+    #expect(planTests.contains(test4))
+  }
+
+  @Test("Multiple --skip arguments with tag: prefix")
+  func multipleSkipByTag() async throws {
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--skip", "tag:testTag", "--skip", "tag:unrelatedTag"])
+    let test1 = Test(.tags(.testTag), name: "hello") {}
+    let test2 = Test(.tags(.unrelatedTag), name: "goodbye") {}
+    let test3 = Test(name: "untagged") {}
+    let plan = await Runner.Plan(tests: [test1, test2, test3], configuration: configuration)
+    let planTests = plan.steps.map(\.test)
+    #expect(!planTests.contains(test1))
+    #expect(!planTests.contains(test2))
+    #expect(planTests.contains(test3))
   }
 
   @Test("--filter argument with explicit id: prefix")


### PR DESCRIPTION
While Xcode has had the ability to filter based on tags, this ability has been missing from the command line. This PR introduces a special prefix you can apply to your `--filter` and `--skip` option arguments: `tag:`.

```swift
extension Tag {
  @Tag static var integrationTest: Self
}
```

If you then add that tag to some suites or tests, you'll be able to run those tests exclusively by running:

```
swift test --filter tag:integrationTest
```

Resolves #591.
Resolves rdar://132989780.

https://github.com/user-attachments/assets/77dca6df-f010-4438-9016-7a25b3511426

### Modifications:

This PR enhances the nested `testFilter` function inside of `configurationForEntryPoint(from:)` function. The `testFilter` function now:

- Processes any arguments prefixed with `tag:` as regexes to be matched against tags
- Handles escaping the `tag:` prefix with the following syntax: `tag\:myRegex` to force the entire string to be read as a regex (as it would be normally prior to this change). This allows for filtering on test names that contain `tag:`.
- Continues to process regexes as it did before this change, once all the tag-based arguments are processed.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
