### PR TITLE
[6.3] Fix up some ABI/JSON errata.

### DIFF
--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -198,7 +198,8 @@ sufficient information to display the event in a human-readable format.
 
 <event-kind> ::= "runStarted" | "testStarted" | "testCaseStarted" |
   "issueRecorded" | "testCaseEnded" | "testEnded" | "testSkipped" |
-  "runEnded" | "valueAttached"; additional event kinds may be added in the future
+  "runEnded" | "valueAttached" | "testCancelled" | "testCaseCancelled"
+  ; additional event kinds may be added in the future
 
 <issue> ::= {
   "isKnown": <bool>, ; is this a known issue or not?

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -29,10 +29,10 @@ extension ABI {
       case issueRecorded
       case valueAttached
       case testCaseEnded
-      case testCaseCancelled = "_testCaseCancelled"
+      case testCaseCancelled
       case testEnded
       case testSkipped
-      case testCancelled = "_testCancelled"
+      case testCancelled
       case runEnded
     }
 


### PR DESCRIPTION
- **Explanation**: Fixes incorrect JSON strings for test cancellation events.
- **Scope**: JSON event stream.
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1577
- **Risk**: Low
- **Testing**: Tested at desk.
- **Reviewers**: @stmontgomery @jerryjrchen @harlanhaskins