### PR TITLE
[6.3] Add availability annotations for Xcode 26.4.

### DIFF
--- a/Sources/Overlays/_Testing_AppKit/Attachments/NSImage+AttachableAsImage.swift
+++ b/Sources/Overlays/_Testing_AppKit/Attachments/NSImage+AttachableAsImage.swift
@@ -35,11 +35,13 @@ extension NSImageRep {
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 @available(_uttypesAPI, *)
 extension NSImage: AttachableAsImage, AttachableAsCGImage {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   package var attachableCGImage: CGImage {
     get throws {

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableImageFormat+UTType.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/AttachableImageFormat+UTType.swift
@@ -13,6 +13,7 @@ public import UniformTypeIdentifiers
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 @available(_uttypesAPI, *)
 extension AttachableImageFormat {
@@ -25,6 +26,7 @@ extension AttachableImageFormat {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public var contentType: UTType {
     kind.contentType
@@ -47,6 +49,7 @@ extension AttachableImageFormat {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public init(contentType: UTType, encodingQuality: Float = 1.0) {
     switch contentType {
@@ -86,6 +89,7 @@ extension AttachableImageFormat {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public init?(pathExtension: String, encodingQuality: Float = 1.0) {
     let pathExtension = pathExtension.drop { $0 == "." }

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/CGImage+AttachableAsImage.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/CGImage+AttachableAsImage.swift
@@ -13,11 +13,13 @@ public import CoreGraphics
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 @available(_uttypesAPI, *)
 extension CGImage: AttachableAsImage, AttachableAsCGImage {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   package var attachableCGImage: CGImage {
     self

--- a/Sources/Overlays/_Testing_CoreGraphics/Attachments/_AttachableImageWrapper+AttachableWrapper.swift
+++ b/Sources/Overlays/_Testing_CoreGraphics/Attachments/_AttachableImageWrapper+AttachableWrapper.swift
@@ -15,6 +15,7 @@ private import UniformTypeIdentifiers
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 @available(_uttypesAPI, *)
 extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: AttachableAsImage {
@@ -52,6 +53,7 @@ extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: At
 
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<_AttachableImageWrapper>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     let imageFormat = _imageFormat(forPreferredName: attachment.preferredName)
@@ -60,6 +62,7 @@ extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: At
 
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public borrowing func preferredName(for attachment: borrowing Attachment<_AttachableImageWrapper>, basedOn suggestedName: String) -> String {
     let imageFormat = _imageFormat(forPreferredName: suggestedName)

--- a/Sources/Overlays/_Testing_CoreImage/Attachments/CIImage+AttachableAsImage.swift
+++ b/Sources/Overlays/_Testing_CoreImage/Attachments/CIImage+AttachableAsImage.swift
@@ -14,11 +14,13 @@ public import _Testing_CoreGraphics
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 @available(_uttypesAPI, *)
 extension CIImage: AttachableAsImage, AttachableAsCGImage {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   package var attachableCGImage: CGImage {
     get throws {

--- a/Sources/Overlays/_Testing_UIKit/Attachments/UIImage+AttachableAsImage.swift
+++ b/Sources/Overlays/_Testing_UIKit/Attachments/UIImage+AttachableAsImage.swift
@@ -19,11 +19,13 @@ private import UIKitCore_Private
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 @available(_uttypesAPI, *)
 extension UIImage: AttachableAsImage, AttachableAsCGImage {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   package var attachableCGImage: CGImage {
     get throws {

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
@@ -13,6 +13,7 @@ public import WinSDK
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 extension AttachableImageFormat {
   private static let _encoderPathExtensionsByCLSID = Result {
@@ -194,6 +195,7 @@ extension AttachableImageFormat {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public var encoderCLSID: CLSID {
     kind.encoderCLSID
@@ -219,6 +221,7 @@ extension AttachableImageFormat {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public init(encoderCLSID: CLSID, encodingQuality: Float = 1.0) {
     let encoderCLSID = CLSID.Wrapper(encoderCLSID)
@@ -255,6 +258,7 @@ extension AttachableImageFormat {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public init?(pathExtension: String, encodingQuality: Float = 1.0) {
     let pathExtension = pathExtension.drop { $0 == "." }

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/UnsafeMutablePointer+AttachableAsIWICBitmapSource.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/UnsafeMutablePointer+AttachableAsIWICBitmapSource.swift
@@ -13,6 +13,7 @@ package import WinSDK
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 extension UnsafeMutablePointer: AttachableAsImage, AttachableAsIWICBitmapSource where Pointee: _AttachableByAddressAsIWICBitmapSource {
   package func copyAttachableIWICBitmapSource(using factory: UnsafeMutablePointer<IWICImagingFactory>) throws -> UnsafeMutablePointer<IWICBitmapSource> {

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/_AttachableImageWrapper+AttachableWrapper.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/_AttachableImageWrapper+AttachableWrapper.swift
@@ -13,6 +13,7 @@ private import WinSDK
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: AttachableAsImage {
   /// Get the image format to use when encoding an image.
@@ -43,6 +44,7 @@ extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: At
 
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<_AttachableImageWrapper>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     let imageFormat = _imageFormat(forPreferredName: attachment.preferredName)
@@ -51,6 +53,7 @@ extension _AttachableImageWrapper: Attachable, AttachableWrapper where Image: At
 
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public borrowing func preferredName(for attachment: borrowing Attachment<_AttachableImageWrapper>, basedOn suggestedName: String) -> String {
     let imageFormat = _imageFormat(forPreferredName: suggestedName)

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -160,6 +160,7 @@ extension ABI {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public enum v6_3: Sendable, Version {
     static var versionNumber: VersionNumber {

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -30,6 +30,7 @@ extension ABI {
     ///
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.3)
+    ///   @Available(Xcode, introduced: 26.4)
     /// }
     var severity: Severity?
 
@@ -39,6 +40,7 @@ extension ABI {
     ///
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.3)
+    ///   @Available(Xcode, introduced: 26.4)
     /// }
     var isFailure: Bool?
 

--- a/Sources/Testing/Attachments/Images/AttachableAsImage.swift
+++ b/Sources/Testing/Attachments/Images/AttachableAsImage.swift
@@ -51,6 +51,7 @@
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 #if SWT_NO_IMAGE_ATTACHMENTS
 @available(*, unavailable, message: "Image attachments are not available on this platform.")
@@ -75,6 +76,7 @@ public protocol AttachableAsImage {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   borrowing func withUnsafeBytes<R>(as imageFormat: AttachableImageFormat, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R
 

--- a/Sources/Testing/Attachments/Images/AttachableImageFormat.swift
+++ b/Sources/Testing/Attachments/Images/AttachableImageFormat.swift
@@ -28,6 +28,7 @@
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 #if SWT_NO_IMAGE_ATTACHMENTS
 @_unavailableInEmbedded
@@ -68,6 +69,7 @@ public struct AttachableImageFormat: Sendable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public private(set) var encodingQuality: Float = 1.0
 
@@ -81,6 +83,7 @@ public struct AttachableImageFormat: Sendable {
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 #if SWT_NO_IMAGE_ATTACHMENTS
 @_unavailableInEmbedded
@@ -125,6 +128,7 @@ extension AttachableImageFormat.Kind: Equatable, Hashable {
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 #if SWT_NO_IMAGE_ATTACHMENTS
 @_unavailableInEmbedded
@@ -134,6 +138,7 @@ extension AttachableImageFormat.Kind: Equatable, Hashable {
 extension AttachableImageFormat: CustomStringConvertible, CustomDebugStringConvertible {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public var description: String {
     let kindDescription = String(describing: kind)
@@ -145,6 +150,7 @@ extension AttachableImageFormat: CustomStringConvertible, CustomDebugStringConve
 
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public var debugDescription: String {
     let kindDescription = String(reflecting: kind)
@@ -156,6 +162,7 @@ extension AttachableImageFormat: CustomStringConvertible, CustomDebugStringConve
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 #if SWT_NO_IMAGE_ATTACHMENTS
 @_unavailableInEmbedded
@@ -167,6 +174,7 @@ extension AttachableImageFormat {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public static var png: Self {
     Self(kind: .png, encodingQuality: 1.0)
@@ -176,6 +184,7 @@ extension AttachableImageFormat {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public static var jpeg: Self {
     Self(kind: .jpeg, encodingQuality: 1.0)
@@ -194,6 +203,7 @@ extension AttachableImageFormat {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public static func jpeg(withEncodingQuality encodingQuality: Float) -> Self {
     Self(kind: .jpeg, encodingQuality: encodingQuality)

--- a/Sources/Testing/Attachments/Images/Attachment+AttachableAsImage.swift
+++ b/Sources/Testing/Attachments/Images/Attachment+AttachableAsImage.swift
@@ -10,6 +10,7 @@
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.3)
+///   @Available(Xcode, introduced: 26.4)
 /// }
 #if SWT_NO_IMAGE_ATTACHMENTS
 @_unavailableInEmbedded
@@ -39,6 +40,7 @@ extension Attachment {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public init<T>(
     _ image: T,
@@ -72,6 +74,7 @@ extension Attachment {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public static func record<T>(
     _ image: T,
@@ -96,6 +99,7 @@ extension Attachment where AttachableValue: AttachableWrapper, AttachableValue.W
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   @_disfavoredOverload public var imageFormat: AttachableImageFormat? {
     // FIXME: no way to express `where AttachableValue == _AttachableImageWrapper<???>` on a property (see rdar://47559973)

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -90,6 +90,7 @@ extension Issue {
   /// 
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   @discardableResult public static func record(
     _ comment: Comment? = nil,

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -87,6 +87,7 @@ public struct Issue: Sendable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public enum Severity: Sendable {
     /// The severity level for an issue which should be noted but is not
@@ -97,6 +98,7 @@ public struct Issue: Sendable {
     ///
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.3)
+    ///   @Available(Xcode, introduced: 26.4)
     /// }
     case warning
 
@@ -107,6 +109,7 @@ public struct Issue: Sendable {
     ///
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.3)
+    ///   @Available(Xcode, introduced: 26.4)
     /// }
     case error
   }
@@ -115,6 +118,7 @@ public struct Issue: Sendable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public var severity: Severity
   
@@ -131,6 +135,7 @@ public struct Issue: Sendable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public var isFailure: Bool {
     return !self.isKnown && self.severity >= .error
@@ -344,6 +349,7 @@ extension Issue {
     /// 
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.3)
+    ///   @Available(Xcode, introduced: 26.4)
     /// }
     public var severity: Severity
 

--- a/Sources/Testing/SourceAttribution/SourceLocation.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation.swift
@@ -74,6 +74,7 @@ public struct SourceLocation: Sendable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public var filePath: String
 

--- a/Sources/Testing/Test+Cancellation.swift
+++ b/Sources/Testing/Test+Cancellation.swift
@@ -229,6 +229,7 @@ extension Test: TestCancellable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.3)
+  ///   @Available(Xcode, introduced: 26.4)
   /// }
   public static func cancel(_ comment: Comment? = nil, sourceLocation: SourceLocation = #_sourceLocation) throws -> Never {
     let skipInfo = SkipInfo(comment: comment, sourceContext: SourceContext(backtrace: nil, sourceLocation: sourceLocation))


### PR DESCRIPTION
- **Explanation**: Add Xcode 26.4 availability annotations.
- **Scope**: Documentation
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1565
- **Risk**: None
- **Testing**: N/A
- **Reviewers**: @stmontgomery