### PR TITLE
Mark FileClonable behind SWT_NO_FILE_CLONING.

### DIFF
--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -202,6 +202,7 @@ struct AttachmentTests {
   }
 #endif
 
+#if !SWT_NO_FILE_CLONING
   @Test func cloneAttachment() async throws {
     struct MyFileClonable: Attachable, FileClonable {
       var withUnsafeBytesCalled: Confirmation
@@ -226,6 +227,7 @@ struct AttachmentTests {
       }
     }
   }
+#endif
 
   @Test func attachValue() async {
     await confirmation("Attachment detected", expectedCount: 2) { valueAttached in


### PR DESCRIPTION
This protocol is guarded by SWT_NO_FILE_CLONING and so requires qualification before use, otherwise results in a build error.

### Motivation:

Buildfixes tests for OpenBSD.

### Modifications:

Added requisite guards for uses of FileClonable.

### Checklist:

- [X] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated. (n/a)
