### PR TITLE
Update automerge GHA workflow to target `release/6.4.x`.

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -21,7 +21,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.11
     with:
       head_branch: main
-      base_branch: release/6.3
+      base_branch: release/6.4.x
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Update automerge GHA workflow to target `release/6.4.x`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
