### PR TITLE
Avoid unknown platform warning when setting Embedded-related defines which lack a non-Embedded fallback condition

### DIFF
--- a/Documentation/Porting.md
+++ b/Documentation/Porting.md
@@ -68,8 +68,8 @@ platform-specific attention.
 > without also enabling support for file I/O.) You should be able to resolve
 > these issues by updating `Package.swift` and/or `CompilerSettings.cmake`.
 >
-> Don't forget to add your platform to the `BuildSettingCondition/whenApple(_:)`
-> function in `Package.swift`.
+> Don't forget to add your platform to the
+> `BuildSettingCondition/nonApplePlatforms` property in `Package.swift`.
 
 Most platform dependencies can be resolved through the use of platform-specific
 API. For example, Swift Testing uses the C11 standard [`timespec`](https://en.cppreference.com/w/c/chrono/timespec)

--- a/Package.swift
+++ b/Package.swift
@@ -319,30 +319,6 @@ package.targets.append(contentsOf: [
 #endif
 
 extension BuildSettingCondition {
-  /// Creates a build setting condition that evaluates to `true` for Embedded
-  /// Swift.
-  ///
-  /// - Parameters:
-  ///   - nonEmbeddedCondition: The value to return if the target is not
-  ///     Embedded Swift. If `nil`, the build condition evaluates to `false`.
-  ///
-  /// - Returns: A build setting condition that evaluates to `true` for Embedded
-  ///   Swift or is equal to `nonEmbeddedCondition` for non-Embedded Swift.
-  static func whenEmbedded(or nonEmbeddedCondition: @autoclosure () -> Self? = nil) -> Self? {
-    if !buildingForEmbedded {
-      if let nonEmbeddedCondition = nonEmbeddedCondition() {
-        nonEmbeddedCondition
-      } else {
-        // The caller did not supply a fallback. Specify a non-existent platform
-        // to ensure this condition never matches.
-        .when(platforms: [.custom("DoesNotExist")])
-      }
-    } else {
-      // Enable unconditionally because the target is Embedded Swift.
-      nil
-    }
-  }
-
   /// A build setting condition representing all Apple or non-Apple platforms.
   ///
   /// - Parameters:
@@ -402,19 +378,9 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .define("SWT_NO_LIBRARY_MACRO_PLUGINS"),
 
       .define("SWT_TARGET_OS_APPLE", .whenApple()),
-
-      .define("SWT_NO_EXIT_TESTS", .whenEmbedded(or: .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android]))),
-      .define("SWT_NO_PROCESS_SPAWNING", .whenEmbedded(or: .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android]))),
-      .define("SWT_NO_SNAPSHOT_TYPES", .whenEmbedded(or: .whenApple(false))),
-      .define("SWT_NO_DYNAMIC_LINKING", .whenEmbedded(or: .when(platforms: [.wasi]))),
-      .define("SWT_NO_PIPES", .whenEmbedded(or: .when(platforms: [.wasi]))),
-      .define("SWT_NO_FOUNDATION_FILE_COORDINATION", .whenEmbedded(or: .whenApple(false))),
-      .define("SWT_NO_IMAGE_ATTACHMENTS", .whenEmbedded(or: .when(platforms: [.linux, .custom("freebsd"), .openbsd, .wasi, .android]))),
-      .define("SWT_NO_FILE_CLONING", .whenEmbedded(or: .when(platforms: [.openbsd, .wasi, .android]))),
-
-      .define("SWT_NO_LEGACY_TEST_DISCOVERY", .whenEmbedded()),
-      .define("SWT_NO_LIBDISPATCH", .whenEmbedded()),
     ]
+
+    result.appendEmbeddedRelatedDefines()
 
     return result
   }
@@ -493,19 +459,7 @@ extension Array where Element == PackageDescription.CXXSetting {
       ]
     }
 
-    result += [
-      .define("SWT_NO_EXIT_TESTS", .whenEmbedded(or: .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android]))),
-      .define("SWT_NO_PROCESS_SPAWNING", .whenEmbedded(or: .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android]))),
-      .define("SWT_NO_SNAPSHOT_TYPES", .whenEmbedded(or: .whenApple(false))),
-      .define("SWT_NO_DYNAMIC_LINKING", .whenEmbedded(or: .when(platforms: [.wasi]))),
-      .define("SWT_NO_PIPES", .whenEmbedded(or: .when(platforms: [.wasi]))),
-      .define("SWT_NO_FOUNDATION_FILE_COORDINATION", .whenEmbedded(or: .whenApple(false))),
-      .define("SWT_NO_IMAGE_ATTACHMENTS", .whenEmbedded(or: .when(platforms: [.linux, .custom("freebsd"), .openbsd, .wasi, .android]))),
-      .define("SWT_NO_FILE_CLONING", .whenEmbedded(or: .when(platforms: [.openbsd, .wasi, .android]))),
-
-      .define("SWT_NO_LEGACY_TEST_DISCOVERY", .whenEmbedded()),
-      .define("SWT_NO_LIBDISPATCH", .whenEmbedded()),
-    ]
+    result.appendEmbeddedRelatedDefines()
 
     // Capture the testing library's commit info as C++ constants.
     if let git {
@@ -520,5 +474,62 @@ extension Array where Element == PackageDescription.CXXSetting {
     }
 
     return result
+  }
+}
+
+extension Array where Element: _LanguageBuildSetting {
+  /// Append defines which are conditionalized for the Embedded language mode.
+  mutating func appendEmbeddedRelatedDefines() {
+    // The list of Embedded-related defines to set.
+    let defines: [String: BuildSettingCondition?] = [
+      "SWT_NO_EXIT_TESTS": .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android]),
+      "SWT_NO_PROCESS_SPAWNING": .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android]),
+      "SWT_NO_SNAPSHOT_TYPES": .whenApple(false),
+      "SWT_NO_DYNAMIC_LINKING": .when(platforms: [.wasi]),
+      "SWT_NO_PIPES": .when(platforms: [.wasi]),
+      "SWT_NO_FOUNDATION_FILE_COORDINATION": .whenApple(false),
+      "SWT_NO_IMAGE_ATTACHMENTS": .when(platforms: [.linux, .custom("freebsd"), .openbsd, .wasi, .android]),
+      "SWT_NO_FILE_CLONING": .when(platforms: [.openbsd, .wasi, .android]),
+
+      "SWT_NO_LEGACY_TEST_DISCOVERY": nil,
+      "SWT_NO_LIBDISPATCH": nil,
+    ]
+
+    for (name, condition) in defines {
+      if !buildingForEmbedded {
+        if let condition {
+          append(.define(name, condition))
+        } else {
+          // Since there was no condition and we're not building for Embedded,
+          // the intention was to never match so don't append this define.
+        }
+      } else {
+        // Since we're building for Embedded, append this define unconditionally.
+        append(.define(name, nil))
+      }
+    }
+  }
+}
+
+/// A protocol representing a setting for a package target.
+///
+/// This abstraction facilitates utilities which simplify specifying common
+/// settings across targets of different language types.
+private protocol _LanguageBuildSetting {
+  /// Defines a value for a macro.
+  ///
+  /// - Parameters:
+  ///   - name: The name of the macro.
+  ///   - condition: A condition that restricts the application of the build
+  ///     setting.
+  ///
+  /// - Returns: An instance of this setting.
+  static func define(_ name: String, _ condition: BuildSettingCondition?) -> Self
+}
+
+extension PackageDescription.SwiftSetting: _LanguageBuildSetting {}
+extension PackageDescription.CXXSetting: _LanguageBuildSetting {
+  static func define(_ name: String, _ condition: BuildSettingCondition?) -> Self {
+    .define(name, to: nil, condition)
   }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -327,24 +327,16 @@ extension BuildSettingCondition {
   /// - Returns: A build setting condition that evaluates to `isApple` for Apple
   ///   platforms.
   static func whenApple(_ isApple: Bool = true) -> Self {
-    .when(platforms: .applePlatforms(isApple))
+    .when(platforms: isApple ? .applePlatforms : .nonApplePlatforms)
   }
 }
 
 extension Array where Element == PackageDescription.Platform {
-  /// An array representing all Apple or non-Apple platforms.
-  ///
-  /// - Parameters:
-  ///   - isApple: Whether or not the result represents Apple platforms.
-  ///
-  /// - Returns: An array containing the requested platforms.
-  static func applePlatforms(_ isApple: Bool = true) -> Self {
-    if isApple {
-      [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS]
-    } else {
-      [.linux, .custom("freebsd"), .openbsd, .windows, .wasi, .android]
-    }
-  }
+  /// All Apple platforms.
+  static let applePlatforms: Self = [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS]
+
+  /// All non-Apple platforms.
+  static let nonApplePlatforms: Self = [.linux, .custom("freebsd"), .openbsd, .windows, .wasi, .android]
 }
 
 extension Array where Element == PackageDescription.SwiftSetting {
@@ -502,10 +494,10 @@ extension Array where Element: _LanguageBuildSetting {
     let defines: [String: (platforms: [Platform]?, embedded: Bool)] = [
       "SWT_NO_EXIT_TESTS": (platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android], embedded: true),
       "SWT_NO_PROCESS_SPAWNING": (platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android], embedded: true),
-      "SWT_NO_SNAPSHOT_TYPES": (platforms: .applePlatforms(false), embedded: true),
+      "SWT_NO_SNAPSHOT_TYPES": (platforms: .nonApplePlatforms, embedded: true),
       "SWT_NO_DYNAMIC_LINKING": (platforms: [.wasi], embedded: true),
       "SWT_NO_PIPES": (platforms: [.wasi], embedded: true),
-      "SWT_NO_FOUNDATION_FILE_COORDINATION": (platforms: .applePlatforms(false), embedded: true),
+      "SWT_NO_FOUNDATION_FILE_COORDINATION": (platforms: .nonApplePlatforms, embedded: true),
       "SWT_NO_IMAGE_ATTACHMENTS": (platforms: [.linux, .custom("freebsd"), .openbsd, .wasi, .android], embedded: true),
       "SWT_NO_FILE_CLONING": (platforms: [.openbsd, .wasi, .android], embedded: true),
 

--- a/Package.swift
+++ b/Package.swift
@@ -327,10 +327,22 @@ extension BuildSettingCondition {
   /// - Returns: A build setting condition that evaluates to `isApple` for Apple
   ///   platforms.
   static func whenApple(_ isApple: Bool = true) -> Self {
+    .when(platforms: .applePlatforms(isApple))
+  }
+}
+
+extension Array where Element == PackageDescription.Platform {
+  /// An array representing all Apple or non-Apple platforms.
+  ///
+  /// - Parameters:
+  ///   - isApple: Whether or not the result represents Apple platforms.
+  ///
+  /// - Returns: An array containing the requested platforms.
+  static func applePlatforms(_ isApple: Bool = true) -> Self {
     if isApple {
-      .when(platforms: [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS])
+      [.macOS, .iOS, .macCatalyst, .watchOS, .tvOS, .visionOS]
     } else {
-      .when(platforms: [.linux, .custom("freebsd"), .openbsd, .windows, .wasi, .android])
+      [.linux, .custom("freebsd"), .openbsd, .windows, .wasi, .android]
     }
   }
 }
@@ -380,7 +392,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .define("SWT_TARGET_OS_APPLE", .whenApple()),
     ]
 
-    result.appendEmbeddedRelatedDefines()
+    result.appendFeatureFlags()
 
     return result
   }
@@ -459,7 +471,7 @@ extension Array where Element == PackageDescription.CXXSetting {
       ]
     }
 
-    result.appendEmbeddedRelatedDefines()
+    result.appendFeatureFlags()
 
     // Capture the testing library's commit info as C++ constants.
     if let git {
@@ -478,33 +490,40 @@ extension Array where Element == PackageDescription.CXXSetting {
 }
 
 extension Array where Element: _LanguageBuildSetting {
-  /// Append defines which are conditionalized for the Embedded language mode.
-  mutating func appendEmbeddedRelatedDefines() {
-    // The list of Embedded-related defines to set.
-    let defines: [String: BuildSettingCondition?] = [
-      "SWT_NO_EXIT_TESTS": .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android]),
-      "SWT_NO_PROCESS_SPAWNING": .when(platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android]),
-      "SWT_NO_SNAPSHOT_TYPES": .whenApple(false),
-      "SWT_NO_DYNAMIC_LINKING": .when(platforms: [.wasi]),
-      "SWT_NO_PIPES": .when(platforms: [.wasi]),
-      "SWT_NO_FOUNDATION_FILE_COORDINATION": .whenApple(false),
-      "SWT_NO_IMAGE_ATTACHMENTS": .when(platforms: [.linux, .custom("freebsd"), .openbsd, .wasi, .android]),
-      "SWT_NO_FILE_CLONING": .when(platforms: [.openbsd, .wasi, .android]),
+  /// Append defines for feature flags.
+  mutating func appendFeatureFlags() {
+    // The list of defines to set. Each may have associated conditions:
+    //
+    // - platforms: The list of platforms, if any, to include in a build setting
+    //   condition for this define.
+    // - embedded: Whether this define should be set unconditionally when
+    //   building for Embedded. (This is not currently expressible as a build
+    //   setting conditional.)
+    let defines: [String: (platforms: [Platform]?, embedded: Bool)] = [
+      "SWT_NO_EXIT_TESTS": (platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android], embedded: true),
+      "SWT_NO_PROCESS_SPAWNING": (platforms: [.iOS, .watchOS, .tvOS, .visionOS, .wasi, .android], embedded: true),
+      "SWT_NO_SNAPSHOT_TYPES": (platforms: .applePlatforms(false), embedded: true),
+      "SWT_NO_DYNAMIC_LINKING": (platforms: [.wasi], embedded: true),
+      "SWT_NO_PIPES": (platforms: [.wasi], embedded: true),
+      "SWT_NO_FOUNDATION_FILE_COORDINATION": (platforms: .applePlatforms(false), embedded: true),
+      "SWT_NO_IMAGE_ATTACHMENTS": (platforms: [.linux, .custom("freebsd"), .openbsd, .wasi, .android], embedded: true),
+      "SWT_NO_FILE_CLONING": (platforms: [.openbsd, .wasi, .android], embedded: true),
 
-      "SWT_NO_LEGACY_TEST_DISCOVERY": nil,
-      "SWT_NO_LIBDISPATCH": nil,
+      "SWT_NO_LEGACY_TEST_DISCOVERY": (platforms: .none, embedded: true),
+      "SWT_NO_LIBDISPATCH": (platforms: .none, embedded: true),
     ]
 
-    for (name, condition) in defines {
+    for (name, details) in defines {
       if !buildingForEmbedded {
-        if let condition {
-          append(.define(name, condition))
+        if let platforms = details.platforms {
+          append(.define(name, .when(platforms: platforms)))
         } else {
           // Since there was no condition and we're not building for Embedded,
           // the intention was to never match so don't append this define.
         }
-      } else {
-        // Since we're building for Embedded, append this define unconditionally.
+      } else if details.embedded {
+        // Since we're building for Embedded and this define is supposed to be
+        // included unconditionally when building as such, append it.
         append(.define(name, nil))
       }
     }


### PR DESCRIPTION
This modifies the technique we use in `Package.swift` to set Embedded-related define (`-D`) flags so that we no longer need to reference a fake/non-existent platform `.custom("DoesNotExist")`. When building the package with Swift Build, this now produces the following warning:

```
warning: PIF: Ignoring settings assignments for unknown platform 'DoesNotExist'
```

To resolve this, this PR avoids adding the relevant defines when there is no fallback condition and we're not building for Embedded mode. As a bonus, this leverages a helper protocol to consolidate the Swift and C++ target styles and consolidates the (identical) set of defines into a single place for easier maintainability.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
