### PR TITLE
Apply parameterized test optimizations for `Dictionary` to `KeyValuePairs`.

### DIFF
--- a/Sources/Testing/Parameterization/Test.Case.Generator.swift
+++ b/Sources/Testing/Parameterization/Test.Case.Generator.swift
@@ -226,24 +226,24 @@ extension Test.Case {
     ///   - testFunction: The test function to which each generated test case
     ///     passes an argument value from `dictionary`.
     ///
-    /// This initializer overload is specialized for dictionary collections, to
-    /// efficiently de-structure their elements (which are known to be 2-tuples)
-    /// when appropriate. This overload is distinct from those for other
-    /// collections of 2-tuples because the `Element` tuple type for
-    /// `Dictionary` includes labels (`(key: Key, value: Value)`).
-    init<Key, Value>(
-      arguments dictionary: Dictionary<Key, Value>,
+    /// This initializer overload is specialized for dictionary-like collections
+    /// to efficiently de-structure their elements (which are known to be
+    /// 2-tuples) when appropriate. This overload is distinct from those for
+    /// other collections of 2-tuples because the `Element` tuple type for these
+    /// kinds of collections includes labels (`(key: Key, value: Value)`).
+    init(
+      arguments collection: S,
       parameters: [Test.Parameter],
-      testFunction: @escaping @Sendable ((Key, Value)) async throws -> Void
-    ) where S == Dictionary<Key, Value> {
+      testFunction: @escaping @Sendable ((S.Key, S.Value)) async throws -> Void
+    ) where S: __DictionaryLikeCollection {
       if parameters.count > 1 {
-        self.init(sequence: dictionary) { element in
+        self.init(sequence: collection) { element in
           Test.Case(values: [element.key, element.value], parameters: parameters) {
             try await testFunction(element)
           }
         }
       } else {
-        self.init(sequence: dictionary) { element in
+        self.init(sequence: collection) { element in
           Test.Case(values: [element], parameters: parameters) {
             try await testFunction(element)
           }

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -437,25 +437,25 @@ extension Test {
 
   /// Create an instance of ``Test`` for a parameterized function.
   ///
-  /// This initializer overload is specialized for dictionary collections, to
-  /// efficiently de-structure their elements (which are known to be 2-tuples)
-  /// when appropriate. This overload is distinct from those for other
-  /// collections of 2-tuples because the `Element` tuple type for
-  /// `Dictionary` includes labels (`(key: Key, value: Value)`).
+  /// This initializer overload is specialized for dictionary-like collections
+  /// to efficiently de-structure their elements (which are known to be
+  /// 2-tuples) when appropriate. This overload is distinct from those for other
+  /// collections of 2-tuples because the `Element` tuple type for these kinds
+  /// of collections includes labels (`(key: Key, value: Value)`).
   ///
   /// - Warning: This function is used to implement the `@Test` macro. Do not
   ///   call it directly.
-  public static func __function<S, Key, Value>(
+  public static func __function<S, C>(
     named testFunctionName: String,
     in containingType: S.Type?,
     xcTestCompatibleSelector: __XCTestCompatibleSelector?,
     displayName: String? = nil,
     traits: [any TestTrait],
-    arguments dictionary: @escaping @Sendable () async throws -> Dictionary<Key, Value>,
+    arguments dictionary: @escaping @Sendable () async throws -> C,
     sourceBounds: __SourceBounds,
     parameters paramTuples: [__Parameter],
-    testFunction: @escaping @Sendable ((Key, Value)) async throws -> Void
-  ) -> Self where S: ~Copyable & ~Escapable, Key: Sendable, Value: Sendable {
+    testFunction: @escaping @Sendable (C.Element) async throws -> Void
+  ) -> Self where S: ~Copyable & ~Escapable, C: __DictionaryLikeCollection & Sendable, C.Key: Sendable, C.Value: Sendable {
     let containingTypeInfo: TypeInfo? = if let containingType {
       TypeInfo(describing: containingType)
     } else {
@@ -528,6 +528,21 @@ extension Test {
 @attached(peer) public macro __testing(
   warning message: _const String
 ) = #externalMacro(module: "TestingMacros", type: "PragmaMacro")
+
+// MARK: - Dictionary-like collection disambiguation
+
+/// A protocol that describes the basic shape of a "dictionary-like" collection
+/// whose elements are key-value pairs.
+///
+/// - Warning: This protocol is used to implement the `@Test` macro. Do not use
+///   it directly.
+public protocol __DictionaryLikeCollection<Key, Value>: Collection where Element == (key: Key, value: Value) {
+  associatedtype Key
+  associatedtype Value
+}
+
+extension Dictionary: __DictionaryLikeCollection {}
+extension KeyValuePairs: __DictionaryLikeCollection {}
 
 // MARK: - Helper functions
 


### PR DESCRIPTION
This change ensures that test authors who explicitly pass collections of type `KeyValuePairs<K, V>` as test arguments will get the same sort of optimizations as they would if they passed a `Dictionary<K, V>` instead.

This change complements, but is not dependent on, #1627.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
