### PR TITLE
Explicitly import '_Concurrency' module when building for Embedded

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -364,6 +364,11 @@ extension Array where Element == PackageDescription.SwiftSetting {
 
     if buildingForEmbedded {
       result.append(.enableExperimentalFeature("Embedded"))
+
+      // Swift's concurrency module is not implicitly imported when building for
+      // Embedded, so we must explicitly import it since this project uses
+      // async and other concurrency-related language features.
+      result.append(.unsafeFlags(["-Xfrontend", "-import-module", "-Xfrontend", "_Concurrency"]))
     }
 
     // Define a compiler condition so we can discover at macro expansion time if


### PR DESCRIPTION
This explicitly imports the `_Concurrency` module when building the package for [Embedded Swift](https://docs.swift.org/embedded/documentation/embedded/), since in that context it's not implicitly imported.

### Motivation:

This resolves various errors when attempting to build for Embedded, such as:

```
Test.swift:345:39: error: '_Concurrency' module not imported, required for async
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
