### PR TITLE
Guard `_postToFallbackEventHandler` with an `SWT_NO_INTEROP` check.

### DIFF
--- a/Sources/Testing/Events/Event+FallbackEventHandler.swift
+++ b/Sources/Testing/Events/Event+FallbackEventHandler.swift
@@ -210,6 +210,7 @@ extension Event {
 #endif
   }
 
+#if !SWT_NO_INTEROP
   /// The implementation of ``postToFallbackEventHandler(in:)`` that actually
   /// invokes the installed fallback event handler.
   ///
@@ -239,4 +240,5 @@ extension Event {
       )
     }
   }()
+#endif
 }


### PR DESCRIPTION
Missing a check for `SWT_NO_INTEROP`. Regressed in #1607.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
