### PR TITLE
Fix incorrect type when trying to encode an attachment as JSON.

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -65,13 +65,11 @@ extension ABI.EncodedAttachment: Codable {
     func encodeBytes(_ bytes: UnsafeRawBufferPointer) throws {
 #if canImport(Foundation)
       // If possible, encode this structure as Base64 data.
-      try bytes.withUnsafeBytes { bytes in
-        let data = Data(bytesNoCopy: .init(mutating: bytes.baseAddress!), count: bytes.count, deallocator: .none)
-        try container.encode(data.base64EncodedString(), forKey: .bytes)
-      }
+      let data = Data(bytesNoCopy: .init(mutating: bytes.baseAddress!), count: bytes.count, deallocator: .none)
+      try container.encode(data.base64EncodedString(), forKey: .bytes)
 #else
       // Otherwise, it's an array of integers.
-      try container.encode(bytes, forKey: .bytes)
+      try container.encode(Array(bytes), forKey: .bytes)
 #endif
     }
 


### PR DESCRIPTION
This fixes us using the wrong type when encoding an attachment as JSON if Foundation is not available. (This is not expected to be a fast path, so the array copy is fine).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
