### PR TITLE
@_spi(ForToolsIntegrationOnly) viz for ABI.EncodedEvent.messages

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -60,7 +60,7 @@ extension ABI {
 
     /// Human-readable messages associated with this event that can be presented
     /// to the user.
-    var messages: [EncodedMessage<V>]
+    public var messages: [EncodedMessage<V>]
 
     /// The ID of the test associated with this event, if any.
     var testID: EncodedTest<V>.ID?

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
@@ -16,7 +16,7 @@ extension ABI {
   /// This type is not part of the public interface of the testing library. It
   /// assists in converting values to JSON; clients that consume this JSON are
   /// expected to write their own decoders.
-  struct EncodedMessage<V>: Sendable where V: ABI.Version {
+  public struct EncodedMessage<V>: Sendable where V: ABI.Version {
     /// A type implementing the JSON encoding of ``Event/Symbol`` for the ABI
     /// entry point and event stream output.
     ///
@@ -62,7 +62,7 @@ extension ABI {
     var symbol: Symbol
 
     /// The human-readable, unformatted text associated with this message.
-    var text: String
+    public var text: String
 
     /// How much to indent this message when presenting it.
     ///


### PR DESCRIPTION
### Motivation:

Required for interop test libraries to read issue messages when handling EncodedEvent. This message content is not available in the Issue comments after decoding.

### Modifications:

Affected types are already under the @_spi umbrella of the ABI type.

- Add public viz to ABI.EncodedEvent.messages

- Add public viz to ABI.EncodedMessage.text

Resolves rdar://175600485

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
