### PR TITLE
Only enable 'ExplicitSendable' warnings when building for development

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -374,7 +374,12 @@ extension Array where Element == PackageDescription.SwiftSetting {
     var result = availabilityMacroSettings
 
 #if compiler(>=6.3)
-    result.append(.treatWarning("ExplicitSendable", as: .warning))
+    // treatWarning(..., as: .warning) cannot be used in packages which are
+    // used as dependencies, since the package manager suppresses all warnings
+    // for dependencies. (See: rdar://170562285)
+    if buildingForDevelopment {
+      result.append(.treatWarning("ExplicitSendable", as: .warning))
+    }
 #endif
 
     if buildingForEmbedded {


### PR DESCRIPTION
Avoid a build failure when the package is used by clients due to `treatWarning("ExplicitSendable", as: .warning)`. The package manager suppresses all warnings in dependencies (by passing `-suppress-warnings`) and this is incompatible with the underlying flag that `treatWarnings()` uses (`-Wwarning <group>`) so this results in a build error.

Fix this by restoring a previous `if buildingForDevelopment { ... }` conditional.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
