### PR TITLE
[6.3.2] Diagnose the use of a generic clause on `@Test`, `@Suite`, and `@Tag`.

### DIFF
--- a/Sources/TestingMacros/SuiteDeclarationMacro.swift
+++ b/Sources/TestingMacros/SuiteDeclarationMacro.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftDiagnostics
+import SwiftIfConfig
 public import SwiftSyntax
 import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
@@ -81,6 +82,11 @@ public struct SuiteDeclarationMacro: PeerMacro, Sendable {
       if suiteAttributes.count > 1 {
         diagnostics.append(.multipleAttributesNotSupported(suiteAttributes, on: declaration))
       }
+    }
+
+    // @Suite should not use a generic argument clause.
+    if let genericArgumentClause = suiteAttribute.genericArgumentClause {
+      diagnostics.append(.genericAttributeNotSupported(suiteAttribute, on: declaration, becauseOf: genericArgumentClause, languageMode: context.buildConfiguration?.languageVersion))
     }
 
     return !diagnostics.lazy.map(\.severity).contains(.error)

--- a/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
+++ b/Sources/TestingMacros/Support/Additions/WithAttributesSyntaxAdditions.swift
@@ -137,12 +137,14 @@ extension WithAttributesSyntax {
 }
 
 extension AttributeSyntax {
-  /// The text of this attribute's name.
-  var attributeNameText: String {
-    attributeName
-      .tokens(viewMode: .fixedUp)
-      .map(\.textWithoutBackticks)
-      .joined()
+  /// The generic argument clause of this attribute's name, if any.
+  var genericArgumentClause: GenericArgumentClauseSyntax? {
+    if let type = attributeName.as(IdentifierTypeSyntax.self) {
+      return type.genericArgumentClause
+    } else if let type = attributeName.as(MemberTypeSyntax.self) {
+      return type.genericArgumentClause
+    }
+    return nil
   }
 }
 

--- a/Sources/TestingMacros/Support/DiagnosticMessage.swift
+++ b/Sources/TestingMacros/Support/DiagnosticMessage.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftDiagnostics
+import SwiftIfConfig
 import SwiftParser
 import SwiftSyntax
 import SwiftSyntaxBuilder
@@ -76,8 +77,19 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
   /// - Returns: The name of the macro as understood by a developer, such as
   ///   `"'@Test'"`. Include single quotes.
   private static func _macroName(_ attribute: AttributeSyntax) -> String {
+    var attributeName = attribute.attributeName
+    if let type = attributeName.as(IdentifierTypeSyntax.self) {
+      attributeName = TypeSyntax(type.with(\.genericArgumentClause, nil))
+    } else if let type = attributeName.as(MemberTypeSyntax.self) {
+      attributeName = TypeSyntax(type.with(\.genericArgumentClause, nil))
+    }
+    let attributeNameText = attributeName
+      .tokens(viewMode: .fixedUp)
+      .map(\.textWithoutBackticks)
+      .joined()
+
     // SEE: https://github.com/swiftlang/swift/blob/main/docs/Diagnostics.md?plain=1#L44
-    "'\(attribute.attributeNameText)'"
+    return "'\(attributeNameText)'"
   }
 
   /// Get a string corresponding to the specified syntax node (for instance,
@@ -175,6 +187,39 @@ struct DiagnosticMessage: SwiftDiagnostics.DiagnosticMessage {
         syntax: syntax,
         message: "Attribute \(_macroName(attribute)) cannot be applied to a generic \(_kindString(for: decl))",
         severity: .error
+      )
+    }
+  }
+
+  /// Create a diagnostic message stating that the given attribute has an unused
+  /// generic argument clause (e.g. `@Test<T>`).
+  ///
+  /// - Parameters:
+  ///   - attribute: The `@Test` or `@Suite` attribute.
+  ///   - decl: The generic declaration in question.
+  ///   - genericClause: The child node on `attribute` that makes it generic.
+  ///
+  /// - Returns: A diagnostic message.
+  static func genericAttributeNotSupported(_ attribute: AttributeSyntax, on decl: some SyntaxProtocol, becauseOf genericClause: some SyntaxProtocol, languageMode: VersionTuple?) -> Self {
+    let fixIts: [FixIt] = [
+      FixIt(
+        message: MacroExpansionFixItMessage("Remove generic attribute clause from \(_macroName(attribute))"),
+        changes: [.replace(oldNode: Syntax(genericClause), newNode: Syntax("" as ExprSyntax))]
+      ),
+    ]
+    if let languageMode, languageMode >= .init(7, 0) {
+      return Self(
+        syntax: Syntax(genericClause),
+        message: "Generic argument clause of attribute \(_macroName(attribute)) is unsupported",
+        severity: .error,
+        fixIts: fixIts
+      )
+    } else {
+      return Self(
+        syntax: Syntax(genericClause),
+        message: "Generic argument clause of attribute \(_macroName(attribute)) is unsupported; this is an error in the Swift 7 language mode",
+        severity: .warning,
+        fixIts: fixIts
       )
     }
   }

--- a/Sources/TestingMacros/TagMacro.swift
+++ b/Sources/TestingMacros/TagMacro.swift
@@ -8,6 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+import SwiftIfConfig
 public import SwiftSyntax
 import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
@@ -44,6 +45,10 @@ public struct TagMacro: PeerMacro, AccessorMacro, Sendable {
     guard let type = context.typeOfLexicalContext else {
       context.diagnose(.nonMemberTagDeclarationNotSupported(variableDecl, whenUsing: node))
       return _fallbackAccessorDecls
+    }
+
+    if let genericArgumentClause = node.genericArgumentClause {
+      context.diagnose(.genericAttributeNotSupported(node, on: declaration, becauseOf: genericArgumentClause, languageMode: context.buildConfiguration?.languageVersion))
     }
 
     // Check that the tag is declared within Tag's namespace.

--- a/Sources/TestingMacros/TestDeclarationMacro.swift
+++ b/Sources/TestingMacros/TestDeclarationMacro.swift
@@ -9,6 +9,7 @@
 //
 
 import SwiftDiagnostics
+import SwiftIfConfig
 public import SwiftSyntax
 import SwiftSyntaxBuilder
 public import SwiftSyntaxMacros
@@ -128,6 +129,11 @@ public struct TestDeclarationMacro: PeerMacro, Sendable {
           diagnostics.append(.genericDeclarationNotSupported(function, whenUsing: testAttribute, becauseOf: parameter, on: function))
         }
       }
+    }
+
+    // @Test should not use a generic argument clause.
+    if let genericArgumentClause = testAttribute.genericArgumentClause {
+      diagnostics.append(.genericAttributeNotSupported(testAttribute, on: function, becauseOf: genericArgumentClause, languageMode: context.buildConfiguration?.languageVersion))
     }
 
     return !diagnostics.lazy.map(\.severity).contains(.error)

--- a/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
+++ b/Tests/TestingMacrosTests/TestDeclarationMacroTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 import SwiftBasicFormat
 import SwiftDiagnostics
+import SwiftIfConfig
 import SwiftParser
 import SwiftSyntax
 import SwiftSyntaxBuilder
@@ -348,6 +349,26 @@ struct TestDeclarationMacroTests {
           Issue.record("Change \(change) differs from expected change \(expectedChange)")
         }
       }
+    }
+  }
+
+  @Test("Error diagnostics emitted dependent on language mode",
+    arguments: [
+      ("@Suite<T> struct S {}", "Generic argument clause of attribute 'Suite' is unsupported; this is an error in the Swift 7 language mode", 6, DiagnosticSeverity.warning),
+      ("@Suite<T> struct S {}", "Generic argument clause of attribute 'Suite' is unsupported", 7, DiagnosticSeverity.error),
+      ("@Test<T> func f() {}", "Generic argument clause of attribute 'Test' is unsupported; this is an error in the Swift 7 language mode", 6, DiagnosticSeverity.warning),
+      ("@Test<T> func f() {}", "Generic argument clause of attribute 'Test' is unsupported", 7, DiagnosticSeverity.error),
+      ("extension Tag { @Tag<T> static var f: Self }", "Generic argument clause of attribute 'Tag' is unsupported; this is an error in the Swift 7 language mode", 6, DiagnosticSeverity.warning),
+      ("extension Tag { @Tag<T> static var f: Self }", "Generic argument clause of attribute 'Tag' is unsupported", 7, DiagnosticSeverity.error),
+    ]
+  )
+  func languageModeDependentDiagnostics(input: String, expectedMessage: String, languageMode: Int, severity: DiagnosticSeverity) throws {
+    let (_, diagnostics) = try parse(input, languageMode: VersionTuple(languageMode))
+
+    #expect(diagnostics.count > 0)
+    for diagnostic in diagnostics {
+      #expect(diagnostic.diagMessage.severity == severity)
+      #expect(diagnostic.message == expectedMessage)
     }
   }
 

--- a/Tests/TestingMacrosTests/TestSupport/Parse.swift
+++ b/Tests/TestingMacrosTests/TestSupport/Parse.swift
@@ -12,6 +12,7 @@
 
 import SwiftBasicFormat
 import SwiftDiagnostics
+import SwiftIfConfig
 import SwiftOperators
 import SwiftParser
 import SwiftSyntax
@@ -34,16 +35,20 @@ fileprivate let allMacros: [String: any (Macro & Sendable).Type] = [
   "__testing": PragmaMacro.self,
 ]
 
-func parse(_ sourceCode: String, activeMacros activeMacroNames: [String] = [], removeWhitespace: Bool = false) throws -> (sourceCode: String, diagnostics: [Diagnostic]) {
+func parse(_ sourceCode: String, activeMacros activeMacroNames: [String] = [], removeWhitespace: Bool = false, languageMode: VersionTuple? = nil) throws -> (sourceCode: String, diagnostics: [Diagnostic]) {
   let activeMacros: [String: any Macro.Type]
   if activeMacroNames.isEmpty {
     activeMacros = allMacros
   } else {
     activeMacros = allMacros.filter { activeMacroNames.contains($0.key) }
   }
+  var buildConfiguration: StaticBuildConfiguration?
+  if let languageMode {
+    buildConfiguration = StaticBuildConfiguration(languageVersion: languageMode, compilerVersion: VersionTuple(99, 0))
+  }
   let operatorTable = OperatorTable.standardOperators
   let originalSyntax = try operatorTable.foldAll(Parser.parse(source: sourceCode))
-  let context = BasicMacroExpansionContext(lexicalContext: [], expansionDiscriminator: "", sourceFiles: [:])
+  let context = BasicMacroExpansionContext(lexicalContext: [], expansionDiscriminator: "", sourceFiles: [:], buildConfiguration: buildConfiguration)
   let syntax = try operatorTable.foldAll(
     originalSyntax.expand(macros: activeMacros) { syntax in
       BasicMacroExpansionContext(sharingWith: context, lexicalContext: syntax.allMacroLexicalContexts())


### PR DESCRIPTION
- **Explanation**: Disallow (warn) the use of the generic clause syntax on our attribute macros as we never intended for them to work and they are not handled by the macro expansions.
- **Scope**: Macro expansion
- **Issues**: N/A
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1650
- **Risk**: Low (adds a warning)
- **Testing**: New unit test
- **Reviewers**: @stmontgomery @harlanhaskins