### PR TITLE
Disable library evolution when building for Embedded

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -425,7 +425,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
   static func enableLibraryEvolution(_ condition: BuildSettingCondition? = nil) -> Self {
     var result = [PackageDescription.SwiftSetting]()
 
-    if buildingForDevelopment {
+    if buildingForDevelopment && !buildingForEmbedded {
       result.append(.unsafeFlags(["-enable-library-evolution"], condition))
     }
 


### PR DESCRIPTION
This disables library evolution when building the package for [Embedded Swift](https://docs.swift.org/embedded/documentation/embedded/). This resolves an error seen early on when attempting to build:

```
error: Library evolution cannot be enabled with embedded Swift.
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
