### PR TITLE
Respect `Configuration` when snapshotting a runner plan

### DIFF
--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -453,10 +453,25 @@ extension Runner.Plan {
     ///
     /// - Parameters:
     ///   - plan: The original plan to snapshot.
+    @available(*, deprecated, message: "Use init(snapshotting:configuration:)")
     public init(snapshotting plan: borrowing Runner.Plan) {
-      plan.stepGraph.forEach { keyPath, step in
-        let step = step.map(Step.Snapshot.init(snapshotting:))
-        _stepGraph.insertValue(step, at: keyPath)
+      self.init(snapshotting: plan, configuration: .init())
+    }
+
+    /// Initialize an instance of this type by snapshotting the specified plan, with behavior
+    /// specified by the provided ``Configuration``.
+    ///
+    /// - Parameters:
+    ///   - plan: The original plan to snapshot.
+    ///   - configuration: The configuration that specifies the snapshotting behavior.
+    ///   Most likely, this is the configuration that was used to create `plan`.
+    @_spi(ForToolsIntegrationOnly)
+    public init(snapshotting plan: borrowing Runner.Plan, configuration: Configuration) {
+      Configuration.withCurrent(configuration) {
+        plan.stepGraph.forEach { keyPath, step in
+          let step = step.map(Step.Snapshot.init(snapshotting:))
+          _stepGraph.insertValue(step, at: keyPath)
+        }
       }
     }
 

--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -22,7 +22,7 @@ struct Runner_Plan_SnapshotTests {
     configuration.setTestFilter(toInclude: [suite.id], includeHiddenTests: true)
 
     let plan = await Runner.Plan(configuration: configuration)
-    let snapshot = Runner.Plan.Snapshot(snapshotting: plan)
+    let snapshot = Runner.Plan.Snapshot(snapshotting: plan, configuration: configuration)
     let decoded = try JSON.encodeAndDecode(snapshot)
 
     try #require(decoded.steps.count == snapshot.steps.count)
@@ -47,6 +47,25 @@ struct Runner_Plan_SnapshotTests {
     }
   }
 #endif
+
+  @Test
+  func `Respects valueReflectionOptions`() async throws {
+    let suite = try #require(await test(for: Runner_Plan_SnapshotFixtures.self))
+
+    var configuration = Configuration()
+    configuration.valueReflectionOptions = nil
+    configuration.setTestFilter(toInclude: [suite.id], includeHiddenTests: true)
+
+    let plan = await Runner.Plan(configuration: configuration)
+    let snapshot = Runner.Plan.Snapshot(snapshotting: plan, configuration: configuration)
+
+    for step in snapshot.steps {
+      guard let testCases = step.test.testCases else { continue }
+      for testCase in testCases {
+        #expect(testCase.arguments.allSatisfy { $0.value.children == nil })
+      }
+    }
+  }
 }
 
 // MARK: - Fixture tests
@@ -66,5 +85,8 @@ private struct Runner_Plan_SnapshotFixtures {
 
   @Test(.hidden, .enabled(if: try _erroneousCondition(), "To demonstrate recordIssue action"))
   func erroneousTest() {}
+
+  @Test(arguments: [0, 2, 3 as Optional])
+  func withArguments(_ x: Int?) {}
 }
 #endif


### PR DESCRIPTION
This introduces another initializer of `Runner.Plan.Snapshot` that overrides `Configuration.current`

### Motivation:

Currently, Runner.Plan.Snapshot doesn't respect settings in `Configuration`s like `valueReflectionOptions` because those read from the Task-local static properties.

### Modifications:

Adds one initializer and wraps the existing initializer body with `Configuration.withCurrent(...) { ... }`, and then defers to the more specific one.

Fixes rdar://173801709

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.