### PR TITLE
Provide @_spi for decoding EncodedTest.ID -> Test.ID

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -215,13 +215,13 @@ extension Test {
   /// - Returns: On success, an instance of ``TypeInfo`` describing the suite
   ///   type containing or equalling `test`. On failure, `nil`.
   private static func _makeTypeInfo<V>(for test: ABI.EncodedTest<V>) -> TypeInfo? {
-    guard let (module, suiteComponents, _) = test.decodeComponents() else {
+    guard let (module, suiteComponents, _) = test.decodeIDComponents() else {
       return nil
     }
 
     // Recombine the module name with the rest of the test ID to produce the
     // fully-qualified type name. Join everything by slashes.
-    let testIDComponents = [module] + suiteComponents
+    let testIDComponents = CollectionOfOne(module) + suiteComponents
     return TypeInfo(fullyQualifiedNameComponents: testIDComponents.map(String.init))
   }
 
@@ -294,26 +294,23 @@ extension Test {
 extension Test.ID {
   /// Initialize an instance of this type from the given value.
   ///
-  /// This uses the test id, test kind, and source location fields to recreate
+  /// This uses the test ID, test kind, and source location fields to recreate
   /// the ID.
   ///
   /// - Parameters:
   ///   - test: The encoded test to initialize this instance from.
-  ///
   public init?<V>(decoding test: ABI.EncodedTest<V>) {
     guard
-      let (module, suiteComponents, function) = test.decodeComponents(),
+      let (module, suiteComponents, function) = test.decodeIDComponents(),
       let sourceLocation = SourceLocation(decoding: test.sourceLocation)
     else {
       return nil
     }
 
-    let nameComponents =
-      if let function {
-        suiteComponents + [function]
-      } else {
-        suiteComponents
-      }
+    var nameComponents = suiteComponents
+    if let function {
+      nameComponents.append(function)
+    }
     self.init(
       moduleName: String(module), nameComponents: nameComponents.map(String.init),
       sourceLocation: sourceLocation)
@@ -322,6 +319,10 @@ extension Test.ID {
 
 extension ABI.EncodedTest {
   /// Extract module and component information from a Test ID description.
+  ///
+  /// - Returns: On success, the module and suite components for the described
+  ///   test. If the encoded test is a function, extract the function name
+  ///   separately. On failure, `nil`.
   ///
   /// If the encoded test is a function:
   /// * Trim source location if detected from the end of the components. If you
@@ -335,12 +336,10 @@ extension ABI.EncodedTest {
   ///   ModuleFoo.BarLibraryTests/testBaz()/BazTests.swift:10:1
   ///             ^^^^^^^^^^^^^^^           ^^^^^^^^^^^^^^^^^^^
   ///             <suiteComponents>             discarded!
-  ///
-  /// - Returns: On success, the module and suite components for the described
-  ///   Test. If the encoded test is a function, extract the function name
-  ///   separately. On failure, `nil`.
-  func decodeComponents() -> (
-    module: String.SubSequence, suiteComponents: [String.SubSequence], function: String.SubSequence?
+  func decodeIDComponents() -> (
+    module: Substring,
+    suiteComponents: [Substring],
+    function: Substring?
   )? {
     // Find the module name, which for XCTest compatibility is split from the
     // rest of the test ID by a period character instead of a slash character.
@@ -357,12 +356,12 @@ extension ABI.EncodedTest {
     }
 
     // Replace the first component string, which is currently shaped like
-    // "ModuleName.TypeName", with ["TypeName"]
-    // This slice below returns ".TypeName", so dropFirst() to remove the leading dot
+    // "ModuleName.TypeName", with ["TypeName"]. This slice below returns
+    // ".TypeName", so dropFirst() to remove the leading dot.
     let secondTestIDComponent = testID[moduleName.endIndex..<firstComponent.endIndex].dropFirst()
     testIDComponents[0] = secondTestIDComponent
 
-    var function: String.SubSequence?
+    var function: Substring?
     if kind == .function {
       if let lastComponent = testIDComponents.last?.utf8,
         lastComponent.first != UInt8(ascii: "`"),

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -215,42 +215,13 @@ extension Test {
   /// - Returns: On success, an instance of ``TypeInfo`` describing the suite
   ///   type containing or equalling `test`. On failure, `nil`.
   private static func _makeTypeInfo<V>(for test: ABI.EncodedTest<V>) -> TypeInfo? {
-    // Find the module name, which for XCTest compatibility is split from the
-    // rest of the test ID by a period character instead of a slash character.
-    let testID = test.id.stringValue
-    let splitByPeriod = rawIdentifierAwareSplit(testID, separator: ".", maxSplits: 1)
-    var testIDComponents = rawIdentifierAwareSplit(testID, separator: "/")
-    guard let moduleName = splitByPeriod.first,
-          let firstComponent = testIDComponents.first,
-          moduleName.endIndex < firstComponent.endIndex else {
-      // The string wasn't structured as expected for a Swift Testing or XCTest
-      // test ID.
+    guard let (module, suiteComponents, _) = test.decodeComponents() else {
       return nil
-    }
-
-    // Replace the first component string, which is currently shaped like
-    // "ModuleName.TypeName", with ["ModuleName", "TypeName"]
-    let secondTestIDComponent = testID[moduleName.endIndex ..< firstComponent.endIndex].dropFirst()
-    testIDComponents[0] = moduleName
-    testIDComponents.insert(secondTestIDComponent, at: 1)
-
-    if test.kind == .function {
-      if let lastComponent = testIDComponents.last?.utf8,
-         lastComponent.first != UInt8(ascii: "`"),
-         lastComponent.contains(UInt8(ascii: ":")) {
-        // The last component of the test ID (when split by slash characters)
-        // appears to be a source location. Remove it as it's not part of the
-        // suite type.
-        testIDComponents.removeLast()
-      }
-
-      // The last component of the test ID is the name of the test function.
-      // Remove that too.
-      testIDComponents.removeLast()
     }
 
     // Recombine the module name with the rest of the test ID to produce the
     // fully-qualified type name. Join everything by slashes.
+    let testIDComponents = [module] + suiteComponents
     return TypeInfo(fullyQualifiedNameComponents: testIDComponents.map(String.init))
   }
 
@@ -316,5 +287,96 @@ extension Test {
         parameters: parameters ?? []
       )
     }
+  }
+}
+
+@_spi(ForToolsIntegrationOnly)
+extension Test.ID {
+  /// Initialize an instance of this type from the given value.
+  ///
+  /// This uses the test id, test kind, and source location fields to recreate
+  /// the ID.
+  ///
+  /// - Parameters:
+  ///   - test: The encoded test to initialize this instance from.
+  ///
+  public init?<V>(decoding test: ABI.EncodedTest<V>) {
+    guard
+      let (module, suiteComponents, function) = test.decodeComponents(),
+      let sourceLocation = SourceLocation(decoding: test.sourceLocation)
+    else {
+      return nil
+    }
+
+    let nameComponents =
+      if let function {
+        suiteComponents + [function]
+      } else {
+        suiteComponents
+      }
+    self.init(
+      moduleName: String(module), nameComponents: nameComponents.map(String.init),
+      sourceLocation: sourceLocation)
+  }
+}
+
+extension ABI.EncodedTest {
+  /// Extract module and component information from a Test ID description.
+  ///
+  /// If the encoded test is a function:
+  /// * Trim source location if detected from the end of the components. If you
+  /// need the source location information, decode it from the encoded
+  /// `sourceLocation` property directly.
+  /// * Returns the function name as a separate component.
+  ///
+  /// For example:
+  ///   <module>                  <function>
+  ///   vvvvvvvvv                 vvvvvvvvv
+  ///   ModuleFoo.BarLibraryTests/testBaz()/BazTests.swift:10:1
+  ///             ^^^^^^^^^^^^^^^           ^^^^^^^^^^^^^^^^^^^
+  ///             <suiteComponents>             discarded!
+  ///
+  /// - Returns: On success, the module and suite components for the described
+  ///   Test. If the encoded test is a function, extract the function name
+  ///   separately. On failure, `nil`.
+  func decodeComponents() -> (
+    module: String.SubSequence, suiteComponents: [String.SubSequence], function: String.SubSequence?
+  )? {
+    // Find the module name, which for XCTest compatibility is split from the
+    // rest of the test ID by a period character instead of a slash character.
+    let testID = id.stringValue
+    let splitByPeriod = rawIdentifierAwareSplit(testID, separator: ".", maxSplits: 1)
+    var testIDComponents = rawIdentifierAwareSplit(testID, separator: "/")
+    guard let moduleName = splitByPeriod.first,
+      let firstComponent = testIDComponents.first,
+      moduleName.endIndex < firstComponent.endIndex
+    else {
+      // The string wasn't structured as expected for a Swift Testing or XCTest
+      // test ID.
+      return nil
+    }
+
+    // Replace the first component string, which is currently shaped like
+    // "ModuleName.TypeName", with ["TypeName"]
+    // This slice below returns ".TypeName", so dropFirst() to remove the leading dot
+    let secondTestIDComponent = testID[moduleName.endIndex..<firstComponent.endIndex].dropFirst()
+    testIDComponents[0] = secondTestIDComponent
+
+    var function: String.SubSequence?
+    if kind == .function {
+      if let lastComponent = testIDComponents.last?.utf8,
+        lastComponent.first != UInt8(ascii: "`"),
+        lastComponent.contains(UInt8(ascii: ":"))
+      {
+        // The last component of the test ID (when split by slash characters)
+        // appears to be a source location. Remove it as it's not part of the
+        // suite type.
+        testIDComponents.removeLast()
+      }
+
+      function = testIDComponents.removeLast()
+    }
+
+    return (moduleName, testIDComponents, function)
   }
 }

--- a/Tests/TestingTests/ABI.EncodedTestTests.swift
+++ b/Tests/TestingTests/ABI.EncodedTestTests.swift
@@ -34,7 +34,7 @@ private import Foundation
     var test = fixture
     test.id = try testID("Module.FooTests/testFunc()")
 
-    let (module, components, function) = try #require(test.decodeComponents())
+    let (module, components, function) = try #require(test.decodeIDComponents())
     #expect(module == "Module")
     #expect(components == ["FooTests"])
     #expect(function == "testFunc()")
@@ -45,7 +45,7 @@ private import Foundation
     test.kind = .suite
     test.id = try testID("Module.FooTests")
 
-    let (module, components, function) = try #require(test.decodeComponents())
+    let (module, components, function) = try #require(test.decodeIDComponents())
     #expect(module == "Module")
     #expect(components == ["FooTests"])
     #expect(function == nil)
@@ -55,7 +55,7 @@ private import Foundation
     var test = fixture
     test.id = try testID("Module.FooTests/testFunc()/FooTests.swift:1:10")
 
-    let (_, components, _) = try #require(test.decodeComponents())
+    let (_, components, _) = try #require(test.decodeIDComponents())
     #expect(components == ["FooTests"])
   }
 
@@ -66,24 +66,24 @@ private import Foundation
       ["`foo.swift:1:1`"], "`test foo.swift:1:1`()"
     ),
   ]) func `Handles raw identifiers`(
-    id: String, components: [String.SubSequence], function: String.SubSequence
+    id: String, components: [Substring], function: Substring
   ) throws {
     var test = fixture
     test.id = try testID(id)
 
-    let actual = try #require(test.decodeComponents())
+    let actual = try #require(test.decodeIDComponents())
     #expect(actual == ("Module", components, .some(function)))
   }
 
   @Test(arguments: [
     ("Module.ImNot.AModule/Foo", ["ImNot.AModule", "Foo"]),  // Dotted components are allowed
     ("Module.", [""]),  // Module specified with empty components
-  ]) func `Weird but supported formats`(id: String, components: [String.SubSequence]) throws {
+  ]) func `Weird but supported formats`(id: String, components: [Substring]) throws {
     var test = fixture
     test.kind = .suite
     test.id = try testID(id)
 
-    let actual = try #require(test.decodeComponents())
+    let actual = try #require(test.decodeIDComponents())
     #expect(actual == ("Module", components, nil))
   }
 
@@ -96,6 +96,6 @@ private import Foundation
     test.kind = .suite
     test.id = try testID(invalidTestID)
 
-    #expect(test.decodeComponents() == nil)
+    #expect(test.decodeIDComponents() == nil)
   }
 }

--- a/Tests/TestingTests/ABI.EncodedTestTests.swift
+++ b/Tests/TestingTests/ABI.EncodedTestTests.swift
@@ -1,0 +1,101 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+#if canImport(Foundation)
+private import Foundation
+#endif
+
+@Suite struct `ABI.EncodedTestTests` {
+  let fixture = ABI.EncodedTest<ABI.CurrentVersion>(
+    kind: .function,
+    name: "TestName",
+    sourceLocation: .init(),
+    id: .init(encoding: .init([])))  // Blank placeholder; should be set in each test case
+
+  /// Creates an EncodedTest.ID from a string.
+  ///
+  /// It doesn't really "decode" anything and just stores the string, so this
+  /// should never throw in practice.
+  func testID<V: ABI.Version>(_ string: String) throws -> ABI.EncodedTest<V>.ID {
+    let data = try JSONEncoder().encode(string)
+    return try JSONDecoder().decode(ABI.EncodedTest<V>.ID.self, from: data)
+  }
+
+  @Test func `Decode test components`() throws {
+    var test = fixture
+    test.id = try testID("Module.FooTests/testFunc()")
+
+    let (module, components, function) = try #require(test.decodeComponents())
+    #expect(module == "Module")
+    #expect(components == ["FooTests"])
+    #expect(function == "testFunc()")
+  }
+
+  @Test func `Decode suite components`() throws {
+    var test = fixture
+    test.kind = .suite
+    test.id = try testID("Module.FooTests")
+
+    let (module, components, function) = try #require(test.decodeComponents())
+    #expect(module == "Module")
+    #expect(components == ["FooTests"])
+    #expect(function == nil)
+  }
+
+  @Test func `Discards source location`() throws {
+    var test = fixture
+    test.id = try testID("Module.FooTests/testFunc()/FooTests.swift:1:10")
+
+    let (_, components, _) = try #require(test.decodeComponents())
+    #expect(components == ["FooTests"])
+  }
+
+  @Test(arguments: [
+    ("Module.`Foo Tests`/`test foo`()/FooTests.swift:1:10", ["`Foo Tests`"], "`test foo`()"),
+    (
+      "Module.`foo.swift:1:1`/`test foo.swift:1:1`()/FooTests.swift:1:10",
+      ["`foo.swift:1:1`"], "`test foo.swift:1:1`()"
+    ),
+  ]) func `Handles raw identifiers`(
+    id: String, components: [String.SubSequence], function: String.SubSequence
+  ) throws {
+    var test = fixture
+    test.id = try testID(id)
+
+    let actual = try #require(test.decodeComponents())
+    #expect(actual == ("Module", components, .some(function)))
+  }
+
+  @Test(arguments: [
+    ("Module.ImNot.AModule/Foo", ["ImNot.AModule", "Foo"]),  // Dotted components are allowed
+    ("Module.", [""]),  // Module specified with empty components
+  ]) func `Weird but supported formats`(id: String, components: [String.SubSequence]) throws {
+    var test = fixture
+    test.kind = .suite
+    test.id = try testID(id)
+
+    let actual = try #require(test.decodeComponents())
+    #expect(actual == ("Module", components, nil))
+  }
+
+  @Test(arguments: [
+    "MyTests/Foo",  // Missing module
+    "",  // Empty test ID
+    "ModuleA",  // Module only
+  ]) func `Fails to decode invalid formats`(invalidTestID: String) throws {
+    var test = fixture
+    test.kind = .suite
+    test.id = try testID(invalidTestID)
+
+    #expect(test.decodeComponents() == nil)
+  }
+}


### PR DESCRIPTION
### Motivation:

This is a subtask for decoding EncodedEvent -> Event: it requires decoding EncodedTest.ID -> Test.ID

### Modifications:

* Extract a helper decodeComponents() from within the existing _makeTypeInfo() that splits components from an EncodedTest

* Implement and test Test.ID decoding using the new helper

Resolves rdar://174177181