### PR TITLE
Revert "Avoid hanging trying to diff `Data` and similar collections. (#1644)"

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -667,34 +667,6 @@ public func __checkBinaryOperation(
 /// Check that an expectation has passed after a condition has been evaluated
 /// and throw an error if it failed.
 ///
-/// This overload is necessary because collections whose elements are of type
-/// `UInt8` or `Int8` tend to be raw data and diffing them can be very slow
-/// while also not producing useful, readable output.
-///
-/// - Warning: This function is used to implement the `#expect()` and
-///   `#require()` macros. Do not call it directly.
-public func __checkBinaryOperation<T, U>(
-  _ lhs: T, _ op: (T, () -> U) -> Bool, _ rhs: @autoclosure () -> U,
-  expression: __Expression,
-  comments: @autoclosure () -> [Comment],
-  isRequired: Bool,
-  sourceLocation: SourceLocation
-) -> Result<Void, any Error> where T: Collection, U: Collection, T.Element == U.Element, T.Element: BinaryInteger, T.Element.Magnitude == UInt8 {
-  let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
-  return __checkValue(
-    condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, rhs),
-    difference: nil,
-    comments: comments(),
-    isRequired: isRequired,
-    sourceLocation: sourceLocation
-  )
-}
-
-/// Check that an expectation has passed after a condition has been evaluated
-/// and throw an error if it failed.
-///
 /// This overload is necessary because ranges are collections and satisfy the
 /// requirements for the difference-calculating overload above, but it doesn't
 /// make sense to diff them and very large ranges can cause overflows or hangs.

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1288,26 +1288,6 @@ final class IssueTests: XCTestCase {
     }.run(configuration: configuration)
   }
 
-  func testCollectionDifferenceSkippedForByteCollections() async {
-    var configuration = Configuration()
-    configuration.eventHandler = { event, _ in
-      guard case let .issueRecorded(issue) = event.kind else {
-        return
-      }
-      guard case let .expectationFailed(expectation) = issue.kind else {
-        XCTFail("Unexpected issue kind \(issue.kind)")
-        return
-      }
-      XCTAssertNil(expectation.differenceDescription)
-    }
-
-    await Test {
-      let lhs = [1, 2, 3] as [UInt8]
-      let rhs = [4, 5, 6] as [UInt8]
-      #expect(lhs == rhs)
-    }.run(configuration: configuration)
-  }
-
   func testCollectionDifferenceSkippedForRanges() async {
     var configuration = Configuration()
     configuration.eventHandler = { event, _ in


### PR DESCRIPTION
This reverts the change recently made in #1644. It ended up causing slow type-checking of certain complex expressions passed to `#expect`, such as [this one](https://github.com/swiftlang/swift-build/blob/48e5c4ff4f37aa6ce2c85b5ff1e8600fe809b722/Tests/SWBBuildSystemTests/BuildTaskBehaviorTests.swift#L1079) in particular in the swift-build project:

```swift
#expect(output.unsafeStringValue.split(separator: "\n").map({ $0.split("=").0 }).sorted().filter { $0 != "VCToolsInstallDir" && !$0.hasPrefix("ANDROID_") && !$0.hasPrefix("QNX_") } == [
    "LLBUILD_BUILD_ID", "LLBUILD_CONTROL_FD", "LLBUILD_LANE_ID", "LLBUILD_TASK_ID"
])
```

It appears the new `__checkBinaryOperation()` overload added in that PR caused type-checking to become more complex and slower for complex expressions such as this. It may be possible to implement an alternate approach for this which checks the type at runtime only, to avoid needing an additional overload.

Related to: rdar://173002947

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
