### PR TITLE
[6.3] Disable package customization of module ABI name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -476,7 +476,10 @@ extension Array where Element == PackageDescription.SwiftSetting {
   /// module related to Swift Testing loaded into a runner process avoids this
   /// issue.
   static func moduleABIName(_ targetName: String) -> Self {
-    [.unsafeFlags(["-module-abi-name", "\(targetName)_package"])]
+    // Workaround: Disable module ABI name customization, since it has regressed
+    // building DocC documentation (see rdar://171555540).
+//    [.unsafeFlags(["-module-abi-name", "\(targetName)_package"])]
+    []
   }
 }
 

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -77,7 +77,7 @@ extension Runner {
   /// type at runtime, it may be better-suited for ``Configuration`` instead.
   private struct _Context: Sendable {
     /// A serializer used to reduce parallelism among test cases.
-    var testCaseSerializer: Serializer?
+    var testCaseSerializer: Serializer<Void>?
   }
 
   /// Apply the custom scope for any test scope providers of the traits

--- a/Sources/Testing/Support/Serializer.swift
+++ b/Sources/Testing/Support/Serializer.swift
@@ -46,8 +46,13 @@ let defaultParallelizationWidth: Int = {
 /// items do not start running; they must wait until the suspended work item
 /// either returns or throws an error.
 ///
+/// The generic type parameter `T` is unused. It avoids warnings when multiple
+/// copies of the testing library are loaded into a runner process on platforms
+/// which use the Objective-C runtime, due to non-generic actor types being
+/// implemented as classes there.
+///
 /// This type is not part of the public interface of the testing library.
-final actor Serializer {
+final actor Serializer<T> {
   /// The maximum number of work items that may run concurrently.
   nonisolated let maximumWidth: Int
 


### PR DESCRIPTION
- **Explanation**: Resolve an issue which prevents building documentation for the package locally.
- **Scope**: Affects the package build only, does not affect production builds.
- **Issues**: rdar://170069880
- **Original PRs**: #1601
- **Risk**: Low; disables a compiler flag added within this release.
- **Testing**: Local documentation build no longer emits these warnings.
- **Reviewers**: @grynspan 
