### PR TITLE
[6.3] Only enable 'ExplicitSendable' warnings when building for development

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -373,7 +373,12 @@ extension Array where Element == PackageDescription.SwiftSetting {
     var result = availabilityMacroSettings
 
 #if compiler(>=6.3)
-    result.append(.treatWarning("ExplicitSendable", as: .warning))
+    // treatWarning(..., as: .warning) cannot be used in packages which are
+    // used as dependencies, since the package manager suppresses all warnings
+    // for dependencies. (See: rdar://170562285)
+    if buildingForDevelopment {
+      result.append(.treatWarning("ExplicitSendable", as: .warning))
+    }
 #endif
 
     if buildingForEmbedded {


### PR DESCRIPTION
- **Explanation**: Avoid a build failure when the package is used by clients due to `treatWarning("ExplicitSendable", as: .warning)`.
- **Scope**: The problem can prevent package clients from building.
- **Issues**: rdar://170562285
- **Original PRs**: #1559 
- **Risk**: Low
- **Testing**: Built in CI
- **Reviewers**: @grynspan 
