### PR TITLE
Add a mode flags optionset to `FileHandle`.

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -432,10 +432,9 @@ extension Attachable where Self: ~Copyable {
 #endif
 
     try withUnsafeBytes(for: attachment) { buffer in
-      // Note "x" in the mode string which indicates that the file should be
-      // created and opened exclusively. The underlying `fopen()` call will thus
-      // fail with `EEXIST` if a file exists at `filePath`.
-      let file = try FileHandle(atPath: filePath, mode: "wxeb")
+      // The underlying `fopen()` call should fail with `EEXIST` if a file
+      // exists at `filePath`.
+      let file = try FileHandle(atPath: filePath, options: [.writeAccess, .creationRequired])
       try file.write(buffer)
     }
   }

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -72,7 +72,7 @@ struct AttachmentTests {
 
 #if !SWT_NO_FILE_IO
   func compare(_ attachableValue: borrowing MySendableAttachable, toContentsOfFileAtPath filePath: String) throws {
-    let file = try FileHandle(forReadingAtPath: filePath)
+    let file = try Testing.FileHandle(forReadingAtPath: filePath)
     let bytes = try file.readToEnd()
 
     let decodedValue = if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -48,7 +48,7 @@ struct FileHandleTests {
   @Test("Init from invalid file descriptor")
   func invalidFileDescriptor() throws {
     #expect(throws: CError.self) {
-      _ = try FileHandle(unsafePOSIXFileDescriptor: -1, mode: "")
+      _ = try FileHandle(unsafePOSIXFileDescriptor: -1, options: [])
     }
   }
 #endif
@@ -86,7 +86,7 @@ struct FileHandleTests {
   @Test("Writing requires contiguous storage")
   func writeIsContiguous() async {
     await #expect(processExitsWith: .failure) {
-      let fileHandle = try FileHandle.null(mode: "wb")
+      let fileHandle = try FileHandle.null(options: [.writeAccess])
       try fileHandle.write([1, 2, 3, 4, 5].lazy.filter { $0 == 1 })
     }
   }
@@ -110,7 +110,7 @@ struct FileHandleTests {
 
   @Test("Cannot write bytes to a read-only file")
   func cannotWriteBytesToReadOnlyFile() throws {
-    let fileHandle = try FileHandle.null(mode: "rb")
+    let fileHandle = try FileHandle.null(options: [.readAccess])
     #expect(throws: CError.self) {
       try fileHandle.write([0, 1, 2, 3, 4, 5])
     }
@@ -118,7 +118,7 @@ struct FileHandleTests {
 
   @Test("Cannot write string to a read-only file")
   func cannotWriteStringToReadOnlyFile() throws {
-    let fileHandle = try FileHandle.null(mode: "rb")
+    let fileHandle = try FileHandle.null(options: [.readAccess])
     #expect(throws: CError.self) {
       try fileHandle.write("Impossible!")
     }
@@ -181,7 +181,7 @@ struct FileHandleTests {
 
   @Test("/dev/null is not a TTY or pipe")
   func devNull() throws {
-    let fileHandle = try FileHandle.null(mode: "wb")
+    let fileHandle = try FileHandle.null(options: [.writeAccess])
     #expect(!Bool(fileHandle.isTTY))
 #if !SWT_NO_PIPES
     #expect(!Bool(fileHandle.isPipe))
@@ -230,11 +230,11 @@ extension FileHandle {
     return FileHandle(unsafeCFILEHandle: tmpFile, closeWhenDone: true)
   }
 
-  static func null(mode: String) throws -> FileHandle {
+  static func null(options: FileHandle.OpenOptions) throws -> FileHandle {
 #if os(Windows)
-    try FileHandle(atPath: "NUL", mode: mode)
+    try FileHandle(atPath: "NUL", options: options)
 #else
-    try FileHandle(atPath: "/dev/null", mode: mode)
+    try FileHandle(atPath: "/dev/null", options: options)
 #endif
   }
 }

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -223,7 +223,7 @@ struct SwiftPMTests {
       configuration.handleEvent(Event(.runEnded, testID: nil, testCaseID: nil), in: eventContext)
     }
 
-    let fileHandle = try FileHandle(forReadingAtPath: temporaryFilePath)
+    let fileHandle = try Testing.FileHandle(forReadingAtPath: temporaryFilePath)
     let fileContents = try fileHandle.readToEnd()
     #expect(!fileContents.isEmpty)
     #expect(fileContents.contains(UInt8(ascii: "<")))
@@ -241,7 +241,7 @@ struct SwiftPMTests {
       _ = remove(temporaryFilePath)
     }
     do {
-      let fileHandle = try FileHandle(forWritingAtPath: temporaryFilePath)
+      let fileHandle = try Testing.FileHandle(forWritingAtPath: temporaryFilePath)
       try fileHandle.write(
         """
         {

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -143,7 +143,7 @@ struct TagListTests {
     }
     """
     try jsonContent.withUTF8 { jsonContent in
-      let fileHandle = try FileHandle(forWritingAtPath: jsonPath)
+      let fileHandle = try Testing.FileHandle(forWritingAtPath: jsonPath)
       try fileHandle.write(jsonContent)
     }
     defer {


### PR DESCRIPTION
This PR adds an `OptionSet`-conforming type to `FileHandle` so that we don't have to hard-code mode strings we pass to `fopen()`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
