### PR TITLE
[6.3] Declare availability for `SourceLocation.filePath`.

### DIFF
--- a/Sources/Testing/SourceAttribution/SourceLocation.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation.swift
@@ -71,6 +71,10 @@ public struct SourceLocation: Sendable {
   }
 
   /// The path to the source file.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.3)
+  /// }
   public var filePath: String
 
   /// The line in the source file.


### PR DESCRIPTION
- **Explanation**: Declare availability for `SourceLocation.filePath`.
- **Scope**: Documentation
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1544
- **Risk**: None
- **Testing**: N/A
- **Reviewers**: @stmontgomery