### PR TITLE
The subprocess wait thread's name shouldn't be exit-test-specific.

### DIFF
--- a/Sources/Testing/ExitTests/WaitFor.swift
+++ b/Sources/Testing/ExitTests/WaitFor.swift
@@ -192,15 +192,15 @@ private let _createWaitThread: Void = {
       // on Darwin, TASK_COMM_LEN on Linux, MAXCOMLEN on FreeBSD, and _MAXCOMLEN
       // on OpenBSD. We try to maximize legibility in the available space.
 #if SWT_TARGET_OS_APPLE
-      _ = pthread_setname_np("Swift Testing exit test monitor")
+      _ = pthread_setname_np("Swift Testing subprocess monitor")
 #elseif os(Linux)
 #if !SWT_NO_DYNAMIC_LINKING
-      _ = _pthread_setname_np?(pthread_self(), "SWT ExT monitor")
+      _ = _pthread_setname_np?(pthread_self(), "SWT prc monitor")
 #endif
 #elseif os(FreeBSD)
-      pthread_set_name_np(pthread_self(), "SWT ex test monitor")
+      pthread_set_name_np(pthread_self(), "SWT subproc monitor")
 #elseif os(OpenBSD)
-      pthread_set_name_np(pthread_self(), "SWT exit test monitor")
+      pthread_set_name_np(pthread_self(), "SWT subprocess monitor")
 #else
 #warning("Platform-specific implementation missing: thread naming unavailable")
 #endif


### PR DESCRIPTION
We name the thread we create on Linux/BSD to indicate we're using it to monitor for subprocess termination, but it says "exit test" instead of "subprocess" and we already use this code for other purposes (namely spawning zip/tar). Rename the thread.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
