### PR TITLE
Share `TestContentKind` definition/implementation between targets.

### DIFF
--- a/Documentation/ABI/TestContent.md
+++ b/Documentation/ABI/TestContent.md
@@ -98,8 +98,8 @@ record's kind is a 32-bit unsigned value. The following kinds are defined:
 | `0x65786974` | `'exit'` | Exit test |
 | `0x706c6179` | `'play'` | [Playground](https://github.com/apple/swift-play-experimental) |
 
-<!-- The kind values listed in this table should be a superset of the cases in
-the `TestContentKind` enumeration. -->
+<!-- The kind values listed in this table should be a superset of the constants
+in Sources/_TestDiscovery/TestContentKind.swift. -->
 
 If a test content record's `kind` field equals `0x00000000`, the values of all
 other fields in that record are undefined.

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -317,7 +317,7 @@ extension ExitTest {
   /// A type representing an exit test as a test content record.
   fileprivate struct Record: Sendable, DiscoverableAsTestContent {
     static var testContentKind: TestContentKind {
-      "exit"
+      .exitTest
     }
 
     typealias TestContentAccessorHint = ID

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -21,7 +21,7 @@ extension Test {
   /// directly conform to protocols.
   fileprivate struct Generator: DiscoverableAsTestContent, RawRepresentable {
     static var testContentKind: TestContentKind {
-      "test"
+      .testDeclaration
     }
 
     var rawValue: @Sendable () async -> Test

--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -111,6 +111,7 @@ target_sources(TestingMacros PRIVATE
   Support/SourceCodeCapturing.swift
   Support/SourceLocationGeneration.swift
   Support/TestContentGeneration.swift
+  Support/TestContentKind.swift
   TagMacro.swift
   TestDeclarationMacro.swift
   TestingMacrosMain.swift)

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -13,28 +13,14 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-/// An enumeration representing the different kinds of test content known to the
-/// testing library.
-///
-/// When adding cases to this enumeration, be sure to also update the
-/// corresponding enumeration in TestContent.md.
-///
-/// - Bug: This type should be imported directly from `_TestDiscovery` instead
-///   of being redefined (differently) here.
-enum TestContentKind: UInt32 {
-  /// A test or suite declaration.
-  case testDeclaration = 0x74657374
-
-  /// An exit test.
-  case exitTest = 0x65786974
-
+extension TestContentKind {
   /// This kind value as a comment (`/* 'abcd' */`) if it looks like it might be
   /// a [FourCC](https://en.wikipedia.org/wiki/FourCC) value, or `nil` if not.
-  var commentRepresentation: Trivia {
-    let stringValue = withUnsafeBytes(of: self.rawValue.bigEndian) { bytes in
-      String(decoding: bytes, as: Unicode.ASCII.self)
+  fileprivate var commentRepresentation: Trivia {
+    guard let fourCharacterCodeValue else {
+      return .spaces(0)
     }
-    return .blockComment("/* '\(stringValue)' */")
+    return .blockComment("/* '\(fourCharacterCodeValue)' */")
   }
 }
 

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -15,10 +15,11 @@ import SwiftSyntaxMacros
 
 extension TestContentKind {
   /// This kind value as a comment (`/* 'abcd' */`) if it looks like it might be
-  /// a [FourCC](https://en.wikipedia.org/wiki/FourCC) value, or `nil` if not.
+  /// a [FourCC](https://en.wikipedia.org/wiki/FourCC) value, or empty trivia if
+  /// not.
   fileprivate var commentRepresentation: Trivia {
-    guard let fourCharacterCodeValue else {
-      return .spaces(0)
+    guard let fourCharacterCodeValue, !fourCharacterCodeValue.contains("*/") else {
+      return []
     }
     return .blockComment("/* '\(fourCharacterCodeValue)' */")
   }

--- a/Sources/TestingMacros/Support/TestContentKind.swift
+++ b/Sources/TestingMacros/Support/TestContentKind.swift
@@ -1,0 +1,1 @@
+../../_TestDiscovery/TestContentKind.swift

--- a/Sources/_TestDiscovery/TestContentKind.swift
+++ b/Sources/_TestDiscovery/TestContentKind.swift
@@ -8,8 +8,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import _TestingInternals
-
 /// A type representing a test content record's `kind` field.
 ///
 /// Test content kinds are 32-bit unsigned integers and are stored as such when
@@ -81,23 +79,41 @@ extension TestContentKind: CustomStringConvertible {
   /// This test content type's kind value as an ASCII string (of the form
   /// `"abcd"`) if it looks like it might be a [FourCC](https://en.wikipedia.org/wiki/FourCC)
   /// value, or `nil` if not.
-  private var _fourCCValue: String? {
+  package var fourCharacterCodeValue: String? {
     withUnsafeBytes(of: rawValue.bigEndian) { bytes in
-      let allPrintableASCII = bytes.allSatisfy { byte in
-        Unicode.ASCII.isASCII(byte) && 0 != isprint(CInt(byte))
+      // All printable ASCII characters are in the range 0x20 ..< 0x7F.
+      func isPrintableASCII(_ byte: UInt8) -> Bool {
+        Unicode.ASCII.isASCII(byte) && byte >= 0x20 && byte < 0x7F
       }
-      if allPrintableASCII {
-        return String(decoding: bytes, as: Unicode.ASCII.self)
+
+      guard bytes.allSatisfy(isPrintableASCII) else {
+        return nil
       }
-      return nil
+      return String(decoding: bytes, as: Unicode.ASCII.self)
     }
   }
 
   public var description: String {
     let hexValue = "0x" + String(rawValue, radix: 16)
-    if let fourCCValue = _fourCCValue {
-      return "'\(fourCCValue)' (\(hexValue))"
+    if let fourCharacterCodeValue {
+      return "'\(fourCharacterCodeValue)' (\(hexValue))"
     }
     return hexValue
   }
+}
+
+// MARK: - Constants
+
+// NOTE: The set of constants in this extension should be a subset of the
+// constants specified in Documentation/ABI/TestContent.md.
+
+extension TestContentKind {
+  /// A test or suite declaration.
+  package static var testDeclaration: Self { "test" }
+
+  /// An exit test.
+  package static var exitTest: Self { "exit" }
+
+  /// A Swift playground.
+  package static var playground: Self { "play" }
 }


### PR DESCRIPTION
This PR ensures `TestContentKind` is defined and available in the macro target so that we don't have to redeclare it there with slightly different semantics.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
