### PR TITLE
Explicitly require Transferable values for attachments also be Sendable

### DIFF
--- a/Sources/Overlays/_Testing_CoreTransferable/Attachments/Attachment+Transferable.swift
+++ b/Sources/Overlays/_Testing_CoreTransferable/Attachments/Attachment+Transferable.swift
@@ -61,7 +61,7 @@ extension Attachment {
     as contentType: UTType? = nil,
     named preferredName: String? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
-  ) async throws where T: Transferable, AttachableValue == _AttachableTransferableWrapper<T> {
+  ) async throws where T: Transferable & Sendable, AttachableValue == _AttachableTransferableWrapper<T> {
     let transferableWrapper = try await _AttachableTransferableWrapper(exporting: transferableValue, as: contentType)
     self.init(transferableWrapper, named: preferredName, sourceLocation: sourceLocation)
   }

--- a/Sources/Overlays/_Testing_CoreTransferable/Attachments/_AttachableTransferableWrapper.swift
+++ b/Sources/Overlays/_Testing_CoreTransferable/Attachments/_AttachableTransferableWrapper.swift
@@ -26,7 +26,7 @@ import UniformTypeIdentifiers
 ///   @Available(Swift, introduced: 6.4)
 /// }
 @available(_transferableAPI, *)
-public struct _AttachableTransferableWrapper<T>: Sendable where T: Transferable {
+public struct _AttachableTransferableWrapper<T>: Sendable where T: Transferable & Sendable {
   /// The transferable value.
   private var _transferableValue: T
 


### PR DESCRIPTION
This is an attempt to fix a build failure which Swift CI began seeing after the changes in #1519 landed.

Swift CI is [failing](https://github.com/swiftlang/swift-testing/pull/1519#discussion_r3135264435) to build with this change because it's still using Xcode 16.2, but `Transferrable` only gained `Sendable` conformance starting in the OS 26.0 SDK versions. The specific error is:

```
[2026-04-24T01:09:49.272Z] /Users/ec2-user/jenkins/workspace/swift-package-manager-PR-macos-smoke-test/branch-main/swift-testing/Sources/Overlays/_Testing_CoreTransferable/Attachments/_AttachableTransferableWrapper.swift:31:15: error: stored property '_transferableValue' of 'Sendable'-conforming generic struct '_AttachableTransferableWrapper' has non-Sendable type 'T'
[2026-04-24T01:09:49.272Z] 27 | /// }
[2026-04-24T01:09:49.272Z] 28 | @available(_transferableAPI, *)
[2026-04-24T01:09:49.272Z] 29 | public struct _AttachableTransferableWrapper<T>: Sendable where T: Transferable {
[2026-04-24T01:09:49.273Z]    |                                              `- note: consider making generic parameter 'T' conform to the 'Sendable' protocol
[2026-04-24T01:09:49.273Z] 30 |   /// The transferable value.
[2026-04-24T01:09:49.273Z] 31 |   private var _transferableValue: T
[2026-04-24T01:09:49.273Z]    |               `- error: stored property '_transferableValue' of 'Sendable'-conforming generic struct '_AttachableTransferableWrapper' has non-Sendable type 'T'
```

So this works around it by making the `Sendable` requirement explicit, rather than relying on the SDK declaration of `Transferable` to state that requirement.

Hopefully this will avoid the need to [revert](https://github.com/swiftlang/swift-testing/pull/1687) the change outright.

Resolves rdar://175478013.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
