### PR TITLE
Declare availability for `SourceLocation.filePath`.

### DIFF
--- a/Sources/Testing/SourceAttribution/SourceLocation.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation.swift
@@ -71,6 +71,10 @@ public struct SourceLocation: Sendable {
   }
 
   /// The path to the source file.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public var filePath: String
 
   /// The line in the source file.


### PR DESCRIPTION
Added in 6.3.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
