### PR TITLE
Remove temporary '_Testing_ExperimentalImageAttachments' library product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -84,19 +84,6 @@ let package = Package(
     )
 #endif
 
-    result += [
-      .library(
-        name: "_Testing_ExperimentalImageAttachments",
-        targets: [
-          "_Testing_AppKit",
-          "_Testing_CoreGraphics",
-          "_Testing_CoreImage",
-          "_Testing_UIKit",
-          "_Testing_WinSDK",
-        ]
-      )
-    ]
-
     result.append(
       .library(
         name: "_TestDiscovery",


### PR DESCRIPTION
This removes the `_Testing_ExperimentalImageAttachments` library product from the Swift package. This was added to ease the "Trying it out" instructions for [ST-0014](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0014-image-attachments-in-swift-testing-apple-platforms.md), [ST-0015](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0015-image-attachments-in-swift-testing-windows.md), and [ST-0017](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0017-image-attachment-consolidation.md), but it's no longer necessary since those proposals' reviews have concluded.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
