### PR TITLE
Extend file cloning of attachments to `ABI.EncodedAttachment`.

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -79,7 +79,9 @@ extension ABI.EncodedAttachment: Codable {
     case let .savedAtPath(path):
       try container.encode(path, forKey: .path)
     case let .abstract(attachment):
-      if V.includesExperimentalFields {
+      if let path = attachment.fileSystemPath {
+        try container.encode(path, forKey: .path)
+      } else if V.includesExperimentalFields {
         var errorWhileEncoding: (any Error)?
         do {
           try attachment.withUnsafeBytes { bytes in
@@ -207,6 +209,18 @@ extension ABI.EncodedAttachment: Attachable {
   }
 }
 
+#if !SWT_NO_FILE_CLONING
+extension ABI.EncodedAttachment: FileClonable {
+  package func clone(toFileAtPath filePath: String) -> Bool {
+    guard case let .abstract(attachment) = kind else {
+      return false
+    }
+    return attachment.attachableValue.clone(toFileAtPath: filePath)
+  }
+  
+}
+#endif
+
 extension ABI.EncodedAttachment.BytesUnavailableError: CustomStringConvertible {
   var description: String {
     "The attachment's content could not be deserialized."
@@ -221,12 +235,7 @@ extension ABI.EncodedAttachment {
   /// - Parameters:
   ///   - attachment: The attachment to initialize this instance from.
   public init(encoding attachment: borrowing Attachment<AnyAttachable>) {
-    if let path = attachment.fileSystemPath {
-      kind = .savedAtPath(path)
-    } else {
-      kind = .abstract(copy attachment)
-    }
-
+    kind = .abstract(copy attachment)
     if V.includesExperimentalFields {
       _preferredName = attachment.preferredName
     }


### PR DESCRIPTION
This PR ensures that an `ABI.EncodedAttachment` instance that's wrapping an instance of `AnyAttachable` (i.e. one that has not yet been encoded to JSON) will still be able to clone its underlying file where appropriate.

I haven't tried to plumb this through attachments stored solely as file paths because they've already been serialized/deserialized by that point, which implies a slow path anyway. We can revisit that in a future PR if we think it's valuable.

Follow-up to #1590 and #1587.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
