### PR TITLE
Fix a test that's now generating a warning issue with interop enabled.

### DIFF
--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -960,10 +960,17 @@ final class IssueTests: XCTestCase {
   }
 
   func testErrorCheckingWithExpect_ResultValueIsNever() async throws {
-    let error: Never? = #expect(throws: Never.self) {
-      throw MyDescriptiveError(description: "abc123")
+    var configuration = Configuration()
+    configuration.eventHandler = { _, _ in
+      // I'm just here to suppress issue recording.
     }
-    #expect(error == nil)
+
+    await Test {
+      let error: Never? = #expect(throws: Never.self) {
+        throw MyDescriptiveError(description: "abc123")
+      }
+      #expect(error == nil)
+    }.run(configuration: configuration)
   }
 
   func testErrorCheckingWithRequire_ResultValueIsNever() async throws {


### PR DESCRIPTION
We have an XCTest-based test that generates a spurious warning with interop enabled because it makes an unguarded call to `#expect(throws:)`. Guard the call so we don't generate an issue.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
