### PR TITLE
[6.3.2] Fix off-by-one error trimming barrier sequences from exit test output streams.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -578,7 +578,7 @@ extension ExitTest {
     let firstBarrierByte = barrierValue[0]
 
     // If the buffer is too small to contain the barrier value, exit early.
-    guard buffer.count > barrierValue.count else {
+    guard buffer.count >= barrierValue.count else {
       return buffer
     }
 

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -409,6 +409,14 @@ private import _TestingInternals
     #expect(!result.standardErrorContent.contains(ExitTest.barrierValue))
   }
 
+  @Test("Empty stdout/stderr stream is actually empty")
+  func exitTestEmptyStreamIsActuallyEmpty() async throws {
+    let result = try await #require(processExitsWith: .success, observing: [\.standardErrorContent]) {
+      _Exit(EXIT_SUCCESS)
+    }
+    #expect(result.standardErrorContent.isEmpty)
+  }
+
   @Test("Arguments to the macro are not captured during expansion (do not need to be literals/const)")
   func argumentsAreNotCapturedDuringMacroExpansion() async throws {
     let unrelatedSourceLocation = #_sourceLocation


### PR DESCRIPTION
- **Explanation**: Fixes an off-by-one error that can corrupt output from exit tests.
- **Scope**: Exit tests.
- **Issues**: #1693
- **Original PRs**: #1694
- **Risk**: Low
- **Testing**: New unit test.
- **Reviewers**: @stmontgomery @dimitribouniol