### PR TITLE
Maintain environment variable containing test bundle path when spawning an exit test subprocess

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -878,9 +878,10 @@ extension ExitTest {
       // platform-specific changes.
       var childEnvironment = Environment.get()
 #if SWT_TARGET_OS_APPLE
-      // We need to remove Xcode's environment variables from the child
-      // environment to avoid accidentally accidentally recursing.
-      for key in childEnvironment.keys where key.starts(with: "XCTest") {
+      // We need to remove the XCTest-related environment variables set by Xcode,
+      // except those known to be safe and relevant, from the child environment
+      // to avoid accidentally recursing.
+      for key in childEnvironment.keys where key.starts(with: "XCTest") && key != "XCTestBundlePath" {
         childEnvironment.removeValue(forKey: key)
       }
 #endif


### PR DESCRIPTION
This modifies the logic for constructing the set of environment variables applied to an Exit Test subprocess so that it does not filter out a useful environment variable specified by Xcode (`XCTestBundlePath`) and maintains it whenever it is present in the parent process's environment.

Resolves rdar://172950962

### Motivation:

This environment variable can be useful to allow integrated tools to more reliably locate and load the test bundle if it resides an unconventional location. Currently, many environment variables related to XCTest are filtered out to avoid the possibility of an exit test subprocess incorrectly behaving as a "normal" test runner and entering into an infinite loop, but this variable doesn't pose that risk.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
