### PR TITLE
[WIP] Link `_TestDiscovery` into the macro target.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -182,6 +182,7 @@ let package = Package(
     .macro(
       name: "TestingMacros",
       dependencies: [
+        "_TestDiscovery",
         .product(name: "SwiftDiagnostics", package: "swift-syntax"),
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),

--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -114,13 +114,19 @@ target_sources(TestingMacros PRIVATE
   TestDeclarationMacro.swift
   TestingMacrosMain.swift)
 
+add_subdirectory(../_TestDiscovery)
+add_subdirectory(../_TestingInternals)
+
 target_compile_options(TestingMacros PRIVATE
   "SHELL:-Xfrontend -disable-implicit-string-processing-module-import")
 
 target_link_libraries(TestingMacros PRIVATE
   SwiftSyntax::SwiftSyntax
   SwiftSyntax::SwiftSyntaxMacroExpansion
-  SwiftSyntax::SwiftSyntaxMacros)
+  SwiftSyntax::SwiftSyntaxMacros
+  _TestDiscovery
+  _TestingInternals)
+
 if(SwiftTesting_BuildMacrosAsExecutables)
   # Link the 'SwiftCompilerPlugin' target, but only when built as an executable.
   target_link_libraries(TestingMacros PRIVATE

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -13,6 +13,8 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
+@_spi(Experimental) @_spi(ForToolsIntegrationOnly) import _TestDiscovery
+
 /// An enumeration representing the different kinds of test content known to the
 /// testing library.
 ///
@@ -21,12 +23,12 @@ import SwiftSyntaxMacros
 ///
 /// - Bug: This type should be imported directly from `_TestDiscovery` instead
 ///   of being redefined (differently) here.
-enum TestContentKind: UInt32 {
+extension TestContentKind {
   /// A test or suite declaration.
-  case testDeclaration = 0x74657374
+  static var testDeclaration: Self { "test" }
 
   /// An exit test.
-  case exitTest = 0x65786974
+  static var exitTest: Self { "exit" }
 
   /// This kind value as a comment (`/* 'abcd' */`) if it looks like it might be
   /// a [FourCC](https://en.wikipedia.org/wiki/FourCC) value, or `nil` if not.


### PR DESCRIPTION

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
