### PR TITLE
Export _TestingInterop target as a cmake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,3 +59,4 @@ set(SwiftTesting_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<
 add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-no-toolchain-stdlib-rpath>)
 
 add_subdirectory(Sources)
+add_subdirectory(cmake/modules)

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -35,4 +35,9 @@ if(NOT BUILD_SHARED_LIBS)
   # is linked into the main library and does not need to be installed separately.
   install(TARGETS _TestingInternals
     ARCHIVE DESTINATION "${SwiftTesting_INSTALL_LIBDIR}")
+
+  # We don't necessarily want to export _TestingInternals, but it is unavoidable
+  # when building statically since _TestingInterop depends on it
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/20041
+  set_property(GLOBAL APPEND PROPERTY SwiftTesting_EXPORTS _TestingInternals)
 endif()

--- a/Sources/_TestingInterop/CMakeLists.txt
+++ b/Sources/_TestingInterop/CMakeLists.txt
@@ -23,3 +23,5 @@ target_compile_options(_TestingInterop PRIVATE
   -emit-module-interface -emit-module-interface-path $<TARGET_PROPERTY:_TestingInterop,Swift_MODULE_DIRECTORY>/_TestingInterop.swiftinterface)
 
 _swift_testing_install_target(_TestingInterop)
+
+set_property(GLOBAL APPEND PROPERTY SwiftTesting_EXPORTS _TestingInterop)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -1,0 +1,15 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2026 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+set(SwiftTesting_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/SwiftTestingExports.cmake)
+
+configure_file(SwiftTestingConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/SwiftTestingConfig.cmake)
+
+get_property(SwiftTesting_EXPORTS GLOBAL PROPERTY SwiftTesting_EXPORTS)
+export(TARGETS ${SwiftTesting_EXPORTS} FILE ${SwiftTesting_EXPORTS_FILE})

--- a/cmake/modules/SwiftTestingConfig.cmake.in
+++ b/cmake/modules/SwiftTestingConfig.cmake.in
@@ -1,0 +1,13 @@
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2026 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+##
+
+if(NOT TARGET _TestingInterop)
+  include(@SwiftTesting_EXPORTS_FILE@)
+endif()


### PR DESCRIPTION
### Motivation:

After this fix and a build-script change, swift-corelibs-xctest can link the interop library produced by the swift-testing project.

### Modifications:

* Add _TestingInterop to SwiftTesting_EXPORTS

* Create template (cmake/modules/SwiftTestingConfig.cmake.in) for the config file that xctest will get with `find_package(SwiftTesting CONFIG)`

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
