### PR TITLE
Initial FreeBSD workflow

### DIFF
--- a/.github/workflows/manual_build_freebsd.yml
+++ b/.github/workflows/manual_build_freebsd.yml
@@ -1,0 +1,38 @@
+name: Manual FreeBSD Test
+on: workflow_dispatch
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    env:
+      SWIFT_INSTALL_PATH: "/opt/swift-main"
+      SWIFT_WEB_URL: "https://download.swift.org/tmp-ci-nightly/development/freebsd-14_ci_latest.tar.gz"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build in FreeBSD
+        id: build
+        uses: vmactions/freebsd-vm@v1
+        with:
+          envs: 'SWIFT_INSTALL_PATH SWIFT_WEB_URL'
+          release: "14.3"
+          sync: rsync
+          copyback: false
+          usesh: true
+          prepare: |
+            fetch -o /tmp/swift.tar.gz "$SWIFT_WEB_URL"
+            mkdir -p /opt/swift-main
+            tar -xzf /tmp/swift.tar.gz -C /opt/swift-main
+            pkg install -y \
+              sqlite3 \
+              python3 \
+              libuuid \
+              curl \
+              brotli \
+              git
+            git config --global init.defaultBranch 'main'
+            "$SWIFT_INSTALL_PATH/usr/bin/swift" --version
+          run: |
+            export PATH="$SWIFT_INSTALL_PATH/usr/bin:$PATH"
+            swift build
+            swift test


### PR DESCRIPTION
Writing up a quick FreeBSD test workflow for verifying that Swift Testing continues to work on FreeBSD. We can move this to 'swiftlang/github-workflows' once we are reasonably confident that this is the shape that we want. We'll likely want to strip parts into separate actions with an actual interface and then allow workflows to reference the action. In the meantime, it is a manually triggered workflow. I've verified that the steps work and test in my fork here: https://github.com/etcwilde/swift-testing/actions/runs/23322513361/job/67836632217

### Motivation:

We are working on bringing up FreeBSD as a supported host platform. As part of that, we want to ensure that it continues to work as development proceeds on Swift Testing (and other projects).

### Modifications:

Adding a new FreeBSD workflow.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
