### PR TITLE
Conditionalize `Codable` conformances

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -511,6 +511,10 @@ extension Array where Element: _LanguageBuildSetting {
       "SWT_NO_FOUNDATION_FILE_COORDINATION": (platforms: .nonApplePlatforms, embedded: true),
       "SWT_NO_IMAGE_ATTACHMENTS": (platforms: [.linux, .custom("freebsd"), .openbsd, .wasi, .android], embedded: true),
       "SWT_NO_FILE_CLONING": (platforms: [.openbsd, .wasi, .android], embedded: true),
+      "SWT_NO_ABI_ENTRY_POINT": (platforms: .none, embedded: true),
+      "SWT_NO_CODABLE": (platforms: .none, embedded: true),
+      "SWT_NO_INTEROP": (platforms: .none, embedded: true),
+
 
       "SWT_NO_LEGACY_TEST_DISCOVERY": (platforms: .none, embedded: true),
       "SWT_NO_LIBDISPATCH": (platforms: .none, embedded: true),

--- a/Package.swift
+++ b/Package.swift
@@ -520,7 +520,6 @@ extension Array where Element: _LanguageBuildSetting {
       "SWT_NO_CODABLE": (platforms: .none, embedded: true),
       "SWT_NO_INTEROP": (platforms: .none, embedded: true),
 
-
       "SWT_NO_LEGACY_TEST_DISCOVERY": (platforms: .none, embedded: true),
       "SWT_NO_LIBDISPATCH": (platforms: .none, embedded: true),
     ]

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if canImport(Foundation) && !SWT_NO_CODABLE
 public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if canImport(Foundation) && !SWT_NO_CODABLE
 public import Testing
 private import Foundation
 

--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -8,9 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
-private import Foundation
-
+#if (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT) && !SWT_NO_CODABLE
 extension ABI.Version {
   /// Create an event handler that encodes instances of ``Event`` as instances
   /// of ``ABI/Record`` and forwards them to a handler function.
@@ -86,9 +84,7 @@ extension ABI.Xcode16 {
         eventContext: Event.Context.Snapshot(snapshotting: context)
       )
       try? JSON.withEncoding(of: snapshot) { eventAndContextJSON in
-        eventAndContextJSON.withUnsafeBytes { eventAndContextJSON in
-          recordHandler(eventAndContextJSON)
-        }
+        recordHandler(eventAndContextJSON)
       }
     }
   }

--- a/Sources/Testing/ABI/ABI.Record.swift
+++ b/Sources/Testing/ABI/ABI.Record.swift
@@ -58,6 +58,7 @@ extension ABI.Record {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.Record: Codable {
@@ -121,3 +122,4 @@ extension ABI.Record: Codable {
     }
   }
 }
+#endif

--- a/Sources/Testing/ABI/ABI.VersionNumber.swift
+++ b/Sources/Testing/ABI/ABI.VersionNumber.swift
@@ -108,6 +108,7 @@ extension ABI.VersionNumber: Equatable, Comparable {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.VersionNumber: Codable {
@@ -156,3 +157,4 @@ extension ABI.VersionNumber: Codable {
     self = try JSON.decode(MinimalRecord.self, from: recordJSON).version
   }
 }
+#endif

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -26,7 +26,7 @@ extension ABI {
   /// A protocol that extends the public ``ABI/Version`` protocol with
   /// internal-only requirements.
   protocol _Version: Version {
-#if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
+#if (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT) && !SWT_NO_CODABLE
     /// Create an event handler that encodes events as JSON and forwards them to
     /// an ABI-friendly event handler.
     ///
@@ -212,6 +212,7 @@ extension ABI {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: -
 
 /// The set of keys accepted by `_swift_testing_copyMetadataValue(_:_:)`.
@@ -262,3 +263,4 @@ func _swift_testing_copyMetadataValue(_ key: UnsafePointer<CChar>, _ reserved: U
     return nil
   }
 }
+#endif

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -9,7 +9,8 @@
 //
 
 #if canImport(Foundation)
-private import Foundation // for Data (Base64 and file mapping)
+private import struct Foundation.Data
+private import struct Foundation.URL
 #endif
 
 extension ABI {

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -9,7 +9,7 @@
 //
 
 #if canImport(Foundation)
-private import Foundation
+private import Foundation // for Data (Base64 and file mapping)
 #endif
 
 extension ABI {
@@ -49,6 +49,7 @@ extension ABI {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedAttachment: Codable {
@@ -157,6 +158,7 @@ extension ABI.EncodedAttachment: Codable {
     }
   }
 }
+#endif
 
 // MARK: - Attachable
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
@@ -31,6 +31,7 @@ extension ABI {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedBacktrace: Codable {
@@ -42,3 +43,4 @@ extension ABI.EncodedBacktrace: Codable {
     self.symbolicatedAddresses = try [Backtrace.SymbolicatedAddress](from: decoder)
   }
 }
+#endif

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
@@ -64,9 +64,11 @@ extension ABI.EncodedError: Error {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedError: Codable {}
+#endif
 
 // MARK: - CustomTestStringConvertible
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -176,10 +176,12 @@ extension ABI {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedEvent: Codable {}
 extension ABI.EncodedEvent.Kind: Codable {}
+#endif
 
 // MARK: - Conversion to/from library types
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedExpression.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedExpression.swift
@@ -37,9 +37,11 @@ extension ABI {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedExpression: Codable {}
+#endif
 
 // MARK: - Conversion to/from library types
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
@@ -60,6 +60,8 @@ extension SuspendingClock.Instant {
 
 // Date.init(decoding:) is in the Foundation overlay.
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedInstant: Codable {}
+#endif

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -112,10 +112,12 @@ extension ABI {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedIssue: Codable {}
 extension ABI.EncodedIssue.Severity: Codable {}
+#endif
 
 // MARK: - Conversion to/from library types
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedMessage.swift
@@ -82,7 +82,9 @@ extension ABI {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedMessage: Codable {}
 extension ABI.EncodedMessage.Symbol: Codable {}
+#endif

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedSourceLocation.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedSourceLocation.swift
@@ -52,6 +52,7 @@ extension ABI {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedSourceLocation: Codable {
@@ -63,6 +64,7 @@ extension ABI.EncodedSourceLocation: Codable {
     case column
   }
 }
+#endif
 
 // MARK: - Conversion to/from library types
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -42,20 +42,12 @@ extension ABI {
 
     /// A type implementing the JSON encoding of ``Test/ID`` for the ABI entry
     /// point and event stream output.
-    struct ID: Codable {
+    struct ID {
       /// The string value representing the corresponding test ID.
       var stringValue: String
 
       init(encoding testID: borrowing Test.ID) {
         stringValue = String(describing: copy testID)
-      }
-
-      func encode(to encoder: any Encoder) throws {
-        try stringValue.encode(to: encoder)
-      }
-
-      init(from decoder: any Decoder) throws {
-        stringValue = try String(from: decoder)
       }
     }
 
@@ -76,7 +68,7 @@ extension ABI {
     /// A type describing a parameter to a parameterized test function.
     ///
     /// - Warning: Parameter info is not yet part of the JSON schema.
-    struct Parameter: Sendable, Codable {
+    struct Parameter: Sendable {
       /// The name of the parameter, if known.
       var name: String?
 
@@ -148,11 +140,24 @@ extension ABI {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedTest: Codable {}
 extension ABI.EncodedTest.Kind: Codable {}
+extension ABI.EncodedTest.Parameter: Codable {}
 extension ABI.EncodedTestCase: Codable {}
+
+extension ABI.EncodedTest.ID: Codable {
+  func encode(to encoder: any Encoder) throws {
+    try stringValue.encode(to: encoder)
+  }
+
+  init(from decoder: any Decoder) throws {
+    stringValue = try String(from: decoder)
+  }
+}
+#endif
 
 // MARK: - Conversion to/from library types
 

--- a/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/ABIEntryPoint.swift
@@ -8,7 +8,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_ABI_ENTRY_POINT
+#if !SWT_NO_ABI_ENTRY_POINT
+#if SWT_NO_CODABLE
+#error("Platform-specific misconfiguration: support for the ABI entry point function requires support for 'Codable'")
+#endif
+#endif
+
+#if !SWT_NO_ABI_ENTRY_POINT
 private import _TestingInternals
 
 extension ABI.v0 {

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -337,6 +337,7 @@ public struct __CommandLineArguments_v0: Sendable {
   public var attachmentsPath: String?
 }
 
+#if !SWT_NO_CODABLE
 extension __CommandLineArguments_v0: Codable {
   // Explicitly list the coding keys so that storage properties like _verbosity
   // do not end up with leading underscores when encoded.
@@ -359,6 +360,7 @@ extension __CommandLineArguments_v0: Codable {
     case attachmentsPath
   }
 }
+#endif
 
 extension RandomAccessCollection<String> {
   /// Get the value of the command line argument with the given name.
@@ -414,7 +416,7 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   let args = args.dropFirst()
 
 #if !SWT_NO_FILE_IO
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
   // Configuration for the test run passed in as a JSON file (experimental)
   //
   // This argument should always be the first one we parse.
@@ -433,6 +435,7 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
     // allowed to pass a configuration AND e.g. "--verbose" and they'll both be
     // respected (it should be the least "surprising" outcome of passing both.)
   }
+#endif
 
   // Event stream output
   if let path = args.argumentValue(forLabel: "--event-stream-output-path") ?? args.argumentValue(forLabel: "--experimental-event-stream-output") {
@@ -479,7 +482,6 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   if let attachmentsPath = args.argumentValue(forLabel: "--attachments-path") ?? args.argumentValue(forLabel: "--experimental-attachments-path") {
     result.attachmentsPath = attachmentsPath
   }
-#endif
 
   if args.contains("--list-tests") {
     result.listTests = true
@@ -604,7 +606,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
     configuration.attachmentsPath = attachmentsPath
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
   // Event stream output
   if let eventStreamOutputPath = args.eventStreamOutputPath {
     let file = try FileHandle(forWritingAtPath: eventStreamOutputPath)
@@ -690,7 +692,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
   return configuration
 }
 
-#if canImport(Foundation) && (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT)
+#if (!SWT_NO_FILE_IO || !SWT_NO_ABI_ENTRY_POINT) && !SWT_NO_CODABLE
 /// Create an event handler that streams events to the given file using the
 /// specified ABI version.
 ///

--- a/Sources/Testing/Events/Event+FallbackEventHandler.swift
+++ b/Sources/Testing/Events/Event+FallbackEventHandler.swift
@@ -10,11 +10,17 @@
 
 private import _TestingInternals
 
+#if !SWT_NO_INTEROP
+#if SWT_NO_CODABLE
+#error("Platform-specific misconfiguration: support for the fallback event handler (XCTest interop) requires support for 'Codable'")
+#endif
+#endif
+
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly)
 public enum Interop: Sendable {}
 
 extension Interop {
-  public enum Mode: String, Sendable, Codable, CaseIterable {
+  public enum Mode: String, Sendable, CaseIterable {
     /// The interop feature is not active.
     case none
 
@@ -81,8 +87,8 @@ extension Event {
   /// - Throws: Any error that prevented handling the encoded record.
   ///
   /// - Important: This function only handles a subset of event kinds.
-  static func handle<V>(_ recordJSON: UnsafeRawBufferPointer, encodedWith version: V.Type) throws
-  where V: ABI.Version {
+  static func handle<V>(_ recordJSON: UnsafeRawBufferPointer, encodedWith version: V.Type) throws where V: ABI.Version {
+#if !SWT_NO_INTEROP
     let record = try JSON.decode(ABI.Record<V>.self, from: recordJSON)
     guard case .event(let event) = record.kind,
       var issue = Issue(decoding: event)
@@ -118,6 +124,7 @@ extension Event {
         "\(xctestWarningMessage) This is a fatal error because strict interop mode is active (\(Interop.Mode.interopModeEnvKey)=strict)",
       )
     }
+#endif
   }
 
   /// Get the best available source location to use when diagnosing an issue
@@ -142,7 +149,7 @@ extension Event {
     return .unknown
   }
 
-  #if !SWT_NO_INTEROP
+#if !SWT_NO_INTEROP
   /// The fallback event handler to install when Swift Testing is the active
   /// testing library.
   private static let _ourFallbackEventHandler: SWTFallbackEventHandler = {
@@ -181,7 +188,7 @@ extension Event {
       ).record()
     }
   }
-  #endif
+#endif
 
   /// The implementation of ``installFallbackEventHandler()``.
   private static let _installFallbackEventHandler: Bool = {
@@ -218,14 +225,14 @@ extension Event {
   ///   currently-installed handler belongs to the testing library, returns
   ///   `false`.
   borrowing func postToFallbackEventHandler(in context: borrowing Context) -> Bool {
-    #if !SWT_NO_INTEROP
+#if !SWT_NO_INTEROP
     return Self._postToFallbackEventHandler?(self, context) != nil
-    #else
+#else
     return false
-    #endif
+#endif
   }
 
-  #if !SWT_NO_INTEROP
+#if !SWT_NO_INTEROP
   /// The implementation of ``postToFallbackEventHandler(in:)`` that actually
   /// invokes the installed fallback event handler.
   ///
@@ -257,5 +264,11 @@ extension Event {
       )
     }
   }()
-  #endif
+#endif
 }
+
+#if !SWT_NO_CODABLE
+// MARK: - Codable
+
+extension Interop.Mode: Codable {}
+#endif

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -675,6 +675,8 @@ extension Event.Context {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension Event.HumanReadableOutputRecorder.Message: Codable {}
+#endif

--- a/Sources/Testing/Events/Recorder/Event.Symbol.swift
+++ b/Sources/Testing/Events/Recorder/Event.Symbol.swift
@@ -185,6 +185,8 @@ extension Event.Symbol {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension Event.Symbol: Codable {}
+#endif

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -29,6 +29,9 @@ private import CrashReporterSupport // NOTE: depends on Core Foundation!
 #if SWT_NO_PROCESS_SPAWNING
 #error("Platform-specific misconfiguration: support for exit tests requires support for process spawning")
 #endif
+#if SWT_NO_CODABLE
+#error("Platform-specific misconfiguration: support for exit tests requires support for 'Codable'")
+#endif
 #endif
 
 /// A type describing an exit test.
@@ -57,7 +60,7 @@ public struct ExitTest: Sendable, ~Copyable {
   /// time. Instances of this type are only guaranteed to be decodable by the
   /// same version of the testing library that encoded them.
   @_spi(ForToolsIntegrationOnly)
-  public struct ID: Sendable, Equatable, Codable {
+  public struct ID: Sendable, Equatable {
     /// Storage for the underlying bits of the ID.
     ///
     /// - Note: On Apple platforms, we deploy to OS versions that do not include
@@ -155,6 +158,12 @@ public struct ExitTest: Sendable, ~Copyable {
 }
 
 #if !SWT_NO_EXIT_TESTS
+#if !SWT_NO_CODABLE
+// MARK: - Codable
+
+extension ExitTest.ID: Codable {}
+#endif
+
 // MARK: - Current
 
 extension ExitTest {

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -936,6 +936,7 @@ public macro require(
   performing expression: @escaping @Sendable () async throws -> Void
 ) -> ExitTest.Result = #externalMacro(module: "TestingMacros", type: "ExitTestRequireMacro")
 
+#if !SWT_NO_CODABLE
 /// Capture a sendable and codable value to pass to an exit test.
 ///
 /// - Parameters:
@@ -953,6 +954,7 @@ public macro __capturedValue<T>(
   _ name: String,
   _ expectedType: T.Type
 ) -> T = #externalMacro(module: "TestingMacros", type: "ExitTestCapturedValueMacro") where T: Sendable & Codable
+#endif
 
 /// Emit a compile-time diagnostic when an unsupported value is captured by an
 /// exit test.

--- a/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
+++ b/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
@@ -8,6 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if !SWT_NO_CODABLE
 /// A protocol for customizing how arguments passed to parameterized tests are
 /// encoded, which is used to match against when running specific arguments.
 ///
@@ -42,6 +43,7 @@ public protocol CustomTestArgumentEncodable: Sendable {
   /// documentation for [`Encodable`](https://developer.apple.com/documentation/swift/encodable).
   func encodeTestArgument(to encoder: some Encoder) throws
 }
+#endif
 
 extension Test.Case.Argument.ID {
   /// Initialize an ID instance with the specified test argument value.
@@ -69,7 +71,7 @@ extension Test.Case.Argument.ID {
   ///
   /// - ``CustomTestArgumentEncodable``
   init?(identifying value: some Sendable, parameter: Test.Parameter) throws {
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
     func customArgumentWrapper(for value: some CustomTestArgumentEncodable) -> some Encodable {
       CustomArgumentWrapper(rawValue: value)
     }
@@ -95,8 +97,10 @@ extension Test.Case.Argument.ID {
     nil
 #endif
   }
+}
 
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
+extension Test.Case.Argument.ID {
   /// Encode the specified test argument value and store its encoded
   /// representation as an array of bytes suitable for storing in an instance of
   /// ``Test/Case/Argument/ID-swift.struct``.
@@ -115,7 +119,6 @@ extension Test.Case.Argument.ID {
       SHA256.hash(buffer)
     }
   }
-#endif
 }
 
 /// A encodable type which wraps a ``CustomTestArgumentEncodable`` value.
@@ -153,3 +156,4 @@ extension Encoder {
     userInfo[._testParameterUserInfoKey] as? Test.Parameter
   }
 }
+#endif

--- a/Sources/Testing/Parameterization/Test.Case.ID.swift
+++ b/Sources/Testing/Parameterization/Test.Case.ID.swift
@@ -65,6 +65,7 @@ extension Test.Case.ID: CustomStringConvertible {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension Test.Case.ID: Codable {
@@ -82,6 +83,7 @@ extension Test.Case.ID: Codable {
     case isStable
   }
 }
+#endif
 
 // MARK: - Equatable, Hashable
 

--- a/Sources/Testing/Parameterization/Test.Case.swift
+++ b/Sources/Testing/Parameterization/Test.Case.swift
@@ -279,10 +279,12 @@ extension Test {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension Test.Parameter: Codable {}
 extension Test.Case.Argument.ID: Codable {}
+#endif
 
 // MARK: - Equatable, Hashable
 

--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -449,6 +449,7 @@ extension TypeInfo: Hashable {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension TypeInfo: Codable {
@@ -479,6 +480,7 @@ extension TypeInfo: Codable {
 }
 
 extension TypeInfo.EncodedForm: Codable {}
+#endif
 
 // MARK: - Custom casts
 

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -462,6 +462,9 @@ extension Runner.Plan {
   }
 }
 
+#if !SWT_NO_CODABLE
+// MARK: - Codable
+
 extension Runner.Plan.Action.RunOptions: Codable {
   private enum CodingKeys: CodingKey {
     case isParallelizationEnabled
@@ -484,6 +487,7 @@ extension Runner.Plan.Action.RunOptions: Codable {
     try container.encode(false, forKey: .isParallelizationEnabled)
   }
 }
+#endif
 
 #if !SWT_NO_SNAPSHOT_TYPES
 // MARK: - Snapshotting

--- a/Sources/Testing/Running/SkipInfo.swift
+++ b/Sources/Testing/Running/SkipInfo.swift
@@ -50,9 +50,11 @@ extension SkipInfo: Error {}
 
 extension SkipInfo: Equatable, Hashable {}
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension SkipInfo: Codable {}
+#endif
 
 // MARK: -
 

--- a/Sources/Testing/SourceAttribution/Backtrace+Symbolication.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace+Symbolication.swift
@@ -114,9 +114,11 @@ extension Backtrace {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension Backtrace.SymbolicatedAddress: Codable {}
+#endif
 
 // MARK: - Swift runtime wrappers
 

--- a/Sources/Testing/SourceAttribution/Backtrace.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace.swift
@@ -102,6 +102,7 @@ public struct Backtrace: Sendable {
 
 extension Backtrace: Equatable, Hashable {}
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 // Explicitly implement Codable support by encoding and decoding the addresses
@@ -117,6 +118,7 @@ extension Backtrace: Codable {
     try addresses.encode(to: encoder)
   }
 }
+#endif
 
 // MARK: - Backtraces for thrown errors
 

--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -415,11 +415,13 @@ public struct __Expression: Sendable {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension __Expression: Codable {}
 extension __Expression.Kind: Codable {}
 extension __Expression.Value: Codable {}
+#endif
 
 // MARK: - CustomStringConvertible, CustomDebugStringConvertible
 

--- a/Sources/Testing/SourceAttribution/SourceContext.swift
+++ b/Sources/Testing/SourceAttribution/SourceContext.swift
@@ -37,9 +37,11 @@ public struct SourceContext: Sendable {
 
 extension SourceContext: Equatable, Hashable {}
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension SourceContext: Codable {}
+#endif
 
 // MARK: - Deprecated
 

--- a/Sources/Testing/SourceAttribution/SourceLocation.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation.swift
@@ -187,6 +187,7 @@ extension SourceLocation: CustomStringConvertible, CustomDebugStringConvertible 
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension SourceLocation: Codable {
@@ -220,11 +221,16 @@ extension SourceLocation: Codable {
     // For simplicity's sake, we won't be picky about which key contains the
     // file path.
     let filePath = try container.decodeIfPresent(String.self, forKey: .filePath)
-      ?? container.decode(String.self, forKey: ._filePath)
+    ?? container.decode(String.self, forKey: ._filePath)
 
     self.init(fileID: fileID, filePath: filePath, line: line, column: column)
   }
+}
+#endif
 
+// MARK: - File ID synthesis
+
+extension SourceLocation {
   init(fileIDSynthesizingIfNeeded fileID: String?, filePath: String, line: Int, column: Int) {
     // Synthesize the file ID if needed.
     let fileID = fileID ?? Self._synthesizeFileID(fromFilePath: filePath)

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -12,6 +12,12 @@
 private import Foundation
 #endif
 
+#if !SWT_NO_CODABLE
+#if !canImport(Foundation)
+#error("Platform-specific misconfiguration: support for JSON encoding and decoding requires the 'Foundation' module")
+#endif
+#endif
+
 enum JSON {
   /// Whether or not pretty-printed JSON is enabled for this process.
   ///
@@ -19,6 +25,7 @@ enum JSON {
   /// testing library to improve the readability of JSON output.
   private static let _prettyPrintingEnabled = Environment.flag(named: "SWT_PRETTY_PRINT_JSON") == true
 
+#if !SWT_NO_CODABLE
   /// Encode a value as JSON.
   ///
   /// - Parameters:
@@ -30,7 +37,6 @@ enum JSON {
   ///
   /// - Throws: Whatever is thrown by `body` or by the encoding process.
   static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: any Sendable] = [:], _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
-#if canImport(Foundation)
     let encoder = JSONEncoder()
 
     // Keys must be sorted to ensure deterministic matching of encoded data.
@@ -45,10 +51,8 @@ enum JSON {
 
     let data = try encoder.encode(value)
     return try data.withUnsafeBytes(body)
-#else
-    throw SystemError(description: "JSON encoding requires Foundation which is not available in this environment.")
-#endif
   }
+#endif
 
   /// Post-process encoded JSON and write it to a file.
   ///
@@ -74,6 +78,7 @@ enum JSON {
     }
   }
 
+#if !SWT_NO_CODABLE
   /// Decode a value from JSON data.
   ///
   /// - Parameters:
@@ -84,7 +89,6 @@ enum JSON {
   ///
   /// - Throws: Whatever is thrown by the decoding process.
   static func decode<T>(_ type: T.Type, from jsonRepresentation: UnsafeRawBufferPointer) throws -> T where T: Decodable {
-#if canImport(Foundation)
     try withExtendedLifetime(jsonRepresentation) {
       let byteCount = jsonRepresentation.count
       let data = if byteCount > 0 {
@@ -98,8 +102,6 @@ enum JSON {
       }
       return try JSONDecoder().decode(type, from: data)
     }
-#else
-    throw SystemError(description: "JSON decoding requires Foundation which is not available in this environment.")
-#endif
   }
+#endif
 }

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -8,24 +8,22 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if !SWT_NO_CODABLE
 #if canImport(Foundation)
 private import Foundation
-#endif
-
-#if !SWT_NO_CODABLE
-#if !canImport(Foundation)
+#else
 #error("Platform-specific misconfiguration: support for JSON encoding and decoding requires the 'Foundation' module")
 #endif
 #endif
 
 enum JSON {
+#if !SWT_NO_CODABLE
   /// Whether or not pretty-printed JSON is enabled for this process.
   ///
   /// This is a debugging tool that can be used by developers working on the
   /// testing library to improve the readability of JSON output.
   private static let _prettyPrintingEnabled = Environment.flag(named: "SWT_PRETTY_PRINT_JSON") == true
 
-#if !SWT_NO_CODABLE
   /// Encode a value as JSON.
   ///
   /// - Parameters:

--- a/Sources/Testing/Test.ID.swift
+++ b/Sources/Testing/Test.ID.swift
@@ -156,6 +156,8 @@ extension Test.ID: CustomStringConvertible {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension Test.ID: Codable {}
+#endif

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -400,6 +400,10 @@ extension Test: Equatable, Hashable {
 #if !SWT_NO_SNAPSHOT_TYPES
 // MARK: - Snapshotting
 
+#if SWT_NO_CODABLE
+#error("Platform-specific misconfiguration: support for snapshot types requires support for 'Codable'")
+#endif
+
 extension Test {
   /// A serializable snapshot of a ``Test`` instance.
   @_spi(ForToolsIntegrationOnly)

--- a/Sources/Testing/Traits/Bug.swift
+++ b/Sources/Testing/Traits/Bug.swift
@@ -46,9 +46,11 @@ extension Bug: Equatable, Hashable {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension Bug: Codable {}
+#endif
 
 // MARK: - Trait, TestTrait, SuiteTrait
 

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -131,11 +131,12 @@ extension Comment: ExpressibleByStringInterpolation {
 
 extension Comment: Equatable, Hashable {}
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension Comment: Codable {}
-
 extension Comment.Kind: Codable {}
+#endif
 
 // MARK: - Trait, TestTrait, SuiteTrait
 

--- a/Sources/Testing/Traits/ParallelizationTrait.swift
+++ b/Sources/Testing/Traits/ParallelizationTrait.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && _runtime(_ObjC)
+#if _runtime(_ObjC)
 private import ObjectiveC
 #endif
 

--- a/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
+++ b/Sources/Testing/Traits/Tags/Tag.Color+Loading.swift
@@ -95,6 +95,7 @@ var swiftTestingDirectoryPath: String? {
 /// string values and the values represent tag colors. For a list of the
 /// supported formats for tag colors in this dictionary, see <doc:AddingTags>.
 func loadTagColors(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String? = swiftTestingDirectoryPath) throws -> [Tag: Tag.Color] {
+#if !SWT_NO_CODABLE
   guard let swiftTestingDirectoryPath else {
     // If the platform does not support user-specific configuration, skip custom
     // tag colors.
@@ -117,5 +118,8 @@ func loadTagColors(fromFileInDirectoryAtPath swiftTestingDirectoryPath: String? 
     try JSON.decode([Tag: Tag.Color?].self, from: tagColorsData)
       .compactMapValues { $0 }
   }
+#else
+  return [:]
+#endif
 }
 #endif

--- a/Sources/Testing/Traits/Tags/Tag.Color.swift
+++ b/Sources/Testing/Traits/Tags/Tag.Color.swift
@@ -126,7 +126,8 @@ extension Tag.Color: Comparable {
   }
 }
 
-// MARK: - Comparable
+#if !SWT_NO_CODABLE
+// MARK: - Codable
 
 extension Tag.Color: Decodable {
   public init(from decoder: any Decoder) throws {
@@ -163,3 +164,4 @@ extension Tag.Color: Decodable {
     }
   }
 }
+#endif

--- a/Sources/Testing/Traits/Tags/Tag.swift
+++ b/Sources/Testing/Traits/Tags/Tag.swift
@@ -48,6 +48,19 @@ public struct Tag: Sendable {
   public init(userProvidedStringValue stringValue: String) {
     self.init(_codableStringValue: stringValue)
   }
+
+  /// Initialize an instance of this type from a string previously encoded from
+  /// the `_codableStringValue` property.
+  ///
+  /// - Parameters:
+  ///   - stringValue: The previously-encoded string.
+  private init(_codableStringValue stringValue: String) {
+    if stringValue.first == "." {
+      self.init(kind: .staticMember(String(stringValue.dropFirst())))
+    } else {
+      self.init(kind: .staticMember(stringValue))
+    }
+  }
 }
 
 // MARK: - CustomStringConvertible
@@ -72,22 +85,10 @@ extension Tag: Equatable, Hashable, Comparable {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable, CodingKeyRepresentable
 
 extension Tag: Codable, CodingKeyRepresentable {
-  /// Initialize an instance of this type from a string previously encoded from
-  /// the `_codableStringValue` property.
-  ///
-  /// - Parameters:
-  ///   - stringValue: The previously-encoded string.
-  private init(_codableStringValue stringValue: String) {
-    if stringValue.first == "." {
-      self.init(kind: .staticMember(String(stringValue.dropFirst())))
-    } else {
-      self.init(kind: .staticMember(stringValue))
-    }
-  }
-
   public init(from decoder: any Decoder) throws {
     let stringValue = try String(from: decoder)
     self.init(_codableStringValue: stringValue)
@@ -132,6 +133,7 @@ extension Tag: Codable, CodingKeyRepresentable {
     self.init(_codableStringValue: codingKey.stringValue)
   }
 }
+#endif
 
 // MARK: -
 

--- a/Sources/_TestDiscovery/TestContentKind.swift
+++ b/Sources/_TestDiscovery/TestContentKind.swift
@@ -50,7 +50,7 @@ extension TestContentKind: Equatable, Hashable {
   }
 }
 
-#if !hasFeature(Embedded)
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension TestContentKind: Codable {}

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -10,8 +10,8 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
+#if !SWT_NO_CODABLE
 @Suite struct `ABI.EncodedEventTests` {
-#if canImport(Foundation)
   /// Creates an EncodedEvent from a JSON string.
   ///
   /// - Throws: If the JSON doesn't represent a valid EncodedEvent.
@@ -118,5 +118,5 @@
       return
     }
   }
-#endif
 }
+#endif

--- a/Tests/TestingTests/ABI.EncodedTestTests.swift
+++ b/Tests/TestingTests/ABI.EncodedTestTests.swift
@@ -10,10 +10,6 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-#if canImport(Foundation)
-private import Foundation
-#endif
-
 @Suite struct `ABI.EncodedTestTests` {
   let fixture = ABI.EncodedTest<ABI.CurrentVersion>(
     kind: .function,
@@ -21,13 +17,15 @@ private import Foundation
     sourceLocation: .init(),
     id: .init(encoding: .init([])))  // Blank placeholder; should be set in each test case
 
+#if !SWT_NO_CODABLE
   /// Creates an EncodedTest.ID from a string.
   ///
   /// It doesn't really "decode" anything and just stores the string, so this
   /// should never throw in practice.
   func testID<V: ABI.Version>(_ string: String) throws -> ABI.EncodedTest<V>.ID {
-    let data = try JSONEncoder().encode(string)
-    return try JSONDecoder().decode(ABI.EncodedTest<V>.ID.self, from: data)
+    try JSON.withEncoding(of: string) { data in
+      try JSON.decode(ABI.EncodedTest<V>.ID.self, from: data)
+    }
   }
 
   @Test func `Decode test components`() throws {
@@ -98,4 +96,5 @@ private import Foundation
 
     #expect(test.decodeIDComponents() == nil)
   }
+#endif
 }

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -8,13 +8,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_ABI_ENTRY_POINT
+#if !SWT_NO_ABI_ENTRY_POINT
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
-
-#if canImport(Foundation)
-private import Foundation
-#endif
 
 #if !SWT_TARGET_OS_APPLE && canImport(Synchronization)
 import Synchronization
@@ -144,7 +140,6 @@ struct ABIEntryPointTests {
     return try await abiEntryPoint(.init(argumentsJSON), recordHandler)
   }
 
-#if canImport(Foundation)
   @Test func decodeEmptyConfiguration() throws {
     let emptyBuffer = UnsafeRawBufferPointer(start: nil, count: 0)
     #expect(throws: DecodingError.self) {
@@ -184,7 +179,6 @@ struct ABIEntryPointTests {
       }
     }
   }
-#endif
 
   @Test(arguments: [
     (VersionNumber(-1, 0), "-1"),

--- a/Tests/TestingTests/AdvancedConsoleOutputRecorderTests.swift
+++ b/Tests/TestingTests/AdvancedConsoleOutputRecorderTests.swift
@@ -8,10 +8,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-import Foundation
 #if !SWT_TARGET_OS_APPLE && canImport(Synchronization)
 import Synchronization
 #endif

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -387,6 +387,7 @@ struct AttachmentTests {
   }
 #endif
 
+#if !SWT_NO_CODABLE
   struct CodableAttachmentArguments: Sendable, CustomTestArgumentEncodable, CustomTestStringConvertible {
     var forSecureCoding: Bool
     var pathExtension: String?
@@ -489,6 +490,7 @@ struct AttachmentTests {
       try attachment.attachableValue.withUnsafeBytes(for: attachment) { _ in }
     }
   }
+#endif
 #endif
 
 #if canImport(CoreTransferable) && canImport(_Testing_CoreTransferable)
@@ -991,7 +993,7 @@ extension AttachmentTests {
 #endif
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
 #if !SWT_NO_FILE_IO
   @Test("Decoding an encoded attachment with path")
   func decodingAnEncodedAttachmentWithPath() throws {
@@ -1147,9 +1149,11 @@ struct MyBadTransferable: Transferable, Equatable {
 #endif
 
 #if canImport(Foundation) && canImport(_Testing_Foundation)
+#if !SWT_NO_CODABLE
 struct MyCodableAttachable: Codable, Attachable, Sendable {
   var string: String
 }
+#endif
 
 final class MySecureCodingAttachable: NSObject, NSSecureCoding, Attachable, Sendable {
   let string: String
@@ -1171,6 +1175,7 @@ final class MySecureCodingAttachable: NSObject, NSSecureCoding, Attachable, Send
   }
 }
 
+#if !SWT_NO_CODABLE
 final class MyCodableAndSecureCodingAttachable: NSObject, Codable, NSSecureCoding, Attachable, Sendable {
   let string: String
 
@@ -1186,6 +1191,7 @@ final class MyCodableAndSecureCodingAttachable: NSObject, Codable, NSSecureCodin
     string = (coder.decodeObject(of: NSString.self, forKey: "string") as? String) ?? ""
   }
 }
+#endif
 #endif
 
 #if canImport(AppKit) && canImport(_Testing_AppKit)

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(ForToolsIntegrationOnly) import Testing
 #if SWT_TARGET_OS_APPLE && canImport(Foundation)
-import Foundation // for NSError
+private import class Foundation.NSError
 #endif
 
 struct BacktracedError: Error {}

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(ForToolsIntegrationOnly) import Testing
 #if SWT_TARGET_OS_APPLE && canImport(Foundation)
-import Foundation
+import Foundation // for NSError
 #endif
 
 struct BacktracedError: Error {}
@@ -141,7 +141,7 @@ struct BacktraceTests {
     #expect(Backtrace(forFirstThrowOf: BacktracedError()) == nil)
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
   @Test("Encoding/decoding")
   func encodingAndDecoding() throws {
     let original = Backtrace.current()

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -102,7 +102,7 @@ struct ClockTests {
     #expect(duration == .nanoseconds(offsetNanoseconds))
   }
 
-#if !SWT_NO_SNAPSHOT_TYPES && canImport(Foundation)
+#if !SWT_NO_SNAPSHOT_TYPES
   @Test("Codable")
   func codable() async throws {
     let now = Test.Clock.Instant()

--- a/Tests/TestingTests/ConfirmationTests.swift
+++ b/Tests/TestingTests/ConfirmationTests.swift
@@ -10,10 +10,6 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-#if canImport(Foundation)
-private import Foundation
-#endif
-
 @Suite("Confirmation Tests")
 struct ConfirmationTests {
   @Test("Successful confirmations")

--- a/Tests/TestingTests/DiscoveryTests.swift
+++ b/Tests/TestingTests/DiscoveryTests.swift
@@ -10,9 +10,6 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import _TestDiscovery
-#if canImport(Foundation)
-private import Foundation
-#endif
 
 @Suite("Runtime Test Discovery Tests")
 struct DiscoveryTests {
@@ -30,13 +27,14 @@ struct DiscoveryTests {
     #expect(String(describing: kind3).lowercased() == "0xff123456")
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
   @Test func testContentKindCodableConformance() throws {
     let kind1: TestContentKind = "moof"
-    let data = try JSONEncoder().encode(kind1)
-    let uint32 = try JSONDecoder().decode(UInt32.self, from: data)
-    let kind2 = try JSONDecoder().decode(TestContentKind.self, from: data)
-    #expect(uint32 == kind2.rawValue)
+    try JSON.withEncoding(of: kind1) { data in
+      let uint32 = try JSON.decode(UInt32.self, from: data)
+      let kind2 = try JSON.decode(TestContentKind.self, from: data)
+      #expect(uint32 == kind2.rawValue)
+    }
   }
 #endif
 

--- a/Tests/TestingTests/EventHandlingInteropTests.swift
+++ b/Tests/TestingTests/EventHandlingInteropTests.swift
@@ -287,7 +287,7 @@ struct EventHandlingInteropTests {
       try Self.handlerContents.withLock {
         let contents = try #require(
           $0, "Fallback should have been called with non nil contents")
-        let recordData = try #require(contents.record?.utf8CString)
+        let recordData = try #require(contents.record.map(\.utf8).map(Array.init))
         let record = try recordData.withUnsafeBytes { recordData in
           try JSON.decode(ABI.Record<ABI.v6_3>.self, from: recordData)
         }

--- a/Tests/TestingTests/EventHandlingInteropTests.swift
+++ b/Tests/TestingTests/EventHandlingInteropTests.swift
@@ -11,9 +11,6 @@
 @testable @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
 
-#if canImport(Foundation)
-import Foundation
-#endif
 #if !SWT_TARGET_OS_APPLE && canImport(Synchronization)
 import Synchronization
 #endif
@@ -25,7 +22,7 @@ let interopHandlerMayBeInstalled = Environment.variable(named: "XCTestSessionIde
 let interopHandlerMayBeInstalled = false
 #endif
 
-#if !SWT_NO_EXIT_TESTS && !SWT_NO_INTEROP && canImport(Foundation)
+#if !SWT_NO_EXIT_TESTS && !SWT_NO_INTEROP
 @Suite(.disabled(if: interopHandlerMayBeInstalled))
 struct EventHandlingInteropTests {
   static let handlerContents = Mutex<(version: String, record: String?)?>()
@@ -33,9 +30,8 @@ struct EventHandlingInteropTests {
   private static let capturingHandler: SWTFallbackEventHandler = {
     schemaVersion, recordJSONBaseAddress, recordJSONByteCount, _ in
     let version = String(cString: schemaVersion)
-    let record = String(
-      data: Data(bytes: recordJSONBaseAddress, count: recordJSONByteCount),
-      encoding: .utf8)
+    let recordJSON = UnsafeRawBufferPointer(start: recordJSONBaseAddress, count: recordJSONByteCount)
+    let record = String(decoding: recordJSON, as: UTF8.self)
     Self.handlerContents.withLock {
       $0 = (version: version, record: record)
     }
@@ -165,7 +161,7 @@ struct EventHandlingInteropTests {
 
       // Pass an invalid record JSON to the event handler
       let issues = await Test {
-        let emptyJSON = "{}".data(using: .utf8)!
+        let emptyJSON = Array("{}".utf8)
         try _FakeXCTFail(payload: emptyJSON)
       }.runCapturingIssues()
 
@@ -291,8 +287,10 @@ struct EventHandlingInteropTests {
       try Self.handlerContents.withLock {
         let contents = try #require(
           $0, "Fallback should have been called with non nil contents")
-        let recordData = try #require(contents.record?.data(using: .utf8))
-        let record = try JSONDecoder().decode(ABI.Record<ABI.v6_3>.self, from: recordData)
+        let recordData = try #require(contents.record?.utf8CString)
+        let record = try recordData.withUnsafeBytes { recordData in
+          try JSON.decode(ABI.Record<ABI.v6_3>.self, from: recordData)
+        }
         guard case .event(let event) = record.kind else {
           Issue.record("Wrong type of record: \(record)")
           return
@@ -325,22 +323,21 @@ struct EventHandlingInteropTests {
     }
   }
 }
-#endif
 
 /// Simulates the behaviour of XCTFail when called in a Swift Testing test.
 /// This always forwards a test failure through the fallback event handler if it can find one.
 /// It is an error to call this when a handler hasn't been installed yet.
 /// - Parameter payload: Optional payload to use instead of generating a standard one.
-private func _FakeXCTFail(payload: Data? = nil, severity: Issue.Severity = .error) throws {
+private func _FakeXCTFail(payload: [UInt8]? = nil, severity: Issue.Severity = .error) throws {
   // A fallback event handler must be installed ahead of time
   let currentHandler = try #require(_swift_testing_getFallbackEventHandler())
 
-  func wrapInEncodedEvent(issue: Issue) throws -> Data {
+  func wrapInEncodedEvent(issue: Issue) throws -> [UInt8] {
     let event = Event(.issueRecorded(issue), testID: nil, testCaseID: nil, instant: .now)
     let encodedEvent = ABI.Record<ABI.CurrentVersion>(
       encoding: event, in: .init(test: nil, testCase: nil, iteration: nil, configuration: nil),
       messages: [])
-    return try JSONEncoder().encode(encodedEvent)
+    return try JSON.withEncoding(of: encodedEvent) { Array($0) }
   }
 
   let encodedIssue = try payload ?? wrapInEncodedEvent(issue: .init(kind: .unconditional, severity: severity))
@@ -350,3 +347,4 @@ private func _FakeXCTFail(payload: Data? = nil, severity: Issue.Severity = .erro
     currentHandler(vers, ptr.baseAddress!, ptr.count, nil)
   }
 }
+#endif

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -11,7 +11,7 @@
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
 #if canImport(Foundation)
-import Foundation
+import Foundation // for XML API
 #endif
 #if canImport(FoundationXML)
 import FoundationXML

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -14,7 +14,6 @@ private import _TestingInternals
 
 @Suite("Event Tests")
 struct EventTests {
-#if canImport(Foundation)
   @Test("Event's and Event.Kinds's Codable Conformances",
         arguments: [
           Event.Kind.expectationChecked(
@@ -76,6 +75,5 @@ struct EventTests {
     #expect(String(describing: decoded.testCase) == String(describing: eventContext.testCase.map(Test.Case.Snapshot.init(snapshotting:))))
     #expect(decoded.iteration == eventContext.iteration)
   }
-#endif
 }
 #endif

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1715,9 +1715,7 @@ final class IssueTests: XCTestCase {
 }
 #endif
 
-#if canImport(Foundation) && !SWT_NO_SNAPSHOT_TYPES
-import Foundation
-
+#if !SWT_NO_SNAPSHOT_TYPES
 @Suite("Issue Codable Conformance Tests")
 struct IssueCodingTests {
 

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -12,10 +12,6 @@
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import _TestDiscovery
 private import _TestingInternals
 
-#if canImport(Foundation)
-private import Foundation
-#endif
-
 @Test(/* name unspecified */ .hidden)
 @Sendable func freeSyncFunction() {}
 @Sendable func freeAsyncFunction() async {}

--- a/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
+++ b/Tests/TestingTests/Runner.Plan.SnapshotTests.swift
@@ -13,7 +13,6 @@
 
 @Suite("Runner.Plan.Snapshot tests")
 struct Runner_Plan_SnapshotTests {
-#if canImport(Foundation)
   @Test("Codable")
   func codable() async throws {
     let suite = try #require(await test(for: Runner_Plan_SnapshotFixtures.self))
@@ -46,7 +45,6 @@ struct Runner_Plan_SnapshotTests {
       }
     }
   }
-#endif
 }
 
 // MARK: - Fixture tests

--- a/Tests/TestingTests/SkipInfoTests.swift
+++ b/Tests/TestingTests/SkipInfoTests.swift
@@ -29,7 +29,7 @@ struct SkipInfoTests {
     #expect(skipInfo.sourceLocation == sourceLocation2)
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
   @Test(
     "Decode from event",
     arguments: [

--- a/Tests/TestingTests/SourceLocationTests.swift
+++ b/Tests/TestingTests/SourceLocationTests.swift
@@ -10,10 +10,6 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-#if canImport(Foundation)
-private import Foundation
-#endif
-
 @Suite("SourceLocation Tests")
 struct SourceLocationTests {
   @Test("SourceLocation.description property")
@@ -69,7 +65,7 @@ struct SourceLocationTests {
     #expect(sourceLocation.fileName == "D.swift")
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
   @Test("SourceLocation.fileID property is synthesized if not decoded")
   func sourceLocationFileIDSynthesizedWhenNeeded() throws {
 #if os(Windows)

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -11,15 +11,12 @@
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
 
-#if canImport(Foundation)
-private import Foundation
-#endif
-
 private func configurationForEntryPoint(withArguments args: [String]) throws -> Configuration {
   let args = try parseCommandLineArguments(from: args)
   return try configurationForEntryPoint(from: args)
 }
 
+#if !SWT_NO_CODABLE
 /// Reads event stream output from the provided file matching event stream
 /// version `V`.
 private func decodedEventStreamRecords<V: ABI.Version>(fromPath filePath: String) throws -> [ABI.Record<V>] {
@@ -31,6 +28,7 @@ private func decodedEventStreamRecords<V: ABI.Version>(fromPath filePath: String
       }
     }
 }
+#endif
 
 @Suite("Swift Package Manager Integration Tests")
 struct SwiftPMTests {
@@ -230,7 +228,6 @@ struct SwiftPMTests {
     #expect(fileContents.contains(UInt8(ascii: ">")))
   }
 
-#if canImport(Foundation)
   @Test("--configuration-path argument", arguments: [
     "--configuration-path", "--experimental-configuration-path",
   ])
@@ -328,6 +325,7 @@ struct SwiftPMTests {
   }
 #endif
 
+#if !SWT_NO_CODABLE
   @Test("Severity and isFailure fields included in version 6.3")
   func validateEventStreamContents() async throws {
     let tempDirPath = try temporaryDirectory()

--- a/Tests/TestingTests/Test.Case.Argument.IDTests.swift
+++ b/Tests/TestingTests/Test.Case.Argument.IDTests.swift
@@ -12,6 +12,7 @@
 
 @Suite("Test.Case.Argument.ID Tests")
 struct Test_Case_Argument_IDTests {
+#if !SWT_NO_CODABLE
   @Test("One Codable parameter")
   func oneCodableParameter() async throws {
     let test = Test(
@@ -38,12 +39,11 @@ struct Test_Case_Argument_IDTests {
     let arguments = try #require(testCase.arguments)
     #expect(arguments.count == 1)
     let argument = try #require(arguments.first)
-#if canImport(Foundation)
     try JSON.withEncoding(of: CustomArgumentWrapper(rawValue: argumentValue)) { data in
       #expect(argument.id.bytes == SHA256.hash(data))
     }
-#endif
   }
+#endif
 
   @Test("One Identifiable parameter")
   func oneIdentifiableParameter() async throws {
@@ -74,6 +74,7 @@ struct Test_Case_Argument_IDTests {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Fixture parameter types
 
 private struct MyCustomTestArgument: CustomTestArgumentEncodable, Equatable {
@@ -95,6 +96,7 @@ extension MyCustomTestArgument: Decodable {}
 
 @available(*, unavailable, message: "Intentionally not Encodable")
 extension MyCustomTestArgument: Encodable {}
+#endif
 
 private struct MyIdentifiableArgument: Identifiable {
   var id: String

--- a/Tests/TestingTests/Test.CaseTests.swift
+++ b/Tests/TestingTests/Test.CaseTests.swift
@@ -10,10 +10,6 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-#if canImport(Foundation)
-private import Foundation
-#endif
-
 @Suite("Test.Case Tests")
 struct Test_CaseTests {
   @Test func nonParameterized() throws {
@@ -43,6 +39,7 @@ struct Test_CaseTests {
     #expect(testCase.id.isStable)
   }
 
+#if !SWT_NO_CODABLE
   @Test("Two arguments: one non-stable, followed by one stable")
   func nonStableAndStableArgument() throws {
     let testCase = Test.Case(
@@ -58,7 +55,6 @@ struct Test_CaseTests {
 
   @Suite("Test.Case.ID Tests")
   struct IDTests {
-#if canImport(Foundation)
     @Test(arguments: [
       Test.Case.ID(argumentIDs: nil, discriminator: nil, isStable: true),
       Test.Case.ID(argumentIDs: [.init(bytes: "x".utf8)], discriminator: 0, isStable: false),
@@ -69,15 +65,17 @@ struct Test_CaseTests {
     }
 
     @Test func decoding_nonParameterized() throws {
-      let encodedData = Data(#"{"isStable": true}"#.utf8)
-      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData)
+      let encodedData = Array(#"{"isStable": true}"#.utf8)
+      let testCaseID = try encodedData.withUnsafeBytes { encodedData in
+        try JSON.decode(Test.Case.ID.self, from: encodedData)
+      }
       #expect(testCaseID.isStable)
       #expect(testCaseID.argumentIDs == nil)
       #expect(testCaseID.discriminator == nil)
     }
 
     @Test func decoding_parameterizedStable() throws {
-      let encodedData = Data("""
+      let encodedData = Array("""
         {
           "isStable": true,
           "argIDs": [
@@ -86,17 +84,20 @@ struct Test_CaseTests {
           "discriminator": 0
         }
         """.utf8)
-      let testCaseID = try JSON.decode(Test.Case.ID.self, from: encodedData)
+      let testCaseID = try encodedData.withUnsafeBytes { encodedData in
+        try JSON.decode(Test.Case.ID.self, from: encodedData)
+      }
       #expect(testCaseID.isStable)
       #expect(testCaseID.argumentIDs?.count == 1)
       #expect(testCaseID.discriminator == 0)
     }
-#endif
   }
+#endif
 }
 
 // MARK: - Fixtures, helpers
 
+#if !SWT_NO_CODABLE
 private struct NonCodable {}
 
 private struct IssueRecordingEncodable: Encodable {
@@ -104,3 +105,4 @@ private struct IssueRecordingEncodable: Encodable {
     Issue.record("Unexpected attempt to encode an instance of \(Self.self)")
   }
 }
+#endif

--- a/Tests/TestingTests/Test.SnapshotTests.swift
+++ b/Tests/TestingTests/Test.SnapshotTests.swift
@@ -13,7 +13,6 @@
 
 @Suite("Test.Snapshot tests")
 struct Test_SnapshotTests {
-#if canImport(Foundation)
   @Test("Codable")
   func codable() throws {
     let test = try #require(Test.current)
@@ -27,7 +26,6 @@ struct Test_SnapshotTests {
     // FIXME: Compare traits as well, once they are included.
     #expect(decoded.parameters == snapshot.parameters)
   }
-#endif
 
   @Test("isParameterized property")
   func isParameterized() async throws {

--- a/Tests/TestingTests/TestCaseSelectionTests.swift
+++ b/Tests/TestingTests/TestCaseSelectionTests.swift
@@ -113,6 +113,7 @@ struct TestCaseSelectionTests {
     }
   }
 
+#if !SWT_NO_CODABLE
   @Test("Multiple arguments conforming to CustomTestArgumentEncodable, passed to one parameter, selecting one case")
   func oneParameterAcceptingCustomTestArgumentSelectingOneCase() async throws {
     let fixtureTest = Test(arguments: [
@@ -142,6 +143,7 @@ struct TestCaseSelectionTests {
       await fixtureTest.run(configuration: configuration)
     }
   }
+#endif
 
   @Test("Multiple arguments conforming to Identifiable, passed to one parameter, selecting one case")
   func oneParameterAcceptingIdentifiableArgumentSelectingOneCase() async throws {
@@ -204,6 +206,7 @@ struct TestCaseSelectionTests {
   }
 }
 
+#if !SWT_NO_CODABLE
 // MARK: - Fixture parameter types
 
 private struct MyCustomTestArgument: CustomTestArgumentEncodable, Equatable {
@@ -220,6 +223,7 @@ private struct MyCustomTestArgument: CustomTestArgumentEncodable, Equatable {
     try container.encode(y, forKey: .y)
   }
 }
+#endif
 
 private struct MyCustomIdentifiableArgument: Identifiable, CustomStringConvertible {
   var id: String

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -14,10 +14,6 @@
 import XCTest
 #endif
 
-#if canImport(Foundation)
-import Foundation
-#endif
-
 #if canImport(Synchronization)
 private import Synchronization
 #endif
@@ -425,6 +421,7 @@ let testsWithSignificantIOAreEnabled = Environment.flag(named: "SWT_ENABLE_TESTS
 /// should enable these tests.
 let performanceTestsEnabled = Environment.flag(named: "SWT_ENABLE_PERFORMANCE_TESTS") == true
 
+#if !SWT_NO_CODABLE
 extension JSON {
   /// Round-trip a value through JSON encoding/decoding.
   ///
@@ -439,25 +436,8 @@ extension JSON {
       try JSON.decode(T.self, from: data)
     }
   }
-
-#if canImport(Foundation)
-  /// Decode a value from JSON data.
-  ///
-  /// - Parameters:
-  ///   - type: The type of value to decode.
-  ///   - jsonRepresentation: Data of the JSON encoding of the value to decode.
-  ///
-  /// - Returns: An instance of `T` decoded from `jsonRepresentation`.
-  ///
-  /// - Throws: Whatever is thrown by the decoding process.
-  @_disfavoredOverload
-  static func decode<T>(_ type: T.Type, from jsonRepresentation: Data) throws -> T where T: Decodable {
-    try jsonRepresentation.withUnsafeBytes { bytes in
-      try JSON.decode(type, from: bytes)
-    }
-  }
-#endif
 }
+#endif
 
 extension Trait where Self == TimeLimitTrait {
   /// Construct a time limit trait that causes a test to time out if it runs for

--- a/Tests/TestingTests/Traits/BugTests.swift
+++ b/Tests/TestingTests/Traits/BugTests.swift
@@ -84,7 +84,7 @@ struct BugTests {
     #expect(traits.count == 3)
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
   @Test("Encoding/decoding")
   func encodingAndDecoding() throws {
     let original = Bug.bug(id: 12345, "Lorem ipsum")

--- a/Tests/TestingTests/Traits/ParallelizationTraitTests.swift
+++ b/Tests/TestingTests/Traits/ParallelizationTraitTests.swift
@@ -11,10 +11,6 @@
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
 
-#if canImport(Foundation)
-import Foundation
-#endif
-
 #if canImport(Synchronization)
 private import Synchronization
 #endif

--- a/Tests/TestingTests/Traits/TagListTests.swift
+++ b/Tests/TestingTests/Traits/TagListTests.swift
@@ -11,10 +11,6 @@
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
 
-#if canImport(Foundation)
-private import Foundation
-#endif
-
 @Suite("Tag/Tag List Tests", .tags(.traitRelated))
 struct TagListTests {
   @Test(".tags() factory method with one tag")
@@ -102,7 +98,7 @@ struct TagListTests {
     #expect(Tag(userProvidedStringValue: ".red") == .red)
   }
 
-#if canImport(Foundation)
+#if !SWT_NO_CODABLE
   @Test("Encoding/decoding tags")
   func encodeAndDecodeTags() throws {
     let array: [Tag] = [.red, .orange, Tag("abc123"), Tag(".abc123")]

--- a/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
+++ b/Tests/TestingTests/Traits/TimeLimitTraitTests.swift
@@ -10,9 +10,6 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-#if canImport(Foundation)
-private import Foundation
-#endif
 #if canImport(Synchronization)
 private import Synchronization
 #endif


### PR DESCRIPTION
This PR wraps all our uses of `Codable` and related API in `!SWT_NO_CODABLE` checks, and sets `SWT_NO_CODABLE` under Embedded Swift. This PR also removes a number of explicit dependencies on Foundation, mostly in our test suite, and swaps out `canImport(Foundation)` for `!SWT_NO_CODABLE` where the latter is more semantically correct.

This PR doesn't try to provide an alternative API surface for Embedded Swift that isn't reliant on JSON encoding/decoding; that's not a "today" problem.

Resolves rdar://175709858.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
