### PR TITLE
Use the new `#available(Android <API>, *)` instead to look for `backtrace()`

### DIFF
--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -28,3 +28,7 @@ jobs:
       enable_freebsd_checks: true
       freebsd_swift_versions: '["nightly-main"]'
       freebsd_os_versions: '["14.3"]'
+      enable_android_sdk_build: true
+      android_sdk_versions: '["nightly-main"]'
+      android_ndk_versions: '["r28c", "r29"]'
+      android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -25,6 +25,10 @@ jobs:
       macos_xcode_versions: '["swift_6.3"]'
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["nightly-6.3"]'
+      enable_android_sdk_build: true
+      android_sdk_versions: '["6.3", "nightly-6.3"]'
+      android_ndk_versions: '["r28c", "r29"]'
+      android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'
 #       enable_freebsd_checks: true
 #       freebsd_swift_versions: '["nightly-6.3"]'
 #       freebsd_os_versions: '["14.3"]'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,6 +34,8 @@ jobs:
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["nightly-main", "nightly-6.3"]'
       enable_android_sdk_build: true
+      android_ndk_versions: '["r28c", "r29"]'
+      android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'
       enable_freebsd_checks: true
       freebsd_swift_versions: '["nightly-main"]'
       freebsd_os_versions: '["14.3"]'

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -44,16 +44,6 @@ public struct Backtrace: Sendable {
     self.addresses = addresses.map { Address(UInt(bitPattern: $0)) }
   }
 
-#if os(Android) && !SWT_NO_DYNAMIC_LINKING
-  /// The `backtrace()` function.
-  ///
-  /// This function was added to Android with API level 33, which is higher than
-  /// our minimum deployment target, so we look it up dynamically at runtime.
-  private static let _backtrace = symbol(named: "backtrace").map {
-    castCFunction(at: $0, to: (@convention(c) (UnsafeMutablePointer<UnsafeMutableRawPointer?>, CInt) -> CInt).self)
-  }
-#endif
-
   /// Get the current backtrace.
   ///
   /// - Parameters:
@@ -76,11 +66,11 @@ public struct Backtrace: Sendable {
 #if SWT_TARGET_OS_APPLE
       initializedCount = backtrace_async(addresses.baseAddress!, addresses.count, nil)
 #elseif os(Android)
-#if !SWT_NO_DYNAMIC_LINKING
-      if let _backtrace {
-        initializedCount = .init(clamping: _backtrace(addresses.baseAddress!, .init(clamping: addresses.count)))
+      if #available(Android 33, *) {
+        initializedCount = addresses.withMemoryRebound(to: UnsafeMutableRawPointer.self) { addresses in
+          .init(clamping: backtrace(addresses.baseAddress!, .init(clamping: addresses.count)))
+        }
       }
-#endif
 #elseif os(Linux) || os(FreeBSD) || os(OpenBSD)
       initializedCount = .init(clamping: backtrace(addresses.baseAddress!, .init(clamping: addresses.count)))
 #elseif os(Windows)


### PR DESCRIPTION
Mads added this compiler feature for Android in swiftlang/swift#84574 before the 6.3 branch, so update the Android triples and NDK version to test it, as it requires NDK 28 or later.

@grynspan, just a pure rebased copy of #1373, unfortunately, may be a while before we can merge it.