### PR TITLE
Configurable interop modes

### DIFF
--- a/Sources/Testing/Events/Event+FallbackEventHandler.swift
+++ b/Sources/Testing/Events/Event+FallbackEventHandler.swift
@@ -14,8 +14,7 @@ private import _TestingInternals
 public enum Interop: Sendable {}
 
 extension Interop {
-  @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
-  public enum Mode: String, Sendable, CaseIterable {
+  public enum Mode: String, Sendable, Codable, CaseIterable {
     /// The interop feature is not active.
     case none
 
@@ -43,22 +42,29 @@ extension Interop {
   }
 }
 
+extension Interop {
+  /// Name of the environment variable flag to set when opting-in to the
+  /// experimental interop feature.
+  static let experimentalOptInKey = "SWT_EXPERIMENTAL_INTEROP_ENABLED"
+}
+
 extension Interop.Mode {
+  /// The name for the environment variable which if set, overrides the default
+  /// interop mode.
   static let interopModeEnvKey = "SWIFT_TESTING_XCTEST_INTEROP_MODE"
 
+  /// Whether this interop mode causes Swift Testing to install a fallback event
+  /// handler ahead of running tests.
   var requiresInstallation: Bool {
-    self != .none
+    Environment.flag(named: Interop.experimentalOptInKey) == true && self != .none
   }
 
   /// Current interop mode, which should not be changed after tests start
   /// running.
   @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
-  public static let current: Self = _currentImpl()
-
-  /// Exposed for testing only.
-  static func _currentImpl() -> Self {
-    Environment.variable(named: interopModeEnvKey).flatMap(Interop.Mode.init) ?? .complete
-  }
+  public static let current: Self = {
+    Environment.variable(named: interopModeEnvKey).flatMap(Interop.Mode.init) ?? .limited
+  }()
 }
 
 extension Event {
@@ -84,12 +90,15 @@ extension Event {
       return
     }
 
+    let xctestWarningMessage =
+      "XCTest API was used in a Swift Testing test. Adopt Swift Testing primitives, such as #expect, instead."
+
     // For the time being, assume that foreign test events originate from XCTest
-    let warnForXCTestUsageIssue =
+    lazy var warnForXCTestUsageIssue =
       Issue(
         kind: .apiMisused, severity: .warning,
         comments: [
-          "XCTest API was used in a Swift Testing test. Adopt Swift Testing primitives, such as #expect, instead."
+          .init(rawValue: xctestWarningMessage)
         ], sourceContext: issue.sourceContext)
 
     switch Interop.Mode.current {
@@ -106,7 +115,7 @@ extension Event {
       issue.severity = .error
       issue.record()
       fatalError(
-        "XCTest API was used in a Swift Testing test. Adopt Swift Testing primitives, such as #expect, instead. This is a fatal error because strict interop mode is active (\(Interop.Mode.interopModeEnvKey)=strict)",
+        "\(xctestWarningMessage) This is a fatal error because strict interop mode is active (\(Interop.Mode.interopModeEnvKey)=strict)",
       )
     }
   }
@@ -119,7 +128,9 @@ extension Event {
   ///
   /// - Returns: A source location to use when reporting an issue about
   ///   `recordJSON`.
-  private static func _bestAvailableSourceLocation(forInvalidRecordJSON recordJSON: UnsafeRawBufferPointer) -> SourceLocation {
+  private static func _bestAvailableSourceLocation(
+    forInvalidRecordJSON recordJSON: UnsafeRawBufferPointer
+  ) -> SourceLocation {
     // TODO: try to actually extract a source location from arbitrary JSON?
 
     // If there's a test associated with the current task, it should have a
@@ -131,12 +142,13 @@ extension Event {
     return .unknown
   }
 
-#if !SWT_NO_INTEROP
+  #if !SWT_NO_INTEROP
   /// The fallback event handler to install when Swift Testing is the active
   /// testing library.
   private static let _ourFallbackEventHandler: SWTFallbackEventHandler = {
     recordJSONSchemaVersionNumber, recordJSONBaseAddress, recordJSONByteCount, _ in
-    let version = String(validatingCString: recordJSONSchemaVersionNumber)
+    let version =
+      String(validatingCString: recordJSONSchemaVersionNumber)
       .flatMap(VersionNumber.init)
       .flatMap { ABI.version(forVersionNumber: $0) } ?? ABI.v0.self
     let recordJSON = UnsafeRawBufferPointer(
@@ -169,17 +181,15 @@ extension Event {
       ).record()
     }
   }
-#endif
+  #endif
 
   /// The implementation of ``installFallbackEventHandler()``.
   private static let _installFallbackEventHandler: Bool = {
-#if !SWT_NO_INTEROP
-    if Environment.flag(named: "SWT_EXPERIMENTAL_INTEROP_ENABLED") == true
-      && Interop.Mode.current.requiresInstallation
-      {
+    #if !SWT_NO_INTEROP
+    if Interop.Mode.current.requiresInstallation {
       return _swift_testing_installFallbackEventHandler(Self._ourFallbackEventHandler)
     }
-#endif
+    #endif
     return false
   }()
 
@@ -208,14 +218,14 @@ extension Event {
   ///   currently-installed handler belongs to the testing library, returns
   ///   `false`.
   borrowing func postToFallbackEventHandler(in context: borrowing Context) -> Bool {
-#if !SWT_NO_INTEROP
+    #if !SWT_NO_INTEROP
     return Self._postToFallbackEventHandler?(self, context) != nil
-#else
+    #else
     return false
-#endif
+    #endif
   }
 
-#if !SWT_NO_INTEROP
+  #if !SWT_NO_INTEROP
   /// The implementation of ``postToFallbackEventHandler(in:)`` that actually
   /// invokes the installed fallback event handler.
   ///
@@ -228,7 +238,8 @@ extension Event {
     }
 
     let fallbackEventHandlerAddress = castCFunction(fallbackEventHandler, to: UnsafeRawPointer.self)
-    let ourFallbackEventHandlerAddress = castCFunction(Self._ourFallbackEventHandler, to: UnsafeRawPointer.self)
+    let ourFallbackEventHandlerAddress = castCFunction(
+      Self._ourFallbackEventHandler, to: UnsafeRawPointer.self)
     if fallbackEventHandlerAddress == ourFallbackEventHandlerAddress {
       // The fallback event handler belongs to Swift Testing, so we don't want
       // to call it on our own behalf.
@@ -245,5 +256,5 @@ extension Event {
       )
     }
   }()
-#endif
+  #endif
 }

--- a/Tests/TestingTests/EventHandlingInteropTests.swift
+++ b/Tests/TestingTests/EventHandlingInteropTests.swift
@@ -45,7 +45,7 @@ struct EventHandlingInteropTests {
   /// Must be set before we call `Event.installFallbackEventHandler()` which
   /// will cache the install outcome.
   static func enableExperimentalInterop() {
-    Environment.setVariable("1", named: "SWT_EXPERIMENTAL_INTEROP_ENABLED")
+    Environment.setVariable("1", named: Interop.experimentalOptInKey)
   }
 
   /// Sets the env var that determines the interop mode.
@@ -157,31 +157,6 @@ struct EventHandlingInteropTests {
 
   // MARK: - End to end handling of an issue with interop
 
-  /// Simulates the behaviour of XCTFail when called in a Swift Testing test.
-  /// This always forwards a test failure through the fallback event handler if it can find one.
-  /// It is an error to call this when a handler hasn't been installed yet.
-  /// - Parameter payload: Optional payload to use instead of generating a standard one.
-  private static func FakeXCTFail(payload: Data? = nil) throws {
-    let currentHandler = try #require(
-      _swift_testing_getFallbackEventHandler(),
-      "A fallback event handler must be installed ahead of time")
-
-    func wrapInEncodedEvent(issue: Issue) throws -> Data {
-      let event = Event(.issueRecorded(issue), testID: nil, testCaseID: nil, instant: .now)
-      let encodedEvent = ABI.Record<ABI.CurrentVersion>(
-        encoding: event, in: .init(test: nil, testCase: nil, iteration: nil, configuration: nil),
-        messages: [])
-      return try JSONEncoder().encode(encodedEvent)
-    }
-
-    let encodedIssue = try payload ?? wrapInEncodedEvent(issue: .init(kind: .unconditional))
-
-    encodedIssue.withUnsafeBytes { ptr in
-      let vers = String(describing: ABI.CurrentVersion.versionNumber)
-      currentHandler(vers, ptr.baseAddress!, ptr.count, nil)
-    }
-  }
-
   @Test func `Fallback handler records an issue if invalid event provided`() async throws {
     await #expect(processExitsWith: .success) {
       Self.enableExperimentalInterop()
@@ -189,7 +164,7 @@ struct EventHandlingInteropTests {
       // Pass an invalid record JSON to the event handler
       let issues = await Test {
         let emptyJSON = "{}".data(using: .utf8)!
-        try Self.FakeXCTFail(payload: emptyJSON)
+        try _FakeXCTFail(payload: emptyJSON)
       }.runCapturingIssues()
 
       // Assert that we record an issue with a helpful debug message
@@ -228,7 +203,7 @@ struct EventHandlingInteropTests {
 
       // Run the test, which should record two issues in response to the interop one
       let issues = await Test {
-        try Self.FakeXCTFail()
+        try _FakeXCTFail()
       }.runCapturingIssues()
 
       // Generate the interop test failure (as a warning) and warning about XCTest API usage
@@ -246,27 +221,31 @@ struct EventHandlingInteropTests {
 
       // Run the test, which should record two issues in response to the interop one
       let issues = await Test {
-        try Self.FakeXCTFail()
+        try _FakeXCTFail()
       }.runCapturingIssues()
 
       // Generate the interop test failure and warning about XCTest API usage
       #expect(
-        issues.map { $0.severity } == [.error, .warning]
+        issues.map { $0.severity }.sorted() == [.warning, .error]
       )
     }
   }
 
+  @available(macOS 15.0, *) // String(validating:as:) is unavailable on older macOS
   @Test func `Strict interop mode causes a process exit`() async throws {
-    await #expect(processExitsWith: .signal(SIGTRAP)) {  // SIGTRAP to match the fatalError
+    let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
       Self.enableExperimentalInterop()
       Self.setInteropMode(.strict)
       try #require(Event.installFallbackEventHandler())
 
       // Run the test, which should cause a process exit due to strict mode
-      _ = await Test {
-        try Self.FakeXCTFail()
-      }.runCapturingIssues()
+      await Test {
+        try _FakeXCTFail()
+      }.run()
     }
+
+    let stderr = try #require(String(validating: result?.standardErrorContent ?? [UInt8](), as: UTF8.self))
+    #expect(stderr.contains("Fatal error: XCTest API was used in a Swift Testing test"))
   }
 
   @Test func `Handle fallback event warns issue about XCTest API usage`() async throws {
@@ -277,13 +256,13 @@ struct EventHandlingInteropTests {
       // Run the test, which should record two issues in response to the interop one
       // Prepare a test issue to inject into that handler to simulate receiving an interop issue.
       let issues = await Test {
-        try Self.FakeXCTFail()
+        try _FakeXCTFail()
       }.runCapturingIssues()
 
       #expect(
         issues.map { $0.description }.sorted() == [
           "An API was misused (warning): XCTest API was used in a Swift Testing test. Adopt Swift Testing primitives, such as #expect, instead.",
-          "Issue recorded (error)",
+          "Issue recorded (warning)",
         ]
       )
     }
@@ -291,18 +270,26 @@ struct EventHandlingInteropTests {
 }
 #endif
 
-extension Test {
-  func runCapturingIssues() async -> [Issue] {
-    let issues = Mutex<[Issue]>()
+/// Simulates the behaviour of XCTFail when called in a Swift Testing test.
+/// This always forwards a test failure through the fallback event handler if it can find one.
+/// It is an error to call this when a handler hasn't been installed yet.
+/// - Parameter payload: Optional payload to use instead of generating a standard one.
+fileprivate func _FakeXCTFail(payload: Data? = nil) throws {
+  // A fallback event handler must be installed ahead of time
+  let currentHandler = try #require(_swift_testing_getFallbackEventHandler())
 
-    var issueCapturingConfig = Configuration()
-    issueCapturingConfig.eventHandler = { event, _ in
-      if case .issueRecorded(let issue) = event.kind {
-        issues.withLock { $0.append(issue) }
-      }
-    }
+  func wrapInEncodedEvent(issue: Issue) throws -> Data {
+    let event = Event(.issueRecorded(issue), testID: nil, testCaseID: nil, instant: .now)
+    let encodedEvent = ABI.Record<ABI.CurrentVersion>(
+      encoding: event, in: .init(test: nil, testCase: nil, iteration: nil, configuration: nil),
+      messages: [])
+    return try JSONEncoder().encode(encodedEvent)
+  }
 
-    await self.run(configuration: issueCapturingConfig)
-    return issues.rawValue
+  let encodedIssue = try payload ?? wrapInEncodedEvent(issue: .init(kind: .unconditional))
+
+  encodedIssue.withUnsafeBytes { ptr in
+    let vers = String(describing: ABI.CurrentVersion.versionNumber)
+    currentHandler(vers, ptr.baseAddress!, ptr.count, nil)
   }
 }

--- a/Tests/TestingTests/InteropModeTests.swift
+++ b/Tests/TestingTests/InteropModeTests.swift
@@ -12,56 +12,54 @@
 
 #if !SWT_NO_EXIT_TESTS && !SWT_NO_INTEROP
 @Suite struct `Unit tests for interop mode selection` {
+  @Test func `Installation not required if experimentalOptInKey not set`() async {
+    await #expect(processExitsWith: .success) {
+      Environment.setVariable("0", named: Interop.experimentalOptInKey)
+      #expect(Interop.Mode.limited.requiresInstallation == false)
+    }
+  }
+
   @Test(arguments: Interop.Mode.allCases)
-  func `Not-none interop modes require installation`(mode: Interop.Mode) {
-    switch mode {
-    case .none:
-      #expect(!mode.requiresInstallation)
-    case .complete, .limited, .strict:
-      #expect(mode.requiresInstallation)
+  func `Not-none interop modes require installation`(mode: Interop.Mode) async {
+    await #expect(processExitsWith: .success) { [mode] in
+      Environment.setVariable("1", named: Interop.experimentalOptInKey)
+      switch mode {
+      case .none:
+        #expect(!mode.requiresInstallation)
+      case .complete, .limited, .strict:
+        #expect(mode.requiresInstallation)
+      }
     }
   }
 
   @Test func `Default interop mode`() async {
-    #expect(Interop.Mode.current == .complete)
+    #expect(Interop.Mode.current == .limited)
   }
 
   /// Run this test case in a separate process via exit tests since we will
   /// be modifying the environment during the test.
-  ///
-  /// Ideally we'd run each value in a separate exit test, but that requires
-  /// combining parameterized tests and exit tests which is currently unsupported.
-  @Test func `Read interop modes from environment`() async {
-
-    /// Set the interop env var to the provided value. If the value is `nil`,
-    /// then the env var is unset.
-    @Sendable func given(
-      value: String?, expect expectedMode: Interop.Mode,
-      sourceLocation: SourceLocation = #_sourceLocation
-    ) {
-      let key = "SWIFT_TESTING_XCTEST_INTEROP_MODE"
-      Environment.setVariable(value, named: key)
-
-      #expect(Interop.Mode._currentImpl() == expectedMode, sourceLocation: sourceLocation)
-    }
-
-    await #expect(processExitsWith: .success) {
+  @Test(
+    arguments: [
       // Standard mode names
-      given(value: "none", expect: .none)
-      given(value: "limited", expect: .limited)
-      given(value: "complete", expect: .complete)
-      given(value: "strict", expect: .strict)
+      ("none" as String?, Interop.Mode.none),
+      ("limited", .limited),
+      ("complete", .complete),
+      ("strict", .strict),
 
-      let defaultMode = Interop.Mode.complete
-      // Unknown or unset mode
-      given(value: nil, expect: defaultMode)
-      given(value: "idk", expect: defaultMode)
+      // Unknown mode
+      (nil, .limited),
+      ("idk", .limited),
 
       // Case sensitivity
-      given(value: "None", expect: defaultMode)
-      given(value: "Limited", expect: defaultMode)
-      given(value: "Complete", expect: defaultMode)
-      given(value: "Strict", expect: defaultMode)
+      ("None", .limited),
+      ("Limited", .limited),
+      ("Complete", .limited),
+      ("Strict", .limited),
+    ])
+  func `Read interop modes from environment`(envValue: String?, expectedMode: Interop.Mode) async {
+    await #expect(processExitsWith: .success) { [envValue, expectedMode] in
+      Environment.setVariable(envValue, named: Interop.Mode.interopModeEnvKey)
+      #expect(Interop.Mode.current == expectedMode)
     }
   }
 }

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -18,6 +18,10 @@ import XCTest
 import Foundation
 #endif
 
+#if canImport(Synchronization)
+private import Synchronization
+#endif
+
 /// The ABI name of the testing library's main module.
 ///
 /// This can be different than the target name ("Testing") whenever the module
@@ -305,6 +309,24 @@ extension Test {
     let runner = await Runner(testing: [self], configuration: configuration)
     await runner.run()
   }
+
+  /// Run a single test, returning all `.issueRecorded` event types that it
+  /// encountered while running.
+  func runCapturingIssues() async -> [Issue] {
+    let issues = Mutex<[Issue]>()
+
+    var issueCapturingConfig = Configuration()
+    issueCapturingConfig.eventHandler = { event, _ in
+      if case .issueRecorded(let issue) = event.kind {
+        issues.withLock { $0.append(issue) }
+      }
+    }
+
+    let runner = await Runner(testing: [self], configuration: issueCapturingConfig)
+    await runner.run()
+
+    return issues.rawValue
+  }
 }
 
 extension Test.ID {
@@ -465,5 +487,15 @@ extension SourceContext {
 
   init(sourceLocation: SourceLocation?) {
     self.init(backtrace: .current(), sourceLocation: sourceLocation)
+  }
+}
+
+@Suite struct TestingAdditionsTests {
+  @Test func `Demonstrate runCapturingIssues usage`() async {
+    let issues = await Test {
+      #expect(Bool(false))
+    }.runCapturingIssues()
+
+    #expect(issues.count == 1)
   }
 }


### PR DESCRIPTION
Support none/limited/complete/strict interop modes with varying degrees of noisiness when handling interop issues.

### Motivation:

Allow users to configure the interop mode for their tests.

### Modifications:

* Modes will only apply if `SWT_EXPERIMENTAL_INTEROP_ENABLED` is enabled.

* limited: warnings only, complete: report issues as errors, strict: fatalError when handling interop issues

* Default mode is "complete" if opted-in to interop. If interop becomes enabled by default in the future, this will be updated.

Resolves rdar://171907588
### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
