### PR TITLE
Export SwiftTesting_{BUILD_DIR,MACRO_PATH} in CMake

### DIFF
--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -127,3 +127,8 @@ if(SwiftTesting_BuildMacrosAsExecutables)
   target_link_libraries(TestingMacros PRIVATE
     SwiftSyntax::SwiftCompilerPlugin)
 endif()
+
+# Makes SwiftTesting_MACRO_DIR available after find_package(SwiftTestingMacros)
+file(GENERATE
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cmake/modules/SwiftTestingMacrosConfig.cmake"
+  CONTENT "get_filename_component(SwiftTesting_MACRO_DIR \"$<TARGET_FILE:TestingMacros>\" DIRECTORY)\n")

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -6,6 +6,7 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+set(SwiftTesting_BUILD_DIR "${CMAKE_BINARY_DIR}") # Exported by SwiftTestingConfig
 set(SwiftTesting_EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/SwiftTestingExports.cmake)
 
 configure_file(SwiftTestingConfig.cmake.in

--- a/cmake/modules/SwiftTestingConfig.cmake.in
+++ b/cmake/modules/SwiftTestingConfig.cmake.in
@@ -8,6 +8,8 @@
 ## See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 ##
 
+set(SwiftTesting_BUILD_DIR "@SwiftTesting_BUILD_DIR@")
+
 if(NOT TARGET _TestingInterop)
   include(@SwiftTesting_EXPORTS_FILE@)
 endif()


### PR DESCRIPTION
### Motivation:

These are consumed by XCTest when building lit tests in
https://github.com/swiftlang/swift-corelibs-xctest/pull/538

### Modifications:

* Export SwiftTesting_BUILD_DIR in SwiftTestingConfig

* Export SwiftTesting_MACRO_PATH in SwiftTestingMacrosConfig

  SwiftTestingMacrosConfig is a new module exported in this change.

  Note we can't export this as part of SwiftTestingConfig, because we
  set SwiftTesting_MACRO=NO when building the Testing project for Linux,
  so there is no macro path available.


### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
