### PR TITLE
Update `Test.traits` setter to filter applicable values rather than crashing when non-applicable values are encountered

### DIFF
--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -90,17 +90,15 @@ public struct Test: Sendable {
       _properties.value.traits
     }
     set {
-      // Prevent programmatically adding suite traits to test functions or test
-      // traits to test suites.
-      func traitsAreCorrectlyTyped() -> Bool {
-        if isSuite {
-          return newValue.allSatisfy { $0.__as((any SuiteTrait).self) != nil }
-        } else {
-          return newValue.allSatisfy { $0.__as((any TestTrait).self) != nil }
-        }
+      // When setting traits, we take care to only apply those that are
+      // applicable. For example, if a trait only conforms to `SuiteTrait` and
+      // not `TestTrait`, it should only be applied to suites, and not tests.
+      let applicableTraits = if isSuite {
+        newValue.filter { $0.__as((any SuiteTrait).self) != nil }
+      } else {
+        newValue.filter { $0.__as((any TestTrait).self) != nil }
       }
-      precondition(traitsAreCorrectlyTyped(), "Programmatically added an inapplicable trait to test \(self)")
-      _setValue(newValue, forKeyPath: \.traits)
+      _setValue(applicableTraits, forKeyPath: \.traits)
     }
   }
 

--- a/Tests/TestingTests/Test.TraitTests.swift
+++ b/Tests/TestingTests/Test.TraitTests.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/TestingTests/Test.TraitTests.swift
+++ b/Tests/TestingTests/Test.TraitTests.swift
@@ -19,16 +19,17 @@ private struct TestOnlyTrait: TestTrait {}
 /// A trait that applies to both
 private struct TestAndSuiteTrait: SuiteTrait, TestTrait {}
 
-/// A stub test suite.
-@Suite
-private struct DemoTestSuite {}
-
 @Suite("Test.Trait Tests")
 struct Test_TraitTests {
   @Test("Setting traits on a suite filters out non-suite traits", .tags(.traitRelated))
   func filterTraitsOnSuites() async throws {
     let mixedTraits: [any Trait] = [SuiteOnlyTrait(), TestOnlyTrait(), TestAndSuiteTrait()]
-    var suite = try #require(await test(for: DemoTestSuite.self))
+    var suite = Test(
+      displayName: "Fake Suite",
+      traits: [],
+      sourceLocation: #_sourceLocation,
+      containingTypeInfo: TypeInfo(describing: Void.self),
+    )
 
     // Setting the traits property should filter out non-suite traits
     suite.traits = mixedTraits

--- a/Tests/TestingTests/Test.TraitTests.swift
+++ b/Tests/TestingTests/Test.TraitTests.swift
@@ -1,0 +1,52 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+/// A trait that only applies to suites
+private struct SuiteOnlyTrait: SuiteTrait {}
+
+/// A trait that only applies to test functions
+private struct TestOnlyTrait: TestTrait {}
+
+/// A trait that applies to both
+private struct TestAndSuiteTrait: SuiteTrait, TestTrait {}
+
+/// A stub test suite.
+@Suite
+private struct DemoTestSuite {}
+
+@Suite("Test.Trait Tests")
+struct Test_TraitTests {
+  @Test("Setting traits on a suite filters out non-suite traits", .tags(.traitRelated))
+  func filterTraitsOnSuites() async throws {
+    let mixedTraits: [any Trait] = [SuiteOnlyTrait(), TestOnlyTrait(), TestAndSuiteTrait()]
+    var suite = try #require(await test(for: DemoTestSuite.self))
+
+    // Setting the traits property should filter out non-suite traits
+    suite.traits = mixedTraits
+    #expect(suite.traits.count == 2)
+    #expect(suite.traits[0] is SuiteOnlyTrait)
+    #expect(suite.traits[1] is TestAndSuiteTrait)
+  }
+
+  @Test("Setting traits on a test filters out non-test traits", .tags(.traitRelated))
+  func filterTraitsOnTests() async throws {
+    let mixedTraits: [any Trait] = [SuiteOnlyTrait(), TestOnlyTrait(), TestAndSuiteTrait()]
+    var test = Test {}
+
+    // Setting the traits property should filter out non-test traits
+    test.traits = mixedTraits
+    #expect(test.traits.count == 2)
+    #expect(test.traits[0] is TestOnlyTrait)
+    #expect(test.traits[1] is TestAndSuiteTrait)
+  }
+
+}

--- a/Tests/TestingTests/Test.TraitTests.swift
+++ b/Tests/TestingTests/Test.TraitTests.swift
@@ -19,10 +19,10 @@ private struct TestOnlyTrait: TestTrait {}
 /// A trait that applies to both
 private struct TestAndSuiteTrait: SuiteTrait, TestTrait {}
 
-@Suite("Test.Trait Tests")
-struct Test_TraitTests {
-  @Test("Setting traits on a suite filters out non-suite traits", .tags(.traitRelated))
-  func filterTraitsOnSuites() async throws {
+@Suite
+struct `Test.Trait Tests` {
+  @Test(.tags(.traitRelated))
+  func `Setting traits on a suite filters out non-suite traits`() async throws {
     let mixedTraits: [any Trait] = [SuiteOnlyTrait(), TestOnlyTrait(), TestAndSuiteTrait()]
     var suite = Test(
       displayName: "Fake Suite",
@@ -38,8 +38,8 @@ struct Test_TraitTests {
     #expect(suite.traits[1] is TestAndSuiteTrait)
   }
 
-  @Test("Setting traits on a test filters out non-test traits", .tags(.traitRelated))
-  func filterTraitsOnTests() async throws {
+  @Test(.tags(.traitRelated))
+  func `Setting traits on a test filters out non-test traits`() async throws {
     let mixedTraits: [any Trait] = [SuiteOnlyTrait(), TestOnlyTrait(), TestAndSuiteTrait()]
     var test = Test {}
 


### PR DESCRIPTION
Prior to this PR, when a developer would define their own `SuiteTrait` and provide an implementation for `isRecursive` that resolved to `true`, the test process would crash unless they also had the trait conform to `TestTrait`. This happened because we consider a non-suite `Test` having a `SuiteTrait` to be invalid, so we placed a precondition failure in the setter for `Test.traits`. When we would recursively attempt to apply the trait, it would do so for all sub-suites _and_ tests, tripping the precondition.

While this is technically correct behavior, the failure mode is a poor experience that doesn't adequately communicate what went wrong. Here's an example of the log when the crash happens:

```
Build complete! (0.79s)
Test Suite 'All tests' started at 2026-02-12 17:40:55.984.
Test Suite 'All tests' passed at 2026-02-12 17:40:55.985.
         Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.002) seconds
error: Process 'swiftpm-testing-helper --test-bundle-path .build/arm64-apple-macosx/debug/recursive-suite-traitsPackageTests.xctest/Contents/MacOS/recursive-suite-traitsPackageTests .build/arm64-apple-macosx/debug/recursive-suite-traitsPackageTests.xctest/Contents/MacOS/recursive-suite-traitsPackageTests --testing-library swift-testing' exited with unexpected signal code 5
```

To avoid this crash and to allow for previously infeasible trait configurations, this change updates the `Test.traits` setter to:

1. Ditch the precondition failure
2. Instead, only _actually_ set valid values

As a short cookbook, we then have the following:

| As a developer I want to… | Recipe |
| --- | --- |
| … write a trait that only applies to a suite and its sub-suites | Have your trait conform to `SuiteTrait` and set `isRecursive` to `true` (the previous crash scenario). The nested tests will ignore the trait when we attempt to set it on them. |
| … write a trait that applies to a suite, its sub-suites, _and_ tests | Have your trait conform to both `SuiteTrait` **and** `TestTrait`, and set `isRecursive` to `true`. With the extra conformance, nested tests will pick up the trait. |

Resolves #1048 

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
