### PR TITLE
[6.3.1] Fully-qualify reference to 'Comment' type in #expect expansion when comment argument isn't a string literal

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -177,7 +177,7 @@ extension ConditionMacro {
         // the resulting comment array.
         checkArguments.append(Argument(
           label: "comments",
-          expression: #"(\#(commentsArrayExpr) as [Comment?]).compactMap(\.self)"#
+          expression: #"(\#(commentsArrayExpr) as [Testing.Comment?]).compactMap(\.self)"#
         ))
       } else {
         checkArguments.append(Argument(label: "comments", expression: commentsArrayExpr))

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -612,4 +612,14 @@ struct MiscellaneousTests {
     }
     #expect(duration < .seconds(1))
   }
+
+  @Test func `Expectation with a non-string literal comment and ambiguous 'Comment' type`() {
+    let comment: Comment = "foo"
+    do {
+      // Declare a custom type whose name conflicts with the testing library's
+      // built-in Comment type.
+      struct Comment {}
+      #expect(true as Bool, comment)
+    }
+  }
 }


### PR DESCRIPTION
- **Explanation**:
  This fixes a build error which can arise in the code emitted by `#expect` when the `comment` argument is not a string literal and the module the `#expect` appears in has a custom type visible named `Comment`, conflicting with the testing library's built-in type by that name.
- **Scope**: Affects a narrow use case of expectations: those which include custom comment arguments which aren't string literals
- **Issues**: #1641
- **Original PRs**: #1645
- **Risk**: Low; affects a corner case in the expansion of `#expect` and `#require` macros
- **Testing**: Added a new regression test
- **Reviewers**: @grynspan 
