### PR TITLE
Avoid hanging trying to diff `Data` and similar collections.

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -667,6 +667,34 @@ public func __checkBinaryOperation(
 /// Check that an expectation has passed after a condition has been evaluated
 /// and throw an error if it failed.
 ///
+/// This overload is necessary because collections whose elements are of type
+/// `UInt8` or `Int8` tend to be raw data and diffing them can be very slow
+/// while also not producing useful, readable output.
+///
+/// - Warning: This function is used to implement the `#expect()` and
+///   `#require()` macros. Do not call it directly.
+public func __checkBinaryOperation<T, U>(
+  _ lhs: T, _ op: (T, () -> U) -> Bool, _ rhs: @autoclosure () -> U,
+  expression: __Expression,
+  comments: @autoclosure () -> [Comment],
+  isRequired: Bool,
+  sourceLocation: SourceLocation
+) -> Result<Void, any Error> where T: Collection, U: Collection, T.Element == U.Element, T.Element: BinaryInteger, T.Element.Magnitude == UInt8 {
+  let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
+  return __checkValue(
+    condition,
+    expression: expression,
+    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, rhs),
+    difference: nil,
+    comments: comments(),
+    isRequired: isRequired,
+    sourceLocation: sourceLocation
+  )
+}
+
+/// Check that an expectation has passed after a condition has been evaluated
+/// and throw an error if it failed.
+///
 /// This overload is necessary because ranges are collections and satisfy the
 /// requirements for the difference-calculating overload above, but it doesn't
 /// make sense to diff them and very large ranges can cause overflows or hangs.

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1284,6 +1284,26 @@ final class IssueTests: XCTestCase {
     }.run(configuration: configuration)
   }
 
+  func testCollectionDifferenceSkippedForByteCollections() async {
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      guard case let .issueRecorded(issue) = event.kind else {
+        return
+      }
+      guard case let .expectationFailed(expectation) = issue.kind else {
+        XCTFail("Unexpected issue kind \(issue.kind)")
+        return
+      }
+      XCTAssertNil(expectation.differenceDescription)
+    }
+
+    await Test {
+      let lhs = [1, 2, 3] as [UInt8]
+      let rhs = [4, 5, 6] as [UInt8]
+      #expect(lhs == rhs)
+    }.run(configuration: configuration)
+  }
+
   func testCollectionDifferenceSkippedForRanges() async {
     var configuration = Configuration()
     configuration.eventHandler = { event, _ in


### PR DESCRIPTION
This PR suppresses our diffing logic for collections with element types `Int8` or `UInt8`. The output is not currently useful for these types.

Resolves rdar://173002947.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
