### PR TITLE
Encode/decode `.apiMisused` and `.system` issue kinds.

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
@@ -18,11 +18,15 @@ extension ABI {
   ///
   /// - Warning: Errors are not yet part of the JSON schema.
   struct EncodedError<V>: Sendable where V: ABI.Version {
-    /// The error's description
+    /// The error's description.
     var description: String
 
     /// The domain of the error.
-    var domain: String
+    ///
+    /// The value of this property may be `nil` if the error originated in a
+    /// context other than Swift or Objective-C (where errors may not have
+    /// associated domain strings).
+    var domain: String?
 
     /// The code of the error.
     var code: Int
@@ -32,6 +36,9 @@ extension ABI {
     init(encoding error: some Error) {
       description = String(describingForTest: error)
       domain = error._domain
+      if domain == Self.unknownDomain {
+        domain = nil
+      }
       code = error._code
     }
   }
@@ -40,8 +47,13 @@ extension ABI {
 // MARK: - Error
 
 extension ABI.EncodedError: Error {
+  /// The domain of decoded errors that did not specify a domain of their own.
+  static var unknownDomain: String {
+    "<unknown>"
+  }
+
   var _domain: String {
-    domain
+    domain ?? Self.unknownDomain
   }
 
   var _code: Int {

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -92,8 +92,17 @@ extension ABI {
         if let backtrace = issue.sourceContext.backtrace {
           _backtrace = EncodedBacktrace(encoding: backtrace, in: eventContext)
         }
-        if let error = issue.error {
-          _error = EncodedError(encoding: error)
+        _error = if let error = issue.error {
+          EncodedError(encoding: error)
+        } else {
+          switch issue.kind {
+          case .apiMisused:
+            EncodedError(encoding: APIMisuseError(description: ""))
+          case .system:
+            EncodedError(encoding: SystemError(description: ""))
+          default:
+            nil
+          }
         }
         if case let .expectationFailed(expectation) = issue.kind {
           _expression = EncodedExpression(encoding: expectation.evaluatedExpression)
@@ -138,7 +147,14 @@ extension Issue {
   init?<V>(decoding issue: ABI.EncodedIssue<V>) {
     let issueKind: Issue.Kind
     if let error = issue._error {
-      issueKind = .errorCaught(error)
+      switch error.domain {
+      case APIMisuseError.domain:
+        issueKind = .apiMisused
+      case SystemError.domain:
+        issueKind = .system
+      default:
+        issueKind = .errorCaught(error)
+      }
     } else if let expression = issue._expression.flatMap(__Expression.init(decoding:)),
               let sourceLocation = issue.sourceLocation.flatMap(SourceLocation.init) {
       let expectation = Expectation(

--- a/Sources/Testing/Support/CustomIssueRepresentable.swift
+++ b/Sources/Testing/Support/CustomIssueRepresentable.swift
@@ -47,6 +47,14 @@ protocol CustomIssueRepresentable: Error {
 struct SystemError: Error, CustomStringConvertible, CustomIssueRepresentable {
   var description: String
 
+  static var domain: String {
+    "org.swift.testing.SystemError"
+  }
+
+  var _domain: String {
+    Self.domain
+  }
+
   func customize(_ issue: consuming Issue) -> Issue {
     issue.kind = .system
     issue.comments.append("\(self)")
@@ -65,6 +73,14 @@ struct SystemError: Error, CustomStringConvertible, CustomIssueRepresentable {
 /// or by calling ``Issue/record(_:severity:sourceLocation:)``.
 struct APIMisuseError: Error, CustomStringConvertible, CustomIssueRepresentable {
   var description: String
+
+  static var domain: String {
+    "org.swift.testing.APIMisuseError"
+  }
+
+  var _domain: String {
+    Self.domain
+  }
 
   func customize(_ issue: consuming Issue) -> Issue {
     issue.kind = .apiMisused

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -225,6 +225,37 @@ private import _TestingInternals
     }
   }
 
+  @Test("Exit test forwards .apiMisused and .system issues") func forwardsAPIMisusedAndSystemIssues() async {
+    await confirmation(".apiMisused recorded") { apiMisusedRecorded in
+      await confirmation(".system recorded") { systemRecorded in
+        var configuration = Configuration()
+        configuration.eventHandler = { event, _ in
+          guard case let .issueRecorded(issue) = event.kind else {
+            return
+          }
+          switch issue.kind {
+          case .apiMisused:
+            apiMisusedRecorded()
+          case .system:
+            systemRecorded()
+          default:
+            break
+          }
+        }
+        configuration.exitTestHandler = ExitTest.handlerForEntryPoint()
+
+        await Test {
+          await #expect(processExitsWith: .success) {
+            Issue(kind: .apiMisused).record()
+          }
+          await #expect(processExitsWith: .failure) {
+            Issue(kind: .system).record()
+          }
+        }.run(configuration: configuration)
+      }
+    }
+  }
+
   @Test("Exit test issues contain expression trees") func expressionsInIssues() async {
     await confirmation("Expectation failed") { expectationFailed in
       var configuration = Configuration()


### PR DESCRIPTION
This PR takes advantage of the fact that we (experimentally) encode errors for issues and encodes instances of `APIMisuseError` and `SystemError` to represent `.apiMisused` and `.system` issues, respectively. This improves the fidelity of issues reported via XCTest interop and exit test backchannels.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
