### PR TITLE
Update interop modernisation warning message

### DIFF
--- a/Sources/Testing/Events/Event+FallbackEventHandler.swift
+++ b/Sources/Testing/Events/Event+FallbackEventHandler.swift
@@ -97,9 +97,9 @@ extension Event {
     }
 
     let xctestWarningMessage =
-      "XCTest API was used in a Swift Testing test. Adopt Swift Testing primitives, such as #expect, instead."
+      "Replace XCTest API such as 'XCTAssert' with a Swift Testing equivalent such as '#expect'."
 
-    // For the time being, assume that foreign test events originate from XCTest
+    // For the time being, assume that cross-library issues originate from XCTest
     lazy var warnForXCTestUsageIssue =
       Issue(
         kind: .apiMisused, severity: .warning,
@@ -110,7 +110,7 @@ extension Event {
     // Unconditionally downgrade interop issues to warning for limited interop mode.
     // Otherwise, preserve the issue severity.
     switch Interop.Mode.current {
-    case .none: return  // no-op
+    case .none: return  // In practice, this branch should be unreachable since we don't install our handler for mode == .none
     case .limited:
       issue.severity = .warning
       issue.record()

--- a/Tests/TestingTests/EventHandlingInteropTests.swift
+++ b/Tests/TestingTests/EventHandlingInteropTests.swift
@@ -244,7 +244,10 @@ struct EventHandlingInteropTests {
 
     let stderr = try #require(
       String(validating: result?.standardErrorContent ?? [UInt8](), as: UTF8.self))
-    #expect(stderr.contains("Fatal error: XCTest API was used in a Swift Testing test"))
+    #expect(
+      stderr.contains(
+        "Fatal error: Replace XCTest API such as 'XCTAssert' with a Swift Testing equivalent such as '#expect'."
+      ))
   }
 
   @Test func `Handle fallback event warns issue about XCTest API usage`() async throws {
@@ -260,7 +263,7 @@ struct EventHandlingInteropTests {
 
       #expect(
         issues.map { $0.description }.sorted() == [
-          "An API was misused (warning): XCTest API was used in a Swift Testing test. Adopt Swift Testing primitives, such as #expect, instead.",
+          "An API was misused (warning): Replace XCTest API such as 'XCTAssert' with a Swift Testing equivalent such as '#expect'.",
           "Issue recorded (warning)",
         ]
       )
@@ -316,7 +319,7 @@ struct EventHandlingInteropTests {
 
       #expect(issues.map(\.severity) == [.warning, .warning])
       #expect(issues.map(\.description).sorted() == [
-          "An API was misused (warning): XCTest API was used in a Swift Testing test. Adopt Swift Testing primitives, such as #expect, instead.",
+          "An API was misused (warning): Replace XCTest API such as 'XCTAssert' with a Swift Testing equivalent such as '#expect'.",
           "Issue recorded (warning)"
         ]
       )


### PR DESCRIPTION
Update interop modernisation warning message

### Motivation:

Improves clarity of the message that Swift Testing uses to nudge you towards modernisation.

### Modifications:

Update message, and improve clarity for some earlier comments.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

Resolves rdar://177168881.