### PR TITLE
Clarify documentation to mention that unsatisfied @available on @Test will be considered a skip

### DIFF
--- a/Sources/Testing/Testing.docc/DefiningTests.md
+++ b/Sources/Testing/Testing.docc/DefiningTests.md
@@ -79,9 +79,9 @@ the process), it can be annotated `@MainActor`:
 
 If a test function can only run on newer versions of an operating system or of
 the Swift language, use the `@available` attribute when declaring it. When a
-test cannot run due to limited availability, it will be skipped and reported as
-such in the results. Use the `message` argument of the `@available` attribute to
-include a message explaining why the test is unable to run:
+test can't run due to limited availability, the testing library reports it as
+skipped. Use the `message` argument of the `@available` attribute to include a
+message explaining why the test is unable to run:
 
 ```swift
 @available(macOS 11.0, *)


### PR DESCRIPTION
This is a small improvement to the [Limit the availability of a test](https://developer.apple.com/documentation/testing/definingtests#Limit-the-availability-of-a-test) section of our [Defining test functions](https://developer.apple.com/documentation/testing/definingtests) article to mention that when a test doesn't run due to an `@available` attribute being unsatisfied, that test will be skipped and represented that way in the results, instead of this _only_ causing a log line to be emitted to the console.

Resolves rdar://161346836

### Motivation:

A user indicated they were unclear about the current wording since it sounded as if this situation would only be logged and thus could be overlooked or missed.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
