### PR TITLE
Add an experimental `CustomTestReflectable` protocol.

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(Testing
   Running/SkipInfo.swift
   SourceAttribution/Backtrace.swift
   SourceAttribution/Backtrace+Symbolication.swift
+  SourceAttribution/CustomTestReflectable.swift
   SourceAttribution/CustomTestStringConvertible.swift
   SourceAttribution/Expression.swift
   SourceAttribution/Expression+Macro.swift

--- a/Sources/Testing/Parameterization/Test.Case.Generator.swift
+++ b/Sources/Testing/Parameterization/Test.Case.Generator.swift
@@ -89,7 +89,7 @@ extension Test.Case {
     ) where S: Collection {
       if parameters.count > 1 {
         self.init(sequence: collection) { element in
-          let mirror = Mirror(reflecting: element)
+          let mirror = Mirror(reflectingForTest: element)
           let values: [any Sendable] = if mirror.displayStyle == .tuple {
             mirror.children.map { unsafeBitCast($0.value, to: (any Sendable).self) }
           } else {

--- a/Sources/Testing/SourceAttribution/CustomTestReflectable.swift
+++ b/Sources/Testing/SourceAttribution/CustomTestReflectable.swift
@@ -1,0 +1,55 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// A protocol describing types with a custom reflection when presented as part
+/// of a test's output.
+///
+/// ## See Also
+///
+/// - ``Swift/Mirror/init(reflectingForTest:)``
+@_spi(Experimental)
+public protocol CustomTestReflectable {
+  /// The custom mirror for this instance.
+  ///
+  /// Do not use this property directly. To get the test reflection of a value,
+  /// use ``Swift/Mirror/init(reflectingForTest:)``.
+  var customTestMirror: Mirror { get }
+}
+
+@_spi(Experimental)
+extension Mirror {
+  /// Initialize this instance so that it can be presented in a test's output.
+  ///
+  /// - Parameters:
+  ///   - subject: The value to reflect.
+  ///
+  /// ## See Also
+  ///
+  /// - ``CustomTestReflectable``
+  public init(reflectingForTest subject: some CustomTestReflectable) {
+    self = subject.customTestMirror
+  }
+
+  /// Initialize this instance so that it can be presented in a test's output.
+  ///
+  /// - Parameters:
+  ///   - subject: The value to reflect.
+  ///
+  /// ## See Also
+  ///
+  /// - ``CustomTestReflectable``
+  public init(reflectingForTest subject: some Any) {
+    if let subject = subject as? any CustomTestReflectable {
+      self.init(reflectingForTest: subject)
+    } else {
+      self.init(reflecting: subject)
+    }
+  }
+}

--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -122,7 +122,7 @@ public struct __Expression: Sendable {
       debugDescription = String(reflecting: subject)
       typeInfo = TypeInfo(describingTypeOf: subject)
 
-      let mirror = Mirror(reflecting: subject)
+      let mirror = Mirror(reflectingForTest: subject)
       isCollection = mirror.displayStyle?.isCollection ?? false
     }
 
@@ -190,7 +190,7 @@ public struct __Expression: Sendable {
       self.init(describing: subject)
       self.label = label
 
-      let mirror = Mirror(reflecting: subject)
+      let mirror = Mirror(reflectingForTest: subject)
 
       // If the subject being reflected is an instance of a reference type (e.g.
       // a class), keep track of whether it has been seen previously. Later

--- a/Tests/TestingTests/CustomTestReflectableTests.swift
+++ b/Tests/TestingTests/CustomTestReflectableTests.swift
@@ -1,0 +1,44 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) import Testing
+
+struct `CustomTestReflectable Tests` {
+  @Test func `Can get a custom mirror from a value`() throws {
+    let subject = MyReflectable() as Any
+    let mirror = Mirror(reflectingForTest: subject)
+    #expect(mirror.children.count == 4)
+    let fee = try #require(mirror.children.first)
+    #expect(fee.label == "fee")
+    #expect(fee.value is Int)
+  }
+
+  @Test func `Fall back to Mirror(reflecting:)`() throws {
+    let subject = [1, 2, 3] as Any
+    let mirror = Mirror(reflectingForTest: subject)
+    #expect(mirror.children.count > 0)
+  }
+}
+
+// MARK: - Fixtures
+
+struct MyReflectable: CustomTestReflectable {
+  var customTestMirror: Mirror {
+    Mirror(
+      self,
+      children: [
+        (label: "fee", value: 1 as Any),
+        (label: "fi", value: 2.0 as Any),
+        (label: "fo", value: "3" as Any),
+        (label: "fum", value: /4/ as Any)
+      ]
+    )
+  }
+}


### PR DESCRIPTION
This PR adds `CustomTestReflectable` as experimental SPI. This protocol can be used to customize the breakdown of a value shown when an expectation fails. For example, given this structure and test:

```swift
struct MyStruct {
  var x: Int
  func checkX(_ expected: Int) -> Bool { x == expected }
}

@Test func foo() {
  let value = MyStruct(x: 1234)
  #expect(value.checkX(6789))
}
```

A failure would currently be reported as:

```
<X>  Test "..." recorded an issue at [...]: Expectation failed: value.checkX(6789)
`->  value.checkX(6789) → false
`->    value → MyStruct(x: 1234)
`->      x → 1234
````

If we add a custom mirror to it, like so:

```swift
extension MyStruct: CustomTestReflectable {
  var customTestMirror: Mirror {
    Mirror(
      self,
      children: [
        (label: "x", value: x as Any),
        (label: "x is even?", value: x.isMultiple(of: 2)),
        (label: "x is positive?", value: x > 0),
      ]
    )
  }
}
```

Then the output becomes:

```
<X>  Test "..." recorded an issue at [...]: Expectation failed: value.checkX(6789)
`->  value.checkX(6789) → false
`->    value → MyStruct(x: 1234)
`->      x → 1234
`->      x is even? → true
`->      x is positive? → true
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
