### PR TITLE
[6.3] Fix a diagnostic logged by ImageIO on Darwin when attaching an image.

### DIFF
--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableAsCGImage.swift
@@ -107,7 +107,7 @@ extension AttachableAsCGImage {
     let scaleFactor = attachmentScaleFactor
     let properties: [CFString: Any] = [
       kCGImageDestinationLossyCompressionQuality: CGFloat(imageFormat.encodingQuality),
-      kCGImagePropertyOrientation: orientation,
+      kCGImagePropertyOrientation: orientation.rawValue,
       kCGImagePropertyDPIWidth: 72.0 * scaleFactor,
       kCGImagePropertyDPIHeight: 72.0 * scaleFactor,
     ]


### PR DESCRIPTION
- **Explanation**: Fix a warning logged by ImageIO via `os_log()`.
- **Scope**: Image attachments on Darwin.
- **Issues**: rdar://170149329
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1539
- **Risk**: Low
- **Testing**: Tested fix, warning goes away :)
- **Reviewers**: @stmontgomery @jerryjrchen @harlanhaskins