### PR TITLE
Expose initializer for `ABI.EncodedError`.

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
@@ -8,6 +8,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+private import _TestingInternals
+
 extension ABI {
   /// A type implementing the JSON encoding of ``Error`` for the ABI entry point
   /// and event stream output.
@@ -17,9 +19,14 @@ extension ABI {
   /// expected to write their own decoders.
   ///
   /// - Warning: Errors are not yet part of the JSON schema.
-  struct EncodedError<V>: Sendable where V: ABI.Version {
+  @_spi(Experimental)
+  public struct EncodedError<V>: Sendable where V: ABI.Version {
     /// The error's description.
-    var description: String
+    ///
+    /// The value of this property may be `nil` if the error originated in a
+    /// context other than Swift or Objective-C (where errors may not have
+    /// associated descriptions).
+    var description: String?
 
     /// The domain of the error.
     ///
@@ -32,15 +39,6 @@ extension ABI {
     var code: Int
 
     // TODO: userInfo (partial) encoding
-
-    init(encoding error: some Error) {
-      description = String(describingForTest: error)
-      domain = error._domain
-      if domain == Self.unknownDomain {
-        domain = nil
-      }
-      code = error._code
-    }
   }
 }
 
@@ -48,19 +46,19 @@ extension ABI {
 
 extension ABI.EncodedError: Error {
   /// The domain of decoded errors that did not specify a domain of their own.
-  static var unknownDomain: String {
+  public static var unknownDomain: String {
     "<unknown>"
   }
 
-  var _domain: String {
+  public var _domain: String {
     domain ?? Self.unknownDomain
   }
 
-  var _code: Int {
+  public var _code: Int {
     code
   }
 
-  var _userInfo: AnyObject? {
+  public var _userInfo: AnyObject? {
     // TODO: userInfo (partial) encoding
     nil
   }
@@ -73,7 +71,32 @@ extension ABI.EncodedError: Codable {}
 // MARK: - CustomTestStringConvertible
 
 extension ABI.EncodedError: CustomTestStringConvertible {
-  var testDescription: String {
-    description
+  public var testDescription: String {
+    if let description {
+      return description
+    } else if let domain {
+      return "\(domain) error \(code)"
+    }
+    return "error \(code)"
   }
 }
+
+// MARK: - Conversion to/from library types
+
+extension ABI.EncodedError {
+  public init(encoding error: some Error) {
+    let description = String(describingForTest: error)
+    if !description.isEmpty {
+      self.description = description
+    }
+    let domain = error._domain
+    if domain != Self.unknownDomain {
+      self.domain = domain
+    }
+    code = error._code
+  }
+}
+
+// Error.init(decoding:) is not implemented here because a) Error is a protocol
+// and cannot be instantiated directly, and b) ABI.EncodedError already conforms
+// to Error, so a cast is generally not necessary.

--- a/Sources/Testing/Events/Recorder/Event.AdvancedConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.AdvancedConsoleOutputRecorder.swift
@@ -753,8 +753,8 @@ extension Event.AdvancedConsoleOutputRecorder {
     // Get the corresponding messages for this issue
     guard issueIndex < testData.issueMessages.count else {
       // Fallback to error description if available
-      if let error = issue._error {
-        return error.description
+      if let errorDesc = issue._error?.description {
+        return errorDesc
       }
       return "Issue recorded"
     }
@@ -790,8 +790,7 @@ extension Event.AdvancedConsoleOutputRecorder {
     }
     
     // Final fallback
-    if let error = issue._error {
-      let errorDesc = error.description
+    if let errorDesc = issue._error?.description {
       // Truncate very long error descriptions
       if errorDesc.count > 200 {
         return String(errorDesc.prefix(200)) + "..."


### PR DESCRIPTION
This PR exposes `ABI.EncodedError.init(encoding:)` to match similar initializers we've exposed for other ABI/JSON types. Note that `Error.init(decoding:)` is _not_ exposed (see the comment in the diff for details).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
