### PR TITLE
[6.3] Fix `--experimental-event-stream-version` not accepting `99`.

### DIFF
--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -67,6 +67,11 @@ extension ABI {
     forVersionNumber versionNumber: VersionNumber,
     givenSwiftCompilerVersion swiftCompilerVersion: @autoclosure () -> VersionNumber = swiftCompilerVersion
   ) -> (any Version.Type)? {
+    if versionNumber >= ABI.ExperimentalVersion.versionNumber {
+      // The experimental ABI version is higher than any real ABI version.
+      return ABI.ExperimentalVersion.self
+    }
+
     if versionNumber > ABI.HighestVersion.versionNumber {
       // If the caller requested an ABI version higher than the current Swift
       // compiler version and it's not an ABI version we've explicitly defined,

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -171,6 +171,19 @@ struct ABIEntryPointTests {
     }
     #expect(versions == versions.shuffled().sorted())
   }
+
+#if !SWT_NO_FILE_IO
+  @Test func experimentalVersionIsAccepted() {
+    #expect(throws: Never.self) {
+      try withTemporaryPath { path in
+        var args = __CommandLineArguments_v0()
+        args.eventStreamVersionNumber = ABI.ExperimentalVersion.versionNumber
+        args.eventStreamOutputPath = path
+        _ = try configurationForEntryPoint(from: args)
+      }
+    }
+  }
+#endif
 }
 
 #if !SWT_NO_DYNAMIC_LINKING


### PR DESCRIPTION
- **Explanation**: Fixes an issue using `--experimental-event-stream-version` with `99`, the reserved experimental ABI version.
- **Scope**: CLI and event handling
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1575
- **Risk**: Low
- **Testing**: New unit test
- **Reviewers**: @stmontgomery @harlanhaskins