### PR TITLE
Add an environment variable to allow suspending child processes.

### DIFF
--- a/Documentation/EnvironmentVariables.md
+++ b/Documentation/EnvironmentVariables.md
@@ -53,7 +53,7 @@ names prefixed with `SWT_`.
 | `SWT_CAPTURED_VALUES` | `CInt`/`HANDLE` | A file descriptor (handle on Windows) containing captured values passed to the exit test. |
 | `SWT_CLOSEFROM` | `CInt` | Used on OpenBSD to emulate `posix_spawn_file_actions_addclosefrom_np()`. |
 | `SWT_EXIT_TEST_ID` | `String` (JSON) | Specifies which exit test to run. |
-| `SWT_START_CHILDREN_SUSPENDED` | `Bool` | Start child processes (such as those for exit tests) in a suspended state where supported (Apple platforms and Windows). |
+| `SWT_START_CHILD_PROCESSES_SUSPENDED` | `Bool` | Start child processes (such as those for exit tests) in a suspended state where supported (Apple platforms and Windows). |
 | `XCTestBundlePath`\* | `String` | Used on Apple platforms to determine if Xcode is hosting the test run. |
 
 ## Miscellaneous

--- a/Documentation/EnvironmentVariables.md
+++ b/Documentation/EnvironmentVariables.md
@@ -53,6 +53,7 @@ names prefixed with `SWT_`.
 | `SWT_CAPTURED_VALUES` | `CInt`/`HANDLE` | A file descriptor (handle on Windows) containing captured values passed to the exit test. |
 | `SWT_CLOSEFROM` | `CInt` | Used on OpenBSD to emulate `posix_spawn_file_actions_addclosefrom_np()`. |
 | `SWT_EXIT_TEST_ID` | `String` (JSON) | Specifies which exit test to run. |
+| `SWT_START_CHILDREN_SUSPENDED` | `Bool` | Start child processes (such as those for exit tests) in a suspended state where supported (Apple platforms and Windows). |
 | `XCTestBundlePath`\* | `String` | Used on Apple platforms to determine if Xcode is hosting the test run. |
 
 ## Miscellaneous

--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -38,6 +38,14 @@ private let _posix_spawn_file_actions_addclosefrom_np = symbol(named: "posix_spa
 }
 #endif
 
+/// Whether or not to start child processes in an immediately suspended state on
+/// platforms that support doing so.
+///
+/// To resume a child process, send the `SIGCONT` signal to its process ID. On
+/// Windows, call [`ResumeThread()`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-resumethread)
+/// and pass it a handle to the child process' main thread.
+private let _startChildrenSuspended = Environment.flag(named: "SWT_START_CHILDREN_SUSPENDED") ?? false
+
 /// Spawn a child process.
 ///
 /// - Parameters:
@@ -198,8 +206,11 @@ func spawnExecutable(
 #warning("Platform-specific implementation missing: cannot close unused file descriptors")
 #endif
 
-#if SWT_TARGET_OS_APPLE && DEBUG
-      // Start the process suspended so we can attach a debugger if needed.
+#if SWT_TARGET_OS_APPLE
+      // Start the process suspended so we can attach a debugger if needed. We
+      // always start the child process in a suspended state even if the
+      // "SWT_START_CHILDREN_SUSPENDED" environment variable isn't set so that
+      // the debugger has a chance to attach to the child.
       flags |= CShort(POSIX_SPAWN_START_SUSPENDED)
 #endif
 
@@ -229,9 +240,11 @@ func spawnExecutable(
       guard 0 == processSpawned else {
         throw CError(rawValue: processSpawned)
       }
-#if SWT_TARGET_OS_APPLE && DEBUG
-      // Resume the process.
-      _ = kill(pid, SIGCONT) // ignore-unacceptable-language
+#if SWT_TARGET_OS_APPLE
+      if !_startChildrenSuspended {
+        // Resume the process.
+        _ = kill(pid, SIGCONT) // ignore-unacceptable-language
+      }
 #endif
       return pid
     }
@@ -314,10 +327,12 @@ func spawnExecutable(
       let workingDirectoryPath = rootDirectoryPath
 
       var flags = DWORD(CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT)
-#if DEBUG
-      // Start the process suspended so we can attach a debugger if needed.
+
+      // Start the process suspended so we can attach a debugger if needed. We
+      // always start the child process in a suspended state even if the
+      // "SWT_START_CHILDREN_SUSPENDED" environment variable isn't set so that
+      // the debugger has a chance to attach to the child.
       flags |= DWORD(CREATE_SUSPENDED)
-#endif
 
       return try environ.withCString(encodedAs: UTF16.self) { environ in
         try workingDirectoryPath.withCString(encodedAs: UTF16.self) { workingDirectoryPath in
@@ -338,10 +353,10 @@ func spawnExecutable(
             throw Win32Error(rawValue: GetLastError())
           }
 
-#if DEBUG
-          // Resume the process.
-          _ = ResumeThread(processInfo.hThread!)
-#endif
+          if !_startChildrenSuspended {
+            // Resume the process.
+            _ = ResumeThread(processInfo.hThread!)
+          }
 
           _ = CloseHandle(processInfo.hThread)
           return processInfo.hProcess!

--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -44,7 +44,7 @@ private let _posix_spawn_file_actions_addclosefrom_np = symbol(named: "posix_spa
 /// To resume a child process, send the `SIGCONT` signal to its process ID. On
 /// Windows, call [`ResumeThread()`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-resumethread)
 /// and pass it a handle to the child process' main thread.
-private let _startChildrenSuspended = Environment.flag(named: "SWT_START_CHILDREN_SUSPENDED") ?? false
+private let _startChildProcessesSuspended = Environment.flag(named: "SWT_START_CHILD_PROCESSES_SUSPENDED") ?? false
 
 /// Spawn a child process.
 ///
@@ -209,7 +209,7 @@ func spawnExecutable(
 #if SWT_TARGET_OS_APPLE
       // Start the process suspended so we can attach a debugger if needed. We
       // always start the child process in a suspended state even if the
-      // "SWT_START_CHILDREN_SUSPENDED" environment variable isn't set so that
+      // "SWT_START_CHILD_PROCESSES_SUSPENDED" environment variable isn't set so that
       // the debugger has a chance to attach to the child.
       flags |= CShort(POSIX_SPAWN_START_SUSPENDED)
 #endif
@@ -241,7 +241,7 @@ func spawnExecutable(
         throw CError(rawValue: processSpawned)
       }
 #if SWT_TARGET_OS_APPLE
-      if !_startChildrenSuspended {
+      if !_startChildProcessesSuspended {
         // Resume the process.
         _ = kill(pid, SIGCONT) // ignore-unacceptable-language
       }
@@ -330,7 +330,7 @@ func spawnExecutable(
 
       // Start the process suspended so we can attach a debugger if needed. We
       // always start the child process in a suspended state even if the
-      // "SWT_START_CHILDREN_SUSPENDED" environment variable isn't set so that
+      // "SWT_START_CHILD_PROCESSES_SUSPENDED" environment variable isn't set so that
       // the debugger has a chance to attach to the child.
       flags |= DWORD(CREATE_SUSPENDED)
 
@@ -353,7 +353,7 @@ func spawnExecutable(
             throw Win32Error(rawValue: GetLastError())
           }
 
-          if !_startChildrenSuspended {
+          if !_startChildProcessesSuspended {
             // Resume the process.
             _ = ResumeThread(processInfo.hThread!)
           }


### PR DESCRIPTION
This PR adds an environment variable check in our `posix_spawn()` wrapper that causes child processes to start in a suspended state on Darwin. The equivalent logic is implemented on Windows too, but other platforms don't support this functionality.

This change gives developers a chance to manually attach a debugger to the spawned child process.

This environment variable, as with all others we use, is not stable API and is subject to change at any time.

Resolves #1670.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
