### PR TITLE
Get the names of signals like `SIGABRT` on Windows.

### DIFF
--- a/Sources/Testing/ExitTests/ExitStatus.swift
+++ b/Sources/Testing/ExitTests/ExitStatus.swift
@@ -141,7 +141,9 @@ extension ExitStatus: CustomStringConvertible {
         .flatMap(String.init(validatingCString:))
         .map { "SIG\($0)" }
 #endif
-#elseif os(Windows) || os(WASI)
+#elseif os(Windows)
+      windowsSignals[signal]
+#elseif os(WASI)
       // These platforms do not have API to get the programmatic name of a
       // signal constant.
 #else

--- a/Sources/Testing/ExitTests/ExitStatus.swift
+++ b/Sources/Testing/ExitTests/ExitStatus.swift
@@ -142,7 +142,7 @@ extension ExitStatus: CustomStringConvertible {
         .map { "SIG\($0)" }
 #endif
 #elseif os(Windows)
-      windowsSignals[signal]
+      result = windowsSignals[signal]
 #elseif os(WASI)
       // These platforms do not have API to get the programmatic name of a
       // signal constant.

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -286,7 +286,7 @@ extension ExitTest {
     // repository doesn't have an official GitHub mirror, but you can manually
     // navigate to misc/signal.cpp:481 to see the implementation of SIG_DFL
     // (which, again, calls `_exit(3)` unconditionally.)
-    for sig in [SIGINT, SIGILL, SIGFPE, SIGSEGV, SIGTERM, SIGBREAK, SIGABRT, SIGABRT_COMPAT] {
+    for sig in windowsSignals.keys {
       _ = signal(sig) { sig in
         _exit(STATUS_SIGNAL_CAUGHT_BITS | sig)
       }

--- a/Sources/Testing/Support/Additions/WinSDKAdditions.swift
+++ b/Sources/Testing/Support/Additions/WinSDKAdditions.swift
@@ -50,4 +50,29 @@ let STATUS_SIGNAL_CAUGHT_BITS = {
 
   return result
 }()
+
+/// The names of all signals supported on Windows (to the degree that Windows
+/// supports signals).
+///
+/// Most other platforms provide a C API for getting the name of a signal code.
+/// Windows doesn't have such an API, but it does have a short [list](https://learn.microsoft.com/en-us/cpp/c-runtime-library/signal-constants?view=msvc-170)
+/// of supported signals that we can just hard-code here.
+let windowsSignals: [CInt: String] = {
+  var result = [
+    SIGINT: "SIGINT",
+    SIGILL: "SIGILL",
+    SIGFPE: "SIGFPE",
+    SIGSEGV: "SIGSEGV",
+    SIGTERM: "SIGTERM",
+    SIGBREAK: "SIGBREAK",
+    SIGABRT: "SIGABRT",
+  ]
+  if SIGABRT_COMPAT != SIGABRT {
+    // As currently defined, SIGABRT_COMPAT is a different value from SIGABRT,
+    // but I'm going to code defensively here in case Microsoft coalesces them
+    // in some future Windows SDK update.
+    result[SIGABRT_COMPAT] = "SIGABRT_COMPAT"
+  }
+  return result
+}()
 #endif

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -33,6 +33,8 @@ private import _TestingInternals
 #endif
 #elseif os(Linux) && !SWT_NO_DYNAMIC_LINKING
     hasSignalNames = (symbol(named: "sigabbrev_np") != nil)
+#elseif os(Windows)
+    hasSignalNames = true
 #endif
 
     let exitStatus = ExitStatus.signal(SIGABRT)


### PR DESCRIPTION
This change enhances the stringification of `ExitStatus.signal(_:)` on Windows to include the name of a signal as it does on Darwin, Linux, and others. For example, `.signal(SIGABRT)` is now stringified as `".signal(SIGABRT)"` instead of `".signal(22)"`.

On Windows, the set of named signals is small, and we already need to enumerate it anyway during exit test preflighting, so since we have a hard-coded list of them we might as well name them too.

I didn't attempt to do something similar for WASI because WASI doesn't support exit tests _anyway_ (so it would be dead code) and because the list of nominally supported signals on WASI (inherited from Musl) is quite a bit longer than on Windows.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
