### PR TITLE
Decode EncodedEvent -> SkipInfo

### DIFF
--- a/Sources/Testing/Running/SkipInfo.swift
+++ b/Sources/Testing/Running/SkipInfo.swift
@@ -78,6 +78,35 @@ extension SkipInfo {
   }
 }
 
+// MARK: - Conversion to/from ABI types
+
+extension SkipInfo {
+  /// Initialize an instance of this type from the given value.
+  ///
+  /// SkipInfo is only non-nil for the skip/cancel event kinds.
+  ///
+  /// - Parameters:
+  ///   - event: The encoded event to initialize this instance from.
+  ///
+  /// Reconstructs ``SkipInfo`` from the comments and
+  /// source location stored in the encoded event.
+  init?<V>(decoding event: ABI.EncodedEvent<V>) {
+    // Only skip/cancel event kinds can decode SkipInfo.
+    switch event.kind {
+    case .testCancelled, .testCaseCancelled, .testSkipped:
+      break
+    default:
+      return nil
+    }
+
+    // Typically only a single comment is expected for SkipInfo.
+    let comment = event._comments?.first.map(Comment.init(rawValue:))
+    let sourceLocation = event._sourceLocation.flatMap(SourceLocation.init(decoding:))
+    let sourceContext = SourceContext(backtrace: nil, sourceLocation: sourceLocation)
+    self.init(comment: comment, sourceContext: sourceContext)
+  }
+}
+
 // MARK: - Deprecated
 
 extension SkipInfo {

--- a/Tests/TestingTests/SkipInfoTests.swift
+++ b/Tests/TestingTests/SkipInfoTests.swift
@@ -9,6 +9,9 @@
 //
 
 @testable @_spi(ForToolsIntegrationOnly) import Testing
+#if canImport(Foundation)
+import Foundation
+#endif
 
 @Suite("SkipInfo Tests")
 struct SkipInfoTests {
@@ -28,4 +31,52 @@ struct SkipInfoTests {
     skipInfo.sourceLocation = sourceLocation2
     #expect(skipInfo.sourceLocation == sourceLocation2)
   }
+
+#if canImport(Foundation)
+  @Test(
+    "Decode from event",
+    arguments: [
+      "testCancelled",
+      "testCaseCancelled",
+      "testSkipped",
+    ]
+  ) func roundTrip(kind: String) throws {
+    var json = #"""
+      {
+        "kind": "\#(kind)",
+        "instant": { "since1970": 0, "absolute": 0 },
+        "messages": [],
+        "_comments": ["Skipped Test"],
+        "_sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
+      }
+      """#
+    let event = try json.withUTF8 { json in
+      try JSON.decode(ABI.EncodedEvent<ABI.CurrentVersion>.self, from: UnsafeRawBufferPointer(json))
+    }
+
+    let info = SkipInfo(decoding: event)
+    let expected = SkipInfo(
+      comment: "Skipped Test",
+      sourceContext: .init(backtrace: nil, sourceLocation: .init(SourceLocation(fileIDSynthesizingIfNeeded: nil, filePath: "/a/b/c", line: 12345, column: 67890))))
+    #expect(info == expected)
+  }
+
+  @Test("SkipInfo nil for unsupported event kind") func decodeSkipInfoUnsupported() throws {
+    var json = #"""
+      {
+        "kind": "testStarted",
+        "instant": { "since1970": 0, "absolute": 0 },
+        "messages": [],
+        "_comments": ["Skipped Test"],
+        "_sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
+      }
+      """#
+    let event = try json.withUTF8 { json in
+      try JSON.decode(ABI.EncodedEvent<ABI.CurrentVersion>.self, from: UnsafeRawBufferPointer(json))
+    }
+
+    let info = SkipInfo(decoding: event)
+    #expect(info == nil)
+  }
+#endif
 }


### PR DESCRIPTION
### Motivation:

Required for ultimately decoding EncodedEvent -> Event

Resolves rdar://174974921

### Modifications:

Decode EncodedEvent -> SkipInfo

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
