### PR TITLE
Revert "Replace fixture protocol in ConfirmationTests with an existen…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -422,7 +422,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("AvailabilityMacro=_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0"),
       .enableExperimentalFeature("AvailabilityMacro=_typedThrowsAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"),
       .enableExperimentalFeature("AvailabilityMacro=_castingWithNonCopyableGenerics:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"),
-      .enableExperimentalFeature("AvailabilityMacro=_compositionOfParameterizedProtocols:macOS 26.4, iOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4"),
 
       .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0"),
     ]

--- a/Tests/TestingTests/ConfirmationTests.swift
+++ b/Tests/TestingTests/ConfirmationTests.swift
@@ -33,14 +33,7 @@ struct ConfirmationTests {
 
   @Test("Unsuccessful confirmations")
   func unsuccessfulConfirmations() async {
-    // confirmedOutOfRange(_:) is availability-guarded, but if it runs, increase
-    // the number of expected miscounts by the number of arguments passed to it.
-    var expectedCount = 7
-    if #available(_compositionOfParameterizedProtocols, *) {
-      expectedCount += 4
-    }
-
-    await confirmation("Miscount recorded", expectedCount: expectedCount) { miscountRecorded in
+    await confirmation("Miscount recorded", expectedCount: 7) { miscountRecorded in
       var configuration = Configuration()
       configuration.eventHandler = { event, _ in
         if case let .issueRecorded(issue) = event.kind {
@@ -159,28 +152,13 @@ struct UnsuccessfulConfirmationTests {
     }
   }
 
-  // FIXME: Remove this test once the deployment targets are greater than or
-  // equal to the versions specified in `_compositionOfParameterizedProtocols`.
   @Test(.hidden, arguments: [
     1 ... 2 as any ExpectedCount,
     1 ..< 2,
     1 ..< 3,
     999...,
   ])
-  func confirmedOutOfRange_legacy(_ range: any ExpectedCount) async {
-    await confirmation(expectedCount: range) { (thingHappened) async in
-      thingHappened(count: 3)
-    }
-  }
-
-  @Test(.hidden, arguments: [
-    1 ... 2 as any RangeExpression<Int> & Sequence<Int> & Sendable,
-    1 ..< 2,
-    1 ..< 3,
-    999...,
-  ])
-  @available(_compositionOfParameterizedProtocols, *)
-  func confirmedOutOfRange(_ range: any RangeExpression<Int> & Sequence<Int> & Sendable) async {
+  func confirmedOutOfRange(_ range: any ExpectedCount) async {
     await confirmation(expectedCount: range) { (thingHappened) async in
       thingHappened(count: 3)
     }
@@ -190,7 +168,7 @@ struct UnsuccessfulConfirmationTests {
 // MARK: -
 
 /// Needed since we don't have generic test functions, so we need a concrete
-/// argument type for `confirmedOutOfRange_legacy(_:)`. Although we can now write
+/// argument type for `confirmedOutOfRange(_:)`. Although we can now write
 /// `any RangeExpression<Int> & Sequence<Int> & Sendable` as of Swift 6.2
 /// (per [swiftlang/swift#76705](https://github.com/swiftlang/swift/pull/76705)),
 /// attempting to form an array of such values crashes at runtime. ([163980446](rdar://163980446))

--- a/cmake/modules/shared/AvailabilityDefinitions.cmake
+++ b/cmake/modules/shared/AvailabilityDefinitions.cmake
@@ -14,5 +14,4 @@ add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_clockAPI:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_typedThrowsAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_castingWithNonCopyableGenerics:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0\">"
-  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_compositionOfParameterizedProtocols:macOS 26.4, iOS 26.4, watchOS 26.4, tvOS 26.4, visionOS 26.4\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0\">")


### PR DESCRIPTION
…tial composition of parameterized protocols (#1598)"

This reverts commit d63cbd4e8a4454761e83a016eacea2c20c7b25c2.

Resolves rdar://171579639.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
