### PR TITLE
[6.3] Ensure the old overload of `Issue.record()` is still documented.

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -63,7 +63,6 @@ extension Issue {
   /// represented as an expectation (using the ``expect(_:_:sourceLocation:)``
   /// or ``require(_:_:sourceLocation:)-5l63q`` macros.)
   @_disfavoredOverload
-  @_documentation(visibility: private)
   @available(*, deprecated, message: "Use record(_:severity:sourceLocation:) instead.")
   @discardableResult public static func record(
     _ comment: Comment? = nil,


### PR DESCRIPTION
- **Explanation**: Clarify documentation around availability of `Issue.record()`.
- **Scope**: Documentation
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1566
- **Risk**: None
- **Testing**: N/A
- **Reviewers**: @stmontgomery