### PR TITLE
Fix warning about unnecessary 'var' in EntryPoint.swift

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -57,7 +57,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
     // Configure the event recorder to write events to stderr.
     if configuration.verbosity > .min {
       // Check for experimental console output flag
-      var useExperimentalConsoleOutput = (Environment.flag(named: "SWT_ENABLE_EXPERIMENTAL_CONSOLE_OUTPUT") == true)
+      let useExperimentalConsoleOutput = (Environment.flag(named: "SWT_ENABLE_EXPERIMENTAL_CONSOLE_OUTPUT") == true)
 #if !SWT_NO_ABI_JSON_SCHEMA
       if useExperimentalConsoleOutput {
         // Use experimental AdvancedConsoleOutputRecorder


### PR DESCRIPTION
Fix a warning which was fallout from #1697:

```
⚠️ warning: variable 'useExperimentalConsoleOutput' was never mutated; consider changing to 'let' constant
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
