### PR TITLE
JSON test list should include synthesized suites.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -95,7 +95,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
 
     // The set of matching tests (or, in the case of `swift test list`, the set
     // of all tests.)
-    let tests: [Test]
+    var tests: [Test]
 
     if args.listTests ?? false {
       tests = await Array(Test.all)
@@ -110,6 +110,10 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
 #endif
         }
       }
+
+      // Synthesize any missing suites. Note we write to stdout before this
+      // step because we don't emit suites to stdout anyway.
+      tests = Runner.Plan.synthesizeSuites(for: tests)
 
       // Post an event for every discovered test. These events are turned into
       // JSON objects if JSON output is enabled.

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -193,6 +193,26 @@ extension Runner.Plan {
     synthesizeSuites(in: &graph, sourceLocation: &sourceLocation)
   }
 
+  /// Given an array of tests, synthesize any containing suites that are not
+  /// already represented in that array.
+  ///
+  /// - Parameters:
+  ///   - tests: The test functions and test suites that have already been
+  ///     generated.
+  ///
+  /// - Returns: A superset of `tests` that also includes synthesized instances
+  ///   of ``Test`` representing any test suites not already present in `tests`
+  ///   that can be inferred from the contents of that collection.
+  static func synthesizeSuites(for tests: [Test]) -> [Test] {
+    var testGraph = Graph<String, Test?>()
+    for test in tests {
+      let idComponents = test.id.keyPathRepresentation
+      testGraph.insertValue(test, at: idComponents)
+    }
+    _recursivelySynthesizeSuites(in: &testGraph)
+    return testGraph.compactMap { $0.value }
+  }
+
   /// The basic "run" action.
   private static let _runAction = Action.run(options: .init())
 

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -525,6 +525,22 @@ struct SwiftPMTests {
     #expect(testIDs.allSatisfy { $0.contains(".swift:") })
   }
 
+  @Test("list subcommand includes synthesized tests")
+  func listIncludesSynthesizedTests() async throws {
+    var args = __CommandLineArguments_v0()
+    args.verbosity = .min
+    args.listTests = true
+    await confirmation("At least one suite was synthesized", expectedCount: 1...) { suiteSynthesized in
+      _ = await entryPoint(passing: args) { event, eventContext in
+        if case .testDiscovered = event.kind,
+           let test = eventContext.test,
+           test.isSynthesized {
+          suiteSynthesized()
+        }
+      }
+    }
+  }
+
   @Test(
     "--verbose, --very-verbose, and --quiet arguments",
     arguments: [


### PR DESCRIPTION
This PR ensures that we include synthesized suites (i.e. types containing tests that aren't marked `@Suite`) in the JSON event stream when calling `swift test list`. These suites were being omitted unintentionally. They are included correctly in the event stream generated when you actually run tests.

Resolves #1099.
Resolves rdar://150449591.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
