### PR TITLE
Fix up some ABI/JSON errata.

### DIFF
--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -209,7 +209,8 @@ sufficient information to display the event in a human-readable format.
 
 <event-kind> ::= "runStarted" | "testStarted" | "testCaseStarted" |
   "issueRecorded" | "testCaseEnded" | "testEnded" | "testSkipped" |
-  "runEnded" | "valueAttached"; additional event kinds may be added in the future
+  "runEnded" | "valueAttached" | "testCancelled" | "testCaseCancelled"
+  ; additional event kinds may be added in the future
 
 <issue> ::= {
   "isKnown": <bool>, ; is this a known issue or not?

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -43,11 +43,7 @@ extension ABI {
   }
 
   /// The current supported ABI version (ignoring any experimental versions.)
-  typealias CurrentVersion = v6_4
-
-  /// The highest defined and supported ABI version (including any experimental
-  /// versions.)
-  typealias HighestVersion = v6_4
+  public typealias CurrentVersion = v6_4
 
 #if !hasFeature(Embedded)
   /// Get the type representing a given ABI version.
@@ -72,7 +68,7 @@ extension ABI {
       return ABI.ExperimentalVersion.self
     }
 
-    if versionNumber > ABI.HighestVersion.versionNumber {
+    if versionNumber > ABI.CurrentVersion.versionNumber {
       // If the caller requested an ABI version higher than the current Swift
       // compiler version and it's not an ABI version we've explicitly defined,
       // then we assume we don't know what they're talking about and return nil.
@@ -178,9 +174,8 @@ extension ABI {
   /// A namespace and type for ABI version 6.4 symbols.
   ///
   /// @Metadata {
-  ///   @Available(Swift, introduced: 6.4).
+  ///   @Available(Swift, introduced: 6.4)
   /// }
-  @_spi(Experimental)
   public enum v6_4: Sendable, Version {
     static var versionNumber: VersionNumber {
       VersionNumber(6, 4)

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -29,10 +29,10 @@ extension ABI {
       case issueRecorded
       case valueAttached
       case testCaseEnded
-      case testCaseCancelled = "_testCaseCancelled"
+      case testCaseCancelled
       case testEnded
       case testSkipped
-      case testCancelled = "_testCancelled"
+      case testCancelled
       case runEnded
     }
 

--- a/Tests/TestingTests/AdvancedConsoleOutputRecorderTests.swift
+++ b/Tests/TestingTests/AdvancedConsoleOutputRecorderTests.swift
@@ -31,7 +31,7 @@ struct AdvancedConsoleOutputRecorderTests {
   @Test("Recorder initialization with default options")
   func recorderInitialization() {
     let stream = Stream()
-    let recorder = Event.AdvancedConsoleOutputRecorder<ABI.HighestVersion>(writingUsing: stream.write)
+    let recorder = Event.AdvancedConsoleOutputRecorder<ABI.CurrentVersion>(writingUsing: stream.write)
     
     // Verify the recorder was created successfully and has expected defaults
     #expect(recorder.options.base.useANSIEscapeCodes == false) // Default for non-TTY
@@ -40,10 +40,10 @@ struct AdvancedConsoleOutputRecorderTests {
   @Test("Recorder initialization with custom options")
   func recorderInitializationWithCustomOptions() {
     let stream = Stream()
-    var options = Event.AdvancedConsoleOutputRecorder<ABI.HighestVersion>.Options()
+    var options = Event.AdvancedConsoleOutputRecorder<ABI.CurrentVersion>.Options()
     options.base.useANSIEscapeCodes = true
     
-    let recorder = Event.AdvancedConsoleOutputRecorder<ABI.HighestVersion>(
+    let recorder = Event.AdvancedConsoleOutputRecorder<ABI.CurrentVersion>(
       options: options,
       writingUsing: stream.write
     )
@@ -57,7 +57,7 @@ struct AdvancedConsoleOutputRecorderTests {
     let stream = Stream()
     
     var configuration = Configuration()
-    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.HighestVersion>(writingUsing: stream.write)
+    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.CurrentVersion>(writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
@@ -78,7 +78,7 @@ struct AdvancedConsoleOutputRecorderTests {
     let stream = Stream()
     
     var configuration = Configuration()
-    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.HighestVersion>(writingUsing: stream.write)
+    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.CurrentVersion>(writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
@@ -102,7 +102,7 @@ struct AdvancedConsoleOutputRecorderTests {
     let stream = Stream()
     
     var configuration = Configuration()
-    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.HighestVersion>(writingUsing: stream.write)
+    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.CurrentVersion>(writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
@@ -124,7 +124,7 @@ struct AdvancedConsoleOutputRecorderTests {
     let stream = Stream()
     
     var configuration = Configuration()
-    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.HighestVersion>(writingUsing: stream.write)
+    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.CurrentVersion>(writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
@@ -144,7 +144,7 @@ struct AdvancedConsoleOutputRecorderTests {
     let stream = Stream()
     
     var configuration = Configuration()
-    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.HighestVersion>(writingUsing: stream.write)
+    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.CurrentVersion>(writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }
@@ -166,7 +166,7 @@ struct AdvancedConsoleOutputRecorderTests {
     let stream = Stream()
     
     var configuration = Configuration()
-    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.HighestVersion>(writingUsing: stream.write)
+    let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.CurrentVersion>(writingUsing: stream.write)
     configuration.eventHandler = { event, context in
       eventRecorder.record(event, in: context)
     }


### PR DESCRIPTION
Fixes:

- Incorrect event kind strings for test cancellation.
- `ABI.v6_4` is marked experimental.
- `ABI.HighestVersion` is redundant (removed).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
