### PR TITLE
Update JSON.md to discuss issue severity/isFailure fields.

### DIFF
--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -214,6 +214,8 @@ sufficient information to display the event in a human-readable format.
 
 <issue> ::= {
   "isKnown": <bool>, ; is this a known issue or not?
+  "severity": <string>, ; the severity of the issue
+  "isFailure": <bool>, ; if the issue is a failing issue
   ["sourceLocation": <source-location>,] ; where the issue occurred, if known
 }
 
@@ -243,7 +245,7 @@ sufficient information to display the event in a human-readable format.
 |:-|-|-:|-:|
 | [ST-0002](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0002-json-abi.md) | Introduced the initial version of this JSON schema. | 6.0 | `0` |
 | [ST-0009](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0009-attachments.md#integration-with-supporting-tools) | Added attachments. | 6.2 | `0` |
-| [ST-0013](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0013-issue-severity-warning.md#event-stream) | Added test issue severity. | 6.3 | `"6.3"` |
+| [ST-0013](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0013-issue-severity-warning.md#event-stream) | Added test issue `severity` and `isFailure`. | 6.3 | `"6.3"` |
 | [ST-0016](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0016-test-cancellation.md#integration-with-supporting-tools) | Added test cancellation. | 6.3 | `"6.3"` |
 | [ST-0019](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0019-include-tags-bugs-and-timeline-in-event-stream.md#json-schema-changes) | Added `tags`, `bugs`, and `timeLimit`. | 6.4 | `"6.4"` |
 | [ST-0020](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0020-sourcelocation-filepath.md#detailed-design) | Added `filePath`. | 6.3 | `"6.3"` |


### PR DESCRIPTION
These fields were added in Swift 6.3 but we neglected to update JSON.md to describe them.

The fields are optional because they are not present prior to the 6.3 schema version.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
