### PR TITLE
Document the 'SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH' environment variable

### DIFF
--- a/Documentation/EnvironmentVariables.md
+++ b/Documentation/EnvironmentVariables.md
@@ -65,4 +65,5 @@ names prefixed with `SWT_`.
 | `SIMULATOR_RUNTIME_BUILD_VERSION`\* | `String` | Used when running in the iOS (etc.) Simulator to determine the simulator's version. |
 | `SIMULATOR_RUNTIME_VERSION`\* | `String` | Used when running in the iOS (etc.) Simulator to determine the simulator's version. |
 | `SWT_EXPERIMENTAL_SERIALIZED_TRAIT_APPLIES_GLOBALLY` | `Bool` | Whether or not `.serialized` applies globally or just to its branch of the test graph. |
+| `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` | `Int` | The default parallelization width when parallelized testing is enabled. |
 | `SWT_USE_LEGACY_TEST_DISCOVERY` | `Bool` | Used to explicitly enable or disable legacy test discovery. |


### PR DESCRIPTION
Include the `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` environment variable in our `EnvironmentVariables.md` document. This was first added in #1390.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
