### PR TITLE
Enable GHA workflows for FreeBSD.

### DIFF
--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -25,3 +25,6 @@ jobs:
       macos_xcode_versions: '["swift_6.3"]'
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["nightly-main"]'
+      enable_freebsd_checks: true
+      freebsd_swift_versions: '["nightly-main"]'
+      freebsd_os_versions: '["14.3"]'

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -25,6 +25,6 @@ jobs:
       macos_xcode_versions: '["swift_6.3"]'
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["nightly-6.3"]'
-      enable_freebsd_checks: true
-      freebsd_swift_versions: '["nightly-6.3"]'
-      freebsd_os_versions: '["14.3"]'
+#       enable_freebsd_checks: true
+#       freebsd_swift_versions: '["nightly-6.3"]'
+#       freebsd_os_versions: '["14.3"]'

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -25,3 +25,6 @@ jobs:
       macos_xcode_versions: '["swift_6.3"]'
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["nightly-6.3"]'
+      enable_freebsd_checks: true
+      freebsd_swift_versions: '["nightly-6.3"]'
+      freebsd_os_versions: '["14.3"]'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,6 +34,9 @@ jobs:
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["nightly-main", "nightly-6.3"]'
       enable_android_sdk_build: true
+      enable_freebsd_checks: true
+      freebsd_swift_versions: '["nightly-main", "nightly-6.3"]'
+      freebsd_os_versions: '["14.3"]'
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.10

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,7 +35,7 @@ jobs:
       wasm_sdk_versions: '["nightly-main", "nightly-6.3"]'
       enable_android_sdk_build: true
       enable_freebsd_checks: true
-      freebsd_swift_versions: '["nightly-main", "nightly-6.3"]'
+      freebsd_swift_versions: '["nightly-main"]'
       freebsd_os_versions: '["14.3"]'
   soundness:
     name: Soundness

--- a/README.md
+++ b/README.md
@@ -110,10 +110,11 @@ for various platforms:
 | ---------------- | ------------------ | ---------------------- |
 | Apple platforms  | Supported          | Automated              |
 | Linux            | Supported          | Automated              |
+| FreeBSD          | Supported          | Automated              |
 | Windows          | Supported          | Automated              |
 | Wasm             | Experimental       | Automated (Build Only) |
 | Android          | Experimental       | Automated (Build Only) |
-| FreeBSD, OpenBSD | Experimental       | Manual                 |
+| OpenBSD          | Experimental       | [Manual](https://github.com/swiftlang/swift-testing/actions/workflows/manual_build_openbsd.yml) |
 
 [^1]:
     Most platforms have "Automated" qualification, where continuous integration


### PR DESCRIPTION
This PR enables the new GHA workflows for FreeBSD added by https://github.com/swiftlang/github-workflows/pull/257 and updates our documentation to list FreeBSD as fully supported! 🥳

Resolves #684.
Resolves rdar://135874298.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
