### PR TITLE
Resolve a crash when trying to look up a test in a detached task.

### DIFF
--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -256,7 +256,7 @@ public struct Event: Sendable {
       // which set of inputs triggered the issue).
       test = Test(containing: issueSourceLocation)
       if let test, !test.isParameterized {
-        testCase = test.testCases?.first { _ in true }
+        testCase = test.uncheckedTestCases?.first { _ in true }
       }
     }
     let event = Event(kind, testID: test?.id, testCaseID: testCase?.id, instant: instant)


### PR DESCRIPTION
In our new issue-recording logic, we check `Test.testCases` on a fallback path if the issue being recorded corresponds to a non-parameterized test. This should generate a stub instance (basically representing `()` as a parameter) but under some test conditions causes a crash.

These conditions are specific to our own test suite and do not affect third-party code.

Resolves rdar://170572665.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
