### PR TITLE
Avoid transitive Foundation dependency.

### DIFF
--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -18,7 +18,11 @@ extension TestContentKind {
   /// a [FourCC](https://en.wikipedia.org/wiki/FourCC) value, or empty trivia if
   /// not.
   fileprivate var commentRepresentation: Trivia {
-    guard let fourCharacterCodeValue, !fourCharacterCodeValue.contains(/\*\//) else {
+    guard let fourCharacterCodeValue else {
+      return []
+    }
+    if fourCharacterCodeValue.contains("*") && fourCharacterCodeValue.contains("/") {
+      // Avoid FourCC strings that might terminate the winged comment early.
       return []
     }
     return .blockComment("/* '\(fourCharacterCodeValue)' */")

--- a/Sources/TestingMacros/Support/TestContentGeneration.swift
+++ b/Sources/TestingMacros/Support/TestContentGeneration.swift
@@ -18,7 +18,7 @@ extension TestContentKind {
   /// a [FourCC](https://en.wikipedia.org/wiki/FourCC) value, or empty trivia if
   /// not.
   fileprivate var commentRepresentation: Trivia {
-    guard let fourCharacterCodeValue, !fourCharacterCodeValue.contains("*/") else {
+    guard let fourCharacterCodeValue, !fourCharacterCodeValue.contains(/\*\//) else {
       return []
     }
     return .blockComment("/* '\(fourCharacterCodeValue)' */")


### PR DESCRIPTION
Avoid a transitive Foundation dependency looking for the substring `"*/"` in FourCC representations of test content kind values during macro expansion.

Resolves rdar://174768218.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
