### PR TITLE
Add a C-callable "gestalt" function for querying some basic info.

### DIFF
--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -214,7 +214,7 @@ extension ABI {
 
 // MARK: -
 
-/// The set of keys accepted by ``swift_testing_copyMetadataValue(_:_:)``.
+/// The set of keys accepted by `_swift_testing_copyMetadataValue(_:_:)`.
 private enum _MetadataKey: String, Sendable, CaseIterable {
   /// The minimum supported ABI version.
   case minimumSupportedABIVersion = "_minimumSupportedABIVersion"
@@ -236,11 +236,11 @@ private enum _MetadataKey: String, Sendable, CaseIterable {
 ///   available. The caller is responsible for freeing this memory with C's
 ///   `free()` function.
 #if compiler(>=6.3)
-@c(swift_testing_copyMetadataValue)
+@c(_swift_testing_copyMetadataValue)
 #else
-@_cdecl("swift_testing_copyMetadataValue")
+@_cdecl("_swift_testing_copyMetadataValue")
 #endif
-@usableFromInline func swift_testing_copyMetadataValue(_ key: UnsafePointer<CChar>, _ reserved: UInt) -> UnsafeMutablePointer<CChar>? {
+@usableFromInline func _swift_testing_copyMetadataValue(_ key: UnsafePointer<CChar>, _ reserved: UInt) -> UnsafeMutablePointer<CChar>? {
   func copyJSON(for value: some Encodable) -> UnsafeMutablePointer<CChar>? {
     try? JSON.withEncoding(of: value) { json in
       json.withMemoryRebound(to: CChar.self) { json in

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -186,7 +186,7 @@ struct ABIEntryPointTests {
 #endif
 
   func decodeMetadataValue<T>(forKey key: String, ofType type: T.Type) throws -> T where T: Decodable {
-    let cString = try #require(swift_testing_copyMetadataValue(key, 0))
+    let cString = try #require(_swift_testing_copyMetadataValue(key, 0))
     defer {
       free(cString)
     }


### PR DESCRIPTION
This PR adds an exported C function that lets callers query some info that may be necessary to gather before those callers can reliably invoke the testing library's ABI-stable entry point function.

This function is _not_ meant to be a general-purpose querying function, nor is it intended for use by tools authors. Rather, it is useful if you're writing code that works with the JSON event stream and needs to know how to communicate with the testing library. In particular, a caller would need to know the range of supported JSON schema versions.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
