### PR TITLE
Log exit code names for exit codes with known names.

### DIFF
--- a/Sources/Testing/ExitTests/ExitStatus.swift
+++ b/Sources/Testing/ExitTests/ExitStatus.swift
@@ -116,6 +116,9 @@ extension ExitStatus: CustomStringConvertible {
   public var description: String {
     switch self {
     case let .exitCode(exitCode):
+      if let name = swt_getExitCodeName(exitCode).flatMap(String.init(validatingCString:)) {
+        return ".exitCode(\(name) → \(exitCode))"
+      }
       return ".exitCode(\(exitCode))"
     case let .signal(signal):
       var signalName: String?

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -207,6 +207,45 @@ static int swt_setfdflags(int fd, int flags) {
 }
 #endif
 
+/// Get the name of the given exit code if one is available.
+///
+/// - Parameters:
+///   - exitCode: An exit code.
+///
+/// - Returns: The name of `exitCode` if it is a known constant such as
+///   `EXIT_FAILURE` or if a name for it is defined in `<sysexits.h>` and that
+///   header is present at compile time. If no name is available for `exitCode`,
+///   returns `NULL`.
+///
+/// - Note: The set of exit codes in `<sysexits.h>` is _de facto_ standardized
+///   on platforms that include that header.
+static const char *_Nullable swt_getExitCodeName(int exitCode) {
+#define SWT_EXIT_CODE(NAME) NAME: return #NAME
+  switch (exitCode) {
+    case SWT_EXIT_CODE(EXIT_SUCCESS);
+    case SWT_EXIT_CODE(EXIT_FAILURE);
+#if __has_include(<sysexits.h>)
+    case SWT_EXIT_CODE(EX_USAGE);
+    case SWT_EXIT_CODE(EX_DATAERR);
+    case SWT_EXIT_CODE(EX_NOINPUT);
+    case SWT_EXIT_CODE(EX_NOUSER);
+    case SWT_EXIT_CODE(EX_NOHOST);
+    case SWT_EXIT_CODE(EX_UNAVAILABLE);
+    case SWT_EXIT_CODE(EX_SOFTWARE);
+    case SWT_EXIT_CODE(EX_OSERR);
+    case SWT_EXIT_CODE(EX_OSFILE);
+    case SWT_EXIT_CODE(EX_CANTCREAT);
+    case SWT_EXIT_CODE(EX_IOERR);
+    case SWT_EXIT_CODE(EX_TEMPFAIL);
+    case SWT_EXIT_CODE(EX_PROTOCOL);
+    case SWT_EXIT_CODE(EX_NOPERM);
+    case SWT_EXIT_CODE(EX_CONFIG);
+#endif
+    default: return 0;
+  }
+#undef SWT_SYSEXIT_CODE
+};
+
 #if !SWT_NO_INTEROP
 
 /// A type describing a fallback event handler that testing API can invoke as an

--- a/Sources/_TestingInternals/include/TestSupport.h
+++ b/Sources/_TestingInternals/include/TestSupport.h
@@ -43,6 +43,15 @@ static inline LPCSTR swt_IDI_SHIELD(void) {
 }
 #endif
 
+static const int *_Nullable swt_EX_IOERR(void) {
+#if __has_include(<sysexits.h>) && defined(EX_IOERR)
+  static int result = EX_IOERR;
+  return &result;
+#else
+  return 0;
+#endif
+}
+
 SWT_ASSUME_NONNULL_END
 
 #endif

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -13,6 +13,16 @@ private import _TestingInternals
 
 #if !SWT_NO_EXIT_TESTS
 @Suite("Exit test tests") struct ExitTestTests {
+  @Test("Exit code names are reported (where supported)") func exitCodeName() {
+    #expect(String(describing: ExitStatus.exitCode(EXIT_SUCCESS)) == ".exitCode(EXIT_SUCCESS → \(EXIT_SUCCESS))")
+    #expect(String(describing: ExitStatus.exitCode(EXIT_FAILURE)) == ".exitCode(EXIT_FAILURE → \(EXIT_FAILURE))")
+
+    if let EX_IOERR = swt_EX_IOERR()?.pointee {
+      #expect(String(describing: ExitStatus.exitCode(EX_IOERR)) == ".exitCode(EX_IOERR → \(EX_IOERR))")
+    }
+    #expect(String(describing: ExitStatus.exitCode(12345)) == ".exitCode(12345)")
+  }
+
   @Test("Signal names are reported (where supported)") func signalName() {
     var hasSignalNames = false
 #if SWT_TARGET_OS_APPLE || os(FreeBSD) || os(OpenBSD) || os(Android)


### PR DESCRIPTION
This PR enhances the stringification of `ExitStatus` so that, if we have a name for an exit code, we log it. `EXIT_SUCCESS` and `EXIT_FAILURE` are always available, and we also have names for some exit codes defined on some platforms in `<sysexits.h>`.

This mirrors the work we do for signals where we examine `sys_signame` (`_sigabbrev_np()` on Linux), though the implementation is quite different.

For example, the following exit test:

```swift
await #expect(processExitsWith: .exitCode(EX_USAGE)) {
  exit(EX_IOERR)
}
```

Previously logged:

> Test foo() recorded an issue at [...]: Expectation failed: .exitCode(64) → .exitCode(74)

Now it logs:

> Test foo() recorded an issue at [...]: Expectation failed: .exitCode(EX_USAGE → 64) → .exitCode(EX_IOERR → 74)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
