### PR TITLE
[6.3] Make `#expect()` ∞% faster.

### DIFF
--- a/Sources/Testing/SourceAttribution/SourceLocation+Macro.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation+Macro.swift
@@ -30,6 +30,17 @@ extension SourceLocation {
     line: Int = #line,
     column: Int = #column
   ) -> Self {
-    Self(fileID: fileID, filePath: filePath, line: line, column: column)
+    Self(__uncheckedFileID: fileID, filePath: filePath, line: line, column: column)
+  }
+
+  /// Initialize an instance of this type without validating any arguments.
+  ///
+  /// - Warning: This initializer is used to implement the `#_sourceLocation`
+  ///   macro. Do not call it directly.
+  public init(__uncheckedFileID fileID: String, filePath: String, line: Int, column: Int) {
+    self.fileID = fileID
+    self.filePath = filePath
+    self.line = line
+    self.column = column
   }
 }

--- a/Sources/Testing/SourceAttribution/SourceLocation.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation.swift
@@ -24,7 +24,7 @@ public struct SourceLocation: Sendable {
   public var fileID: String {
     willSet {
       precondition(!newValue.isEmpty, "SourceLocation.fileID must not be empty (was \(newValue))")
-      precondition(newValue.contains("/"), "SourceLocation.fileID must be a well-formed file ID (was \(newValue))")
+      precondition(newValue.utf8.contains(UInt8(ascii: "/")), "SourceLocation.fileID must be a well-formed file ID (was \(newValue))")
     }
   }
 
@@ -113,14 +113,11 @@ public struct SourceLocation: Sendable {
   /// - Precondition: `column` must be greater than `0`.
   public init(fileID: String, filePath: String, line: Int, column: Int) {
     precondition(!fileID.isEmpty, "SourceLocation.fileID must not be empty (was \(fileID))")
-    precondition(fileID.contains("/"), "SourceLocation.fileID must be a well-formed file ID (was \(fileID))")
+    precondition(fileID.utf8.contains(UInt8(ascii: "/")), "SourceLocation.fileID must be a well-formed file ID (was \(fileID))")
     precondition(line > 0, "SourceLocation.line must be greater than 0 (was \(line))")
     precondition(column > 0, "SourceLocation.column must be greater than 0 (was \(column))")
 
-    self.fileID = fileID
-    self.filePath = filePath
-    self.line = line
-    self.column = column
+    self.init(__uncheckedFileID: fileID, filePath: filePath, line: line, column: column)
   }
 }
 

--- a/Sources/TestingMacros/Support/SourceLocationGeneration.swift
+++ b/Sources/TestingMacros/Support/SourceLocationGeneration.swift
@@ -37,5 +37,5 @@ func createSourceLocationExpr(of expr: some SyntaxProtocol, context: some MacroE
     return "Testing.SourceLocation.__here()"
   }
 
-  return "Testing.SourceLocation(fileID: \(fileIDSourceLoc.file), filePath: \(filePathSourceLoc.file), line: \(fileIDSourceLoc.line), column: \(fileIDSourceLoc.column))"
+  return "Testing.SourceLocation(__uncheckedFileID: \(fileIDSourceLoc.file), filePath: \(filePathSourceLoc.file), line: \(fileIDSourceLoc.line), column: \(fileIDSourceLoc.column))"
 }


### PR DESCRIPTION
- **Explanation**: Improves performance of `#expect()` _et al._ by eliminating precondition overhead when generating source locations in the compiler.
- **Scope**: Everything everywhere?
- **Issues**: rdar://150474666
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1560
- **Risk**: Low
- **Testing**: Existing test coverage
- **Reviewers**: @stmontgomery @jerryjrchen @harlanhaskins