### PR TITLE
Adjust the "Q&A" documentation for `Allocated` so it's not `Mutex`-specific.

### DIFF
--- a/Sources/Testing/Support/Additions/AtomicAdditions.swift
+++ b/Sources/Testing/Support/Additions/AtomicAdditions.swift
@@ -26,6 +26,11 @@ internal import Synchronization
 /// Since we don't try to implement the complete ``Synchronization/AtomicRepresentable``
 /// protocol, this implementation only supports using a few types that are
 /// actually in use in the testing library.
+///
+/// ## See Also
+///
+/// - ``Allocated``
+/// - ``Mutex``
 struct Atomic<Value>: ~Copyable {
   /// Storage for the underlying atomic value.
   private nonisolated(unsafe) var _address: UnsafeMutablePointer<Value>

--- a/Sources/Testing/Support/Additions/MutexAdditions.swift
+++ b/Sources/Testing/Support/Additions/MutexAdditions.swift
@@ -22,16 +22,10 @@ internal import Synchronization
 /// replicates the interface of that type but is implemented differently (using
 /// heap-allocated storage for the underlying lock and the value it guards).
 ///
-/// **Q:** When should I use `Mutex<T>` vs. `Allocated<Mutex<T>>`?
+/// ## See Also
 ///
-/// **A (short):** Whenever the compiler lets you use `Mutex<T>`, use that.
-///
-/// **A (long):** Mutexes can generally be locally allocated when they are
-///   function-local, global, or `static`. If your mutex is an instance member
-///   of a reference type (a class or actor), you again generally won't need
-///   `Allocated`. If, however, you need a mutex to be an instance member of a
-///   copyable value type (a structure or enumeration), then it _must_ be boxed
-///   with `Allocated` (or something else that moves its storage onto the heap).
+/// - ``Allocated``
+/// - ``Atomic``
 struct Mutex<Value>: Sendable, ~Copyable where Value: ~Copyable {
   /// The underlying lock type.
 #if !SWT_NO_OS_UNFAIR_LOCK

--- a/Sources/Testing/Support/Allocated.swift
+++ b/Sources/Testing/Support/Allocated.swift
@@ -13,6 +13,18 @@
 /// Use this class when you have a move-only value such as an instance of
 /// ``Mutex`` that you need to store in an aggregate value type such as a
 /// copyable structure.
+///
+/// **Q:** When should I use `T` vs. `Allocated<T>`?
+///
+/// **A (short):** Whenever the compiler lets you use `T`, use that.
+///
+/// **A (long):** Move-only values like mutexes and atomics can generally be
+///   locally allocated when they are function-local, global, or `static`. If
+///   the instance of `T` in question is an instance member of a reference type
+///   (a class or actor), you again generally won't need `Allocated`. If,
+///   however, you need your instance of `T` to be an instance member of a
+///   copyable value type (a structure or enumeration), then it _must_ be boxed
+///   with `Allocated` (or something else that moves its storage onto the heap).
 final class Allocated<T> where T: ~Copyable {
   /// The underlying value.
   let value: T


### PR DESCRIPTION
Cleanup of internal docs for `Allocated`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
