### PR TITLE
Don't invent my own "dictionary-like" protocol.

### DIFF
--- a/Sources/Testing/Parameterization/Test.Case.Generator.swift
+++ b/Sources/Testing/Parameterization/Test.Case.Generator.swift
@@ -235,7 +235,7 @@ extension Test.Case {
       arguments collection: S,
       parameters: [Test.Parameter],
       testFunction: @escaping @Sendable ((S.Key, S.Value)) async throws -> Void
-    ) where S: __DictionaryLikeCollection {
+    ) where S: ExpressibleByDictionaryLiteral, S.Element == (key: S.Key, value: S.Value) {
       if parameters.count > 1 {
         self.init(sequence: collection) { element in
           Test.Case(values: [element.key, element.value], parameters: parameters) {

--- a/Sources/Testing/Test+Macro.swift
+++ b/Sources/Testing/Test+Macro.swift
@@ -455,7 +455,7 @@ extension Test {
     sourceBounds: __SourceBounds,
     parameters paramTuples: [__Parameter],
     testFunction: @escaping @Sendable (C.Element) async throws -> Void
-  ) -> Self where S: ~Copyable & ~Escapable, C: __DictionaryLikeCollection & Sendable, C.Key: Sendable, C.Value: Sendable {
+  ) -> Self where S: ~Copyable & ~Escapable, C: ExpressibleByDictionaryLiteral & Collection & Sendable, C.Element == (key: C.Key, value: C.Value), C.Key: Sendable, C.Value: Sendable {
     let containingTypeInfo: TypeInfo? = if let containingType {
       TypeInfo(describing: containingType)
     } else {
@@ -528,21 +528,6 @@ extension Test {
 @attached(peer) public macro __testing(
   warning message: _const String
 ) = #externalMacro(module: "TestingMacros", type: "PragmaMacro")
-
-// MARK: - Dictionary-like collection disambiguation
-
-/// A protocol that describes the basic shape of a "dictionary-like" collection
-/// whose elements are key-value pairs.
-///
-/// - Warning: This protocol is used to implement the `@Test` macro. Do not use
-///   it directly.
-public protocol __DictionaryLikeCollection<Key, Value>: Collection where Element == (key: Key, value: Value) {
-  associatedtype Key
-  associatedtype Value
-}
-
-extension Dictionary: __DictionaryLikeCollection {}
-extension KeyValuePairs: __DictionaryLikeCollection {}
 
 // MARK: - Helper functions
 


### PR DESCRIPTION
In #1699 I added `__DictionaryLikeCollection` but I can just use `ExpressibleByDictionaryLiteral` for this purpose.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
