### PR TITLE
Fix sendability hole in `Mutex.rawValue`.

### DIFF
--- a/Sources/Testing/Support/Additions/MutexAdditions.swift
+++ b/Sources/Testing/Support/Additions/MutexAdditions.swift
@@ -124,7 +124,7 @@ struct Mutex<Value>: Sendable, ~Copyable where Value: ~Copyable {
 #error("Platform-specific misconfiguration: Mutex is unavailable")
 #endif
 
-extension Mutex where Value: Copyable {
+extension Mutex where Value: Copyable & Sendable {
   var rawValue: Value {
     withLock { $0 }
   }


### PR DESCRIPTION
This PR fixes a sendability hole in `Mutex.rawValue` if the raw value is not, in fact, sendable. Found by @gottesmm.

Resolves rdar://176398975.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
