### PR TITLE
Decode EncodedInstant -> Test.Clock.Instant

### DIFF
--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -24,7 +24,7 @@ extension Test {
       fileprivate(set) var suspending = TimeValue(rawValue: SuspendingClock().systemEpoch.duration(to: .now))
 
 #if !SWT_NO_UTC_CLOCK
-      /// The wall-clock time corresponding to this instant.
+      /// The wall-clock time since 1970 corresponding to this instant.
       fileprivate(set) var wall: TimeValue = {
 #if !SWT_NO_TIMESPEC
         var wall = timespec()
@@ -64,6 +64,24 @@ extension SuspendingClock.Instant {
   ///   - testClockInstant: The equivalent instant on ``Test/Clock``.
   public init(_ testClockInstant: Test.Clock.Instant) {
     self = SuspendingClock().systemEpoch + testClockInstant.suspending.rawValue
+  }
+}
+
+@_spi(ForToolsIntegrationOnly)
+extension Test.Clock.Instant {
+  /// Initialize this instant to be exactly equal to an instant from the testing
+  /// library's event stream.
+  ///
+  /// - Note: When the original instant is encoded to the event stream,
+  /// it loses some precision.
+  ///
+  /// - Parameters:
+  ///   - instant: The encoded instant to initialize this instant from.
+  public init?<V>(decoding instant: ABI.EncodedInstant<V>) {
+    suspending = TimeValue(rawValue: .seconds(instant.absolute))
+#if !SWT_NO_UTC_CLOCK
+    wall = TimeValue(rawValue: .seconds(instant.since1970))
+#endif
   }
 }
 

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -112,4 +112,17 @@ struct ClockTests {
     #expect(instant != now)
   }
 #endif
+
+  @Test("Round trip Test.Clock.Instant <-> ABI.EncodedInstant")
+  func roundTrip() async throws {
+    let now = Test.Clock.Instant()
+    let encoded = ABI.EncodedInstant<ABI.CurrentVersion>(encoding: now)
+    let decoded = try #require(Test.Clock.Instant(decoding: encoded))
+
+    // Instant -> EncodedInstant loses some precision when converting from Duration -> Double
+    #expect(abs((now.suspending.rawValue - decoded.suspending.rawValue) / .seconds(1)) < 0.001)
+#if !SWT_NO_UTC_CLOCK
+    #expect(abs((now.durationSince1970 - decoded.durationSince1970) / .seconds(1)) < 0.001)
+#endif
+  }
 }


### PR DESCRIPTION
### Motivation:

Required for ultimately decoding EncodedEvent -> Event

Resolves rdar://175082804

### Modifications:

- Decode `EncodedInstant` to `Test.Clock.Instant`

- Test round trip encode/decode

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
