### PR TITLE
Disable collection diffing on expectation failure.

### DIFF
--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -607,6 +607,7 @@ public func __checkPropertyAccess<T, U>(
 ) -> Result<Void, any Error> where T: BidirectionalCollection, T.Element: Equatable {
   let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
   func difference() -> String? {
+#if SWT_COLLECTION_DIFFING_ENABLED
     guard let rhs else {
       return nil
     }
@@ -623,6 +624,9 @@ public func __checkPropertyAccess<T, U>(
     case (false, false):
       return ""
     }
+#else
+    return nil
+#endif
   }
 
   return __checkValue(

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -90,7 +90,9 @@ struct EventRecorderTests {
       #expect(!buffer.contains("●"))
     }
 
+#if SWT_COLLECTION_DIFFING_ENABLED
     #expect(buffer.contains("inserted ["))
+#endif
 
     if testsWithSignificantIOAreEnabled {
       print(buffer, terminator: "")
@@ -647,9 +649,11 @@ struct EventRecorderTests {
     Issue.record()
   }
 
+#if SWT_COLLECTION_DIFFING_ENABLED
   @Test(.hidden) func diffyDuck() {
     #expect([1, 2, 3] as Array == [1, 2] as Array)
   }
+#endif
 
   @Test(.hidden) func woefulWombat() {
     #expect(throws: MyError.self) {

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1247,6 +1247,7 @@ final class IssueTests: XCTestCase {
     }
   }
 
+#if SWT_COLLECTION_DIFFING_ENABLED
   func testCollectionDifference() async throws {
     var configuration = Configuration()
     configuration.eventHandler = { event, _ in
@@ -1319,6 +1320,7 @@ final class IssueTests: XCTestCase {
       #expect(range_int64 == 0...0, "both incorrect")
     }.run(configuration: configuration)
   }
+#endif
 
   func testNegatedExpressions() async {
     var configuration = Configuration()


### PR DESCRIPTION
We implemented collection diffing with the intent of allowing tools to present a `diff`-like interface, but we don't surface the difference in a structured way that a tool could present to a user, and the cost of diffing very large collections (for effectively no reason) is prohibitive. This PR disables the call to `Collection.difference()` inside the implementation of `#expect()` and `#require()`. The code is still plumbed through, so if there are tools that can make use of it in the future it should be easy to re-enable.

Resolves rdar://173002947.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
