### PR TITLE
Fix off-by-one error trimming barrier sequences from exit test output streams.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -600,7 +600,7 @@ extension ExitTest {
     let firstBarrierByte = barrierValue[0]
 
     // If the buffer is too small to contain the barrier value, exit early.
-    guard buffer.count > barrierValue.count else {
+    guard buffer.count >= barrierValue.count else {
       return buffer
     }
 

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -478,6 +478,14 @@ private import _TestingInternals
     #expect(!result.standardErrorContent.contains(ExitTest.barrierValue))
   }
 
+  @Test("Empty stdout/stderr stream is actually empty")
+  func exitTestEmptyStreamIsActuallyEmpty() async throws {
+    let result = try await #require(processExitsWith: .success, observing: [\.standardErrorContent]) {
+      _Exit(EXIT_SUCCESS)
+    }
+    #expect(result.standardErrorContent.isEmpty)
+  }
+
   @Test("Arguments to the macro are not captured during expansion (do not need to be literals/const)")
   func argumentsAreNotCapturedDuringMacroExpansion() async throws {
     let unrelatedSourceLocation = #_sourceLocation


### PR DESCRIPTION
If the _only_ thing in the `stdout` or `stderr` stream of an exit test's child process is the barrier sequence (i.e. exactly those 32 bytes and nothing else), we fail to trim it off. Fix it.

Resolves #1693.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
