### PR TITLE
Update the Swift versions built on CI

### DIFF
--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -19,12 +19,12 @@ jobs:
     with:
       linux_swift_versions: '["nightly-6.3"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
-      linux_static_sdk_versions: '["nightly-6.3"]'
-      windows_swift_versions: '["nightly-6.3"]'
+      linux_static_sdk_versions: '["6.3", "nightly-6.3"]'
+      windows_swift_versions: '["6.3", "nightly-6.3"]'
       enable_macos_checks: true
       macos_xcode_versions: '["swift_6.3"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["nightly-6.3"]'
+      wasm_sdk_versions: '["6.3", "nightly-6.3"]'
       enable_android_sdk_build: true
       android_sdk_versions: '["6.3", "nightly-6.3"]'
       android_ndk_versions: '["r28c", "r29"]'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,14 +25,14 @@ jobs:
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.3"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
-      linux_static_sdk_versions: '["nightly-main"]'
-      windows_swift_versions: '["nightly-main", "nightly-6.3"]'
+      linux_static_sdk_versions: '["6.3", "nightly-main", "nightly-6.3"]'
+      windows_swift_versions: '["6.3", "nightly-main", "nightly-6.3"]'
       enable_macos_checks: true
       macos_xcode_versions: '["swift_6.3"]'
       enable_ios_checks: true
       ios_host_xcode_versions: '["swift_6.3"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["nightly-main", "nightly-6.3"]'
+      wasm_sdk_versions: '["6.3", "nightly-main", "nightly-6.3"]'
       enable_android_sdk_build: true
       android_ndk_versions: '["r28c", "r29"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'


### PR DESCRIPTION
Update the CI built using the release compilers to build using the latest release also, not just the release snapshots.

Don't update linux because that container is currently missing the `zip` package and fails a test that requires it.