### PR TITLE
Fix a diagnostic logged by ImageIO on Darwin when attaching an image.

### DIFF
--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
@@ -103,7 +103,7 @@ extension AttachableAsCGImage {
     let scaleFactor = attachmentScaleFactor
     let properties: [CFString: Any] = [
       kCGImageDestinationLossyCompressionQuality: CGFloat(imageFormat.encodingQuality),
-      kCGImagePropertyOrientation: orientation,
+      kCGImagePropertyOrientation: orientation.rawValue,
       kCGImagePropertyDPIWidth: 72.0 * scaleFactor,
       kCGImagePropertyDPIHeight: 72.0 * scaleFactor,
     ]


### PR DESCRIPTION
We're passing a boxed C enum value to `CGImageDestinationAddImage()` that causes ImageIO to warn. Fix is to pass its raw value instead.

Resolves rdar://170149329.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
