### PR TITLE
Add support for module selectors in types during macro expansion.

### DIFF
--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -397,11 +397,11 @@ public struct RequireThrowsMacro: RefinedConditionMacro {
     let arguments = argumentList(of: macro, in: context)
     let errorExpr = arguments.first { $0.label?.tokenKind == .identifier("throws") }?.expression
 
-    if let errorExpr {
-      let argumentTokens: [String] = errorExpr.tokens(viewMode: .fixedUp).lazy
-        .filter { $0.tokenKind != .period }
-        .map(\.textWithoutBackticks)
-      if argumentTokens == ["Swift", "Never", "self"] || argumentTokens == ["Never", "self"] {
+    if let errorExpr = errorExpr?.as(MemberAccessExprSyntax.self),
+       errorExpr.declName.argumentNames == nil,
+       errorExpr.declName.baseName.tokenKind == .keyword(.self) {
+      let errorType = "\(errorExpr.base)" as TypeSyntax
+      if errorType.isNamed("Never", inModuleNamed: "Swift") {
         context.diagnose(.requireThrowsNeverIsRedundant(errorExpr, in: macro))
       }
     }

--- a/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/TypeSyntaxProtocolAdditions.swift
@@ -17,6 +17,40 @@ private let _knownGenericTypeKinds: [SyntaxKind] = [
 ]
 
 extension TypeSyntaxProtocol {
+  /// This type's module selector, if any.
+  var moduleSelector: ModuleSelectorSyntax? {
+    if let type = self.as(IdentifierTypeSyntax.self) {
+      return type.moduleSelector
+    } else if let type = self.as(MemberTypeSyntax.self) {
+      return type.moduleSelector ?? type.baseType.moduleSelector
+    }
+    return nil
+  }
+
+  /// Copy this instance and remove its module selector if present.
+  ///
+  /// - Returns: A copy of this instance with a `nil` module selector. If this
+  ///   instance does not specify a module selector, returns `self` verbatim.
+  func removingModuleSelector() -> some TypeSyntaxProtocol {
+    var result = TypeSyntax(self)
+
+    if var type = self.as(IdentifierTypeSyntax.self) {
+      if type.moduleSelector != nil {
+        type.moduleSelector = nil
+        result = TypeSyntax(type)
+      }
+    } else if var type = self.as(MemberTypeSyntax.self) {
+      if type.moduleSelector != nil {
+        type.moduleSelector = nil
+      } else if type.baseType.moduleSelector != nil {
+        type.baseType = TypeSyntax(type.baseType.removingModuleSelector())
+      }
+      result = TypeSyntax(type)
+    }
+
+    return result
+  }
+
   /// Whether or not this type is an optional type (`T?`, `Optional<T>`, etc.)
   var isOptional: Bool {
     if `is`(OptionalTypeSyntax.self) {
@@ -91,6 +125,19 @@ extension TypeSyntaxProtocol {
   ///
   /// - Returns: Whether or not this type has the given name.
   func isNamed(_ name: String, inModuleNamed moduleName: String) -> Bool {
+    // NOTE: the syntax M::M.T is ambiguous without type checking. We don't know
+    // from syntax alone if the second M is the module name (repeated) or if it
+    // is a type in module M with the same name. For example, XCTest::XCTest.T.
+    // Because it's ambiguous, we don't clear the moduleName argument after we
+    // strip the module selector and before we recursively call isNamed().
+    if let moduleSelector {
+      guard moduleName == moduleSelector.moduleName.textWithoutBackticks else {
+        return false
+      }
+      let selfCopy = self.removingModuleSelector()
+      return selfCopy.isNamed(name, inModuleNamed: moduleName)
+    }
+
     // Form a string of the fixed-up tokens representing the type name,
     // omitting any generic type parameters.
     let nameWithoutGenericParameters = tokens(viewMode: .fixedUp)

--- a/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage+Diagnosing.swift
@@ -26,9 +26,9 @@ extension AttributeInfo {
          let calledExpr = functionCallExpr.calledExpression.as(MemberAccessExprSyntax.self) {
         // Check for .tags() traits.
         switch calledExpr.tokens(viewMode: .fixedUp).map(\.textWithoutBackticks).joined() {
-        case ".tags", "Tag.List.tags", "Testing.Tag.List.tags":
+        case ".tags", "Tag.List.tags", "Testing.Tag.List.tags", "Testing::Tag.List.tags", "Testing::Testing.Tag.List.tags":
           _diagnoseIssuesWithTagsTrait(functionCallExpr, addedTo: self, in: context)
-        case ".bug", "Bug.bug", "Testing.Bug.bug":
+        case ".bug", "Bug.bug", "Testing.Bug.bug", "Testing::Bug.bug", "Testing::Testing.Bug.bug":
           _diagnoseIssuesWithBugTrait(functionCallExpr, addedTo: self, in: context)
         default:
           // This is not a trait we can parse.
@@ -36,7 +36,7 @@ extension AttributeInfo {
         }
       } else if let memberAccessExpr = traitExpr.as(MemberAccessExprSyntax.self) {
         switch memberAccessExpr.tokens(viewMode: .fixedUp).map(\.textWithoutBackticks).joined() {
-        case ".serialized", "ParallelizationTrait.serialized", "Testing.ParallelizationTrait.serialized":
+        case ".serialized", "ParallelizationTrait.serialized", "Testing.ParallelizationTrait.serialized", "Testing::ParallelizationTrait.serialized", "Testing::Testing.ParallelizationTrait.serialized":
           _diagnoseIssuesWithParallelizationTrait(memberAccessExpr, addedTo: self, in: context)
         default:
           // This is not a trait we can parse.
@@ -61,7 +61,7 @@ private func _diagnoseIssuesWithTagsTrait(_ traitExpr: FunctionCallExprSyntax, a
       // String literals are supported tags.
     } else if let tagExpr = tagExpr.as(MemberAccessExprSyntax.self) {
       let joinedTokens = tagExpr.tokens(viewMode: .fixedUp).map(\.textWithoutBackticks).joined()
-      if joinedTokens.hasPrefix(".") || joinedTokens.hasPrefix("Tag.") || joinedTokens.hasPrefix("Testing.Tag.") {
+      if joinedTokens.hasPrefix(".") || joinedTokens.hasPrefix("Tag.") || joinedTokens.hasPrefix("Testing.Tag.") || joinedTokens.hasPrefix("Testing::Tag.") || joinedTokens.hasPrefix("Testing::Testing.Tag.") {
         // These prefixes are all allowed as they specify a member access
         // into the Tag type.
       } else {
@@ -338,7 +338,8 @@ func diagnoseExpansionInLibraryTarget(of macro: some FreestandingMacroExpansionS
   }
 
   var targetName = "<unknown>"
-  if let fileID = context.location(of: macro, at: .afterLeadingTrivia, filePathMode: .fileID)?.file.trimmedDescription,
+  if let location = context.location(of: macro, at: .afterLeadingTrivia, filePathMode: .fileID),
+     let fileID = location.file.as(StringLiteralExprSyntax.self)?.representedLiteralValue,
      let slashIndex = fileID.firstIndex(of: "/") {
     targetName = String(fileID[..<slashIndex])
   }

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -784,7 +784,7 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   ///   - expr: The error type expression.
   ///
   /// - Returns: A diagnostic message.
-  static func requireThrowsNeverIsRedundant(_ expr: ExprSyntax, in macro: some FreestandingMacroExpansionSyntax) -> Self {
+  static func requireThrowsNeverIsRedundant(_ expr: some ExprSyntaxProtocol, in macro: some FreestandingMacroExpansionSyntax) -> Self {
     // We do not provide fix-its because we cannot see the leading "try" keyword
     // so we can't provide a valid fix-it to remove the macro either. We can
     // provide a fix-it to add "as Optional", but only providing that fix-it may

--- a/Sources/TestingMacros/TagMacro.swift
+++ b/Sources/TestingMacros/TagMacro.swift
@@ -50,7 +50,13 @@ public struct TagMacro: PeerMacro, AccessorMacro, Sendable {
     let typeNameTokens: [String] = type.tokens(viewMode: .fixedUp).lazy
       .filter { $0.tokenKind != .period }
       .map(\.textWithoutBackticks)
-    guard typeNameTokens.first == "Tag" || typeNameTokens.starts(with: ["Testing", "Tag"]) else {
+    let validTypeNameTokens = [
+      ["Tag"],
+      ["Testing", "Tag"],
+      ["Testing", "::", "Tag"],
+      ["Testing", "::", "Testing", "Tag"],
+    ]
+    guard validTypeNameTokens.contains(where: typeNameTokens.starts(with:)) else {
       context.diagnose(.attributeNotSupportedOutsideTagExtension(node, on: variableDecl))
       return _fallbackAccessorDecls
     }

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -346,6 +346,8 @@ struct ConditionMacroTests {
       "#expect(x as! T!)", "#require(x as! T!)",
       "#expect(x as! Optional<T>)", "#require(x as! Optional<T>)",
       "#expect(x as! Swift.Optional<T>)", "#require(x as! Swift.Optional<T>)",
+      "#expect(x as! Swift::Optional<T>)", "#require(x as! Swift::Optional<T>)",
+      "#expect(x as! Swift::Swift.Optional<T>)", "#require(x as! Swift::Swift.Optional<T>)",
     ]
   )
   func asExclamationMarkSuppressedForBoolAndOptional(input: String) throws {
@@ -424,6 +426,8 @@ struct ConditionMacroTests {
   @Test("#require(throws: Never.self) produces a diagnostic",
     arguments: [
       "#requireThrows(throws: Swift.Never.self)",
+      "#requireThrows(throws: Swift::Never.self)",
+      "#requireThrows(throws: Swift::Swift.Never.self)",
       "#requireThrows(throws: Never.self)",
       "#requireThrowsNever(throws: Never.self)",
     ]

--- a/Tests/TestingMacrosTests/TagMacroTests.swift
+++ b/Tests/TestingMacrosTests/TagMacroTests.swift
@@ -24,10 +24,17 @@ struct TagMacroTests {
       ("extension Tag { @Tag static var x: Tag }", "Tag"),
       ("extension Tag { @Tag static var x: Self }", "Tag"),
       ("extension Testing.Tag { @Tag static var x: Testing.Tag }", "Testing.Tag"),
+      ("extension Testing::Tag { @Tag static var x: Testing::Tag }", "Testing::Tag"),
+      ("extension Testing::Testing.Tag { @Tag static var x: Testing::Testing.Tag }", "Testing::Testing.Tag"),
+      ("extension Testing::Testing.Tag { @Tag static var x: Testing.Tag }", "Testing::Testing.Tag"),
+      ("extension Testing.Tag { @Tag static var x: Testing::Testing.Tag }", "Testing.Tag"),
+
       ("extension Tag.A.B { @Tag static var x: Tag }", "Tag.A.B"),
       ("extension Testing.Tag.A.B { @Tag static var x: Tag }", "Testing.Tag.A.B"),
       ("extension Tag { struct S { @Tag static var x: Tag } }", "Tag.S"),
       ("extension Testing.Tag { enum E { @Tag static var x: Tag } }", "Testing.Tag.E"),
+      ("extension Testing::Tag { enum E { @Tag static var x: Tag } }", "Testing::Tag.E"),
+      ("extension Testing::Testing.Tag { enum E { @Tag static var x: Tag } }", "Testing::Testing.Tag.E"),
     ]
   )
   func tagMacro(input: String, typeName: String) throws {

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -538,13 +538,21 @@ struct TestDeclarationMacroTests {
       #"@Test(.tags(.f)) func f() {}"#,
       #"@Test(Tag.List.tags(.f)) func f() {}"#,
       #"@Test(Testing.Tag.List.tags(.f)) func f() {}"#,
+      #"@Test(Testing::Tag.List.tags(.f)) func f() {}"#,
+      #"@Test(Testing::Testing.Tag.List.tags(.f)) func f() {}"#,
       #"@Test(.tags("abc")) func f() {}"#,
       #"@Test(Tag.List.tags("abc")) func f() {}"#,
       #"@Test(Testing.Tag.List.tags("abc")) func f() {}"#,
+      #"@Test(Testing::Tag.List.tags("abc")) func f() {}"#,
+      #"@Test(Testing::Testing.Tag.List.tags("abc")) func f() {}"#,
       #"@Test(.tags(Tag.f)) func f() {}"#,
       #"@Test(.tags(Testing.Tag.f)) func f() {}"#,
+      #"@Test(.tags(Testing::Tag.f)) func f() {}"#,
+      #"@Test(.tags(Testing::Testing.Tag.f)) func f() {}"#,
       #"@Test(.tags(.Foo.Bar.f)) func f() {}"#,
       #"@Test(.tags(Testing.Tag.Foo.Bar.f)) func f() {}"#,
+      #"@Test(.tags(Testing::Tag.Foo.Bar.f)) func f() {}"#,
+      #"@Test(.tags(Testing::Testing.Tag.Foo.Bar.f)) func f() {}"#,
     ]
   )
   func validTagExpressions(input: String) throws {

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -539,10 +539,14 @@ final class IssueTests: XCTestCase {
         throw MyParameterizedError(index: randomNumber)
       }
       #expect(throws: Never.self) {}
+      #expect(throws: Swift::Never.self) {}
+      #expect(throws: Swift::Swift.Never.self) {}
       func genericExpectThrows(_ type: (some Error).Type) {
         #expect(throws: type) {}
       }
       genericExpectThrows(Never.self)
+      genericExpectThrows(Swift::Never.self)
+      genericExpectThrows(Swift::Swift.Never.self)
       func nonVoidReturning() throws -> Int { throw MyError() }
       #expect(throws: MyError.self) {
         try nonVoidReturning()

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -28,6 +28,15 @@ private import Foundation
 
 @Sendable func freeSyncFunctionParameterized2(_ i: Int, _ j: String) {}
 
+struct SuiteTypeWithModuleSelector {}
+
+extension TestingTests::SuiteTypeWithModuleSelector {
+  @Test(.hidden) func withModuleSelector() {}
+  @Suite(.hidden) struct NestedType {
+    @Test(.hidden) func nestedFunction() {}
+  }
+}
+
 // This type ensures the parser can correctly infer that f() is a member
 // function even though @Test is preceded by another attribute or is embedded in
 // a #if statement.

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -243,7 +243,11 @@ struct TagTests {
     .hidden,
     Tag.List.tags(.fromFunctionPartiallyQualified),
     Testing.Tag.List.tags(.fromFunctionFullyQualified),
-    .tags(.namedConstant, .NestedType.deeperTag, Testing.Tag.anotherConstant)
+    Testing::Tag.List.tags(.fromFunctionFullyQualified),
+    Testing::Testing.Tag.List.tags(.fromFunctionFullyQualified),
+    .tags(.namedConstant, .NestedType.deeperTag, Testing.Tag.anotherConstant),
+    .tags(.namedConstant, .NestedType.deeperTag, Testing::Tag.anotherConstant),
+    .tags(.namedConstant, .NestedType.deeperTag, Testing::Testing.Tag.anotherConstant)
   )
   func variations() async throws {}
 }


### PR DESCRIPTION
This PR modifies our code that detects types so that it correctly handles the module selector if present. For example, we currently misfire on a pattern like this:

```swift
try #require(throws: Swift::Never.self) {
  ...
}
```

We would expect to diagnose with a warning of the form:

> ⚠️ Passing 'Never.self' to 'require(\_:\_:)' is redundant; invoke non-throwing test code directly instead

But we don't because we don't recognize that the listed error type is equivalent to `Never`. This PR fixes that, as well as similar problems with `Tag`, `Tag.List`, `ParallelizationTrait`, and the use of `as` in an expectation expression.

Migrating macro expansion code of the form `Testing.T` to `Testing::T` is a future direction.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
