### PR TITLE
[6.3] Use a different symbol for failure with known issues.

### DIFF
--- a/Sources/SymbolShowcase/SymbolShowcaseMain.swift
+++ b/Sources/SymbolShowcase/SymbolShowcaseMain.swift
@@ -43,7 +43,6 @@ import Foundation
       "Default": .default,
       "Pass": .pass(knownIssueCount: 0),
       "Pass w/known issues": .pass(knownIssueCount: 1),
-      "Pass with warnings": .passWithWarnings,
       "Skip": .skip,
       "Fail": .fail,
       "Difference": .difference,

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
@@ -25,7 +25,6 @@ extension ABI {
       case `default`
       case skip
       case pass
-      case passWithWarnings = "_passWithWarnings"
       case passWithKnownIssue
       case fail
       case difference
@@ -45,8 +44,6 @@ extension ABI {
           } else {
             .pass
           }
-        case .passWithWarnings:
-          .passWithWarnings
         case .fail:
           .fail
         case .difference:

--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -162,12 +162,10 @@ extension Event.Symbol {
           return "\(_ansiEscapeCodePrefix)90m\(symbolCharacter)\(_resetANSIEscapeCode)"
         }
         return "\(_ansiEscapeCodePrefix)92m\(symbolCharacter)\(_resetANSIEscapeCode)"
-      case .passWithWarnings:
+      case .warning:
         return "\(_ansiEscapeCodePrefix)93m\(symbolCharacter)\(_resetANSIEscapeCode)"
       case .fail:
         return "\(_ansiEscapeCodePrefix)91m\(symbolCharacter)\(_resetANSIEscapeCode)"
-      case .warning:
-        return "\(_ansiEscapeCodePrefix)93m\(symbolCharacter)\(_resetANSIEscapeCode)"
       case .attachment:
         return "\(_ansiEscapeCodePrefix)94m\(symbolCharacter)\(_resetANSIEscapeCode)"
       case .details:

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -482,7 +482,7 @@ extension Event.HumanReadableOutputRecorder {
       } else {
         switch issue.severity {
         case .warning:
-          symbol = .passWithWarnings
+          symbol = .warning
           subject = "a warning"
         case .error:
           symbol = .fail

--- a/Sources/Testing/Events/Recorder/Event.Symbol.swift
+++ b/Sources/Testing/Events/Recorder/Event.Symbol.swift
@@ -28,7 +28,8 @@ extension Event {
 
     /// The symbol to use when a test passes with one or more warnings.
     @_spi(Experimental)
-    case passWithWarnings
+    @available(*, deprecated, renamed: "warning")
+    static var passWithWarnings: Self { .warning }
 
     /// The symbol to use when a test fails.
     case fail
@@ -37,7 +38,7 @@ extension Event {
     case difference
 
     /// A warning or caution symbol to use when the developer should be aware of
-    /// some condition.
+    /// some condition, or if a test passes with one or more warnings.
     case warning
 
     /// The symbol to use when presenting details about an event to the user.
@@ -61,12 +62,10 @@ extension Event.Symbol {
       ("\u{10065F}", "arrow.triangle.turn.up.right.diamond.fill")
     case let .pass(knownIssueCount):
       if knownIssueCount > 0 {
-        ("\u{100883}", "xmark.diamond")
+        ("\u{100882}", "minus.diamond.fill")
       } else {
         ("\u{10105B}", "checkmark.diamond.fill")
       }
-    case .passWithWarnings:
-      ("\u{100123}", "questionmark.diamond.fill")
     case .fail:
       ("\u{100884}", "xmark.diamond.fill")
     case .difference:
@@ -121,15 +120,12 @@ extension Event.Symbol {
       return "\u{279C}"
     case let .pass(knownIssueCount):
       if knownIssueCount > 0 {
-        // Unicode: HEAVY BALLOT X
-        return "\u{2718}"
+        // Unicode: BOX DRAWINGS HEAVY HORIZONTAL
+        return "\u{2501}"
       } else {
         // Unicode: HEAVY CHECK MARK
         return "\u{2714}"
       }
-    case .passWithWarnings:
-      // Unicode: QUESTION MARK
-      return "\u{003F}"
     case .fail:
       // Unicode: HEAVY BALLOT X
       return "\u{2718}"
@@ -159,15 +155,12 @@ extension Event.Symbol {
       return "\u{279C}"
     case let .pass(knownIssueCount):
       if knownIssueCount > 0 {
-        // Unicode: MULTIPLICATION SIGN
-        return "\u{00D7}"
+        // Unicode: HYPHEN-MINUS
+        return "\u{002D}"
       } else {
         // Unicode: SQUARE ROOT
         return "\u{221A}"
       }
-    case .passWithWarnings:
-      // Unicode: QUESTION MARK
-      return "\u{003F}"
     case .fail:
       // Unicode: MULTIPLICATION SIGN
       return "\u{00D7}"


### PR DESCRIPTION
- **Explanation**: Makes the known-issue symbol distinct from the failure symbol so it's easier to find one or the other in uncoloured text output.
- **Scope**: CLI and logfile output.
- **Issues**: https://github.com/swiftlang/swift-testing/issues/1583
- **Original PRs**: https://github.com/swiftlang/swift-testing/issues/1585
- **Risk**: Low
- **Testing**: Visually verified changes.
- **Reviewers**: @stmontgomery @jerryjrchen @harlanhaskins