### PR TITLE
Ensure the old overload of `Issue.record()` is still documented.

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -63,7 +63,6 @@ extension Issue {
   /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
   /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
   @_disfavoredOverload
-  @_documentation(visibility: private)
   @available(*, deprecated, message: "Use record(_:severity:sourceLocation:) instead.")
   @discardableResult public static func record(
     _ comment: Comment? = nil,


### PR DESCRIPTION
The new overload of `Issue.record()` that takes a `severity` argument was introduced in Swift 6.3. We need to continue to document the older overload.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
