### PR TITLE
[6.3] Ensure issues with warning severity are delivered to Xcode.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -671,6 +671,11 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
 
   // Warning issues (experimental).
   switch args.eventStreamVersionNumber {
+#if !SWT_NO_SNAPSHOT_TYPES
+  case .some(ABI.Xcode16.versionNumber):
+    // Xcode 26 and later support warning severity, so leave it enabled.
+    break
+#endif
   case .some(..<ABI.v6_3.versionNumber):
     // If the event stream version was explicitly specified to a value < 6.3,
     // disable the warning issue event to maintain legacy behavior.

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -325,6 +325,16 @@ struct SwiftPMTests {
     #expect(versionTypeInfo == nil)
   }
 
+#if !SWT_NO_SNAPSHOT_TYPES
+  @Test("Severity field included in Issue.Snapshot")
+  func issueSnapshotIncludesSeverity() async throws {
+    let configuration = try configurationForEntryPoint(
+      withArguments: ["PATH", "--event-stream-version", "-1"]
+    )
+    #expect(configuration.eventHandlingOptions.isWarningIssueRecordedEventEnabled)
+  }
+#endif
+
   @Test("Severity and isFailure fields included in version 6.3")
   func validateEventStreamContents() async throws {
     let tempDirPath = try temporaryDirectory()


### PR DESCRIPTION
- **Explanation**: Ensure that warning-severity issues aren't dropped when using Swift Testing as a package in Xcode 26 or later.
- **Scope**: Swift Testing as a package in Xcode.
- **Issues**: rdar://169741898
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1529
- **Risk**: Low
- **Testing**: Unit testing and manual verification.
- **Reviewers**: @stmontgomery @jerryjrchen @harlanhaskins