### PR TITLE
Enable targeted interoperability by default

### DIFF
--- a/Documentation/EnvironmentVariables.md
+++ b/Documentation/EnvironmentVariables.md
@@ -64,6 +64,9 @@ names prefixed with `SWT_`.
 | `HOME`[\*](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html) | `String` | Used to determine the user's home directory. |
 | `SIMULATOR_RUNTIME_BUILD_VERSION`\* | `String` | Used when running in the iOS (etc.) Simulator to determine the simulator's version. |
 | `SIMULATOR_RUNTIME_VERSION`\* | `String` | Used when running in the iOS (etc.) Simulator to determine the simulator's version. |
+| `SWIFT_TESTING_XCTEST_INTEROP_MODE` | `String` | Overrides the behavior for handling XCTest assertion failures recorded during a Swift Testing test. One of `none`, `limited`, `complete`, or `strict`. Explanation of modes can be found in [the proposal][interop-modes]. | <!--prefer to link to MigratingFromXCTest.md once it is updated with interop-->
 | `SWT_EXPERIMENTAL_SERIALIZED_TRAIT_APPLIES_GLOBALLY` | `Bool` | Whether or not `.serialized` applies globally or just to its branch of the test graph. |
 | `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` | `Int` | The default parallelization width when parallelized testing is enabled. |
 | `SWT_USE_LEGACY_TEST_DISCOVERY` | `Bool` | Used to explicitly enable or disable legacy test discovery. |
+
+[interop-modes]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0021-targeted-interoperability-swift-testing-and-xctest.md#interoperability-modes

--- a/Documentation/EnvironmentVariables.md
+++ b/Documentation/EnvironmentVariables.md
@@ -64,7 +64,7 @@ names prefixed with `SWT_`.
 | `HOME`[\*](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html) | `String` | Used to determine the user's home directory. |
 | `SIMULATOR_RUNTIME_BUILD_VERSION`\* | `String` | Used when running in the iOS (etc.) Simulator to determine the simulator's version. |
 | `SIMULATOR_RUNTIME_VERSION`\* | `String` | Used when running in the iOS (etc.) Simulator to determine the simulator's version. |
-| `SWIFT_TESTING_XCTEST_INTEROP_MODE` | `String` | Overrides the behavior for handling XCTest assertion failures recorded during a Swift Testing test. One of `none`, `limited`, `complete`, or `strict`. Explanation of modes can be found in [the proposal][interop-modes]. | <!--prefer to link to MigratingFromXCTest.md once it is updated with interop-->
+| `SWIFT_TESTING_XCTEST_INTEROP_MODE` | `String` | Overrides the behavior for handling XCTest assertion failures recorded during a Swift Testing test. One of `none`, `limited`, `complete`, or `strict`. Explanation of modes can be found in [ST-0021][interop-modes]. | <!--prefer to link to MigratingFromXCTest.md once it is updated with interop-->
 | `SWT_EXPERIMENTAL_SERIALIZED_TRAIT_APPLIES_GLOBALLY` | `Bool` | Whether or not `.serialized` applies globally or just to its branch of the test graph. |
 | `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` | `Int` | The default parallelization width when parallelized testing is enabled. |
 | `SWT_USE_LEGACY_TEST_DISCOVERY` | `Bool` | Used to explicitly enable or disable legacy test discovery. |

--- a/Sources/Testing/Events/Event+FallbackEventHandler.swift
+++ b/Sources/Testing/Events/Event+FallbackEventHandler.swift
@@ -48,12 +48,6 @@ extension Interop {
   }
 }
 
-extension Interop {
-  /// Name of the environment variable flag to set when opting-in to the
-  /// experimental interop feature.
-  static let experimentalOptInKey = "SWT_EXPERIMENTAL_INTEROP_ENABLED"
-}
-
 extension Interop.Mode {
   /// The name for the environment variable which if set, overrides the default
   /// interop mode.
@@ -62,7 +56,7 @@ extension Interop.Mode {
   /// Whether this interop mode causes Swift Testing to install a fallback event
   /// handler ahead of running tests.
   var requiresInstallation: Bool {
-    Environment.flag(named: Interop.experimentalOptInKey) == true && self != .none
+    self != .none
   }
 
   /// Current interop mode, which should not be changed after tests start

--- a/Tests/TestingTests/EventHandlingInteropTests.swift
+++ b/Tests/TestingTests/EventHandlingInteropTests.swift
@@ -37,13 +37,6 @@ struct EventHandlingInteropTests {
     }
   }
 
-  /// Sets the env var that enables the experimental interop feature.
-  /// Must be set before we call `Event.installFallbackEventHandler()` which
-  /// will cache the install outcome.
-  static func enableExperimentalInterop() {
-    Environment.setVariable("1", named: Interop.experimentalOptInKey)
-  }
-
   /// Sets the env var that determines the interop mode.
   /// Must be set before we call `Event.installFallbackEventHandler()` which
   /// will cache the install outcome.
@@ -81,25 +74,16 @@ struct EventHandlingInteropTests {
     }
   }
 
-  @Test func `Enabling experimental interop lets you install the handler`() async {
+  @Test func `Interop handler installed by default`() async {
     await #expect(processExitsWith: .success) {
-      // Experimental interop not set
       let ok = Event.installFallbackEventHandler()
 
-      #expect(!ok, "Should fail because experimental interop not enabled")
-    }
-
-    await #expect(processExitsWith: .success) {
-      Self.enableExperimentalInterop()
-      let ok = Event.installFallbackEventHandler()
-
-      #expect(ok, "Should succeed because experimental interop is enabled")
+      #expect(ok, "Should succeed because interop is enabled by default")
     }
   }
 
   @Test func `Running tests installs the fallback handler`() async {
     await #expect(processExitsWith: .success) {
-      Self.enableExperimentalInterop()
       let handlerBefore = _swift_testing_getFallbackEventHandler()
 
       await Test {}.run()
@@ -137,7 +121,6 @@ struct EventHandlingInteropTests {
 
   @Test func `Sending fallback event to ourselves doesn't cause infinite loop`() async {
     await #expect(processExitsWith: .success) {
-      Self.enableExperimentalInterop()
       try #require(Event.installFallbackEventHandler(), "Should successfully install a handler")
 
       // Force the event to be handled by the fallback event handler
@@ -157,8 +140,6 @@ struct EventHandlingInteropTests {
 
   @Test func `Fallback handler records an issue if invalid event provided`() async throws {
     await #expect(processExitsWith: .success) {
-      Self.enableExperimentalInterop()
-
       // Pass an invalid record JSON to the event handler
       let issues = await Test {
         let emptyJSON = Array("{}".utf8)
@@ -178,8 +159,7 @@ struct EventHandlingInteropTests {
 
   @Test func `Fallback handler not installed if interop mode set to none`() async {
     await #expect(processExitsWith: .success) {
-      // Enable the interop feature but explicitly turn off the interop mode
-      Self.enableExperimentalInterop()
+      // Explicitly turn off the interop mode
       Self.setInteropMode(.none)
 
       // Running the test would normally lead to the handler being installed
@@ -195,7 +175,6 @@ struct EventHandlingInteropTests {
 
   @Test func `Limited interop mode uses warning severity`() async throws {
     await #expect(processExitsWith: .success) {
-      Self.enableExperimentalInterop()
       Self.setInteropMode(.limited)
       try #require(Event.installFallbackEventHandler())
 
@@ -213,7 +192,6 @@ struct EventHandlingInteropTests {
 
   @Test func `Complete interop mode uses error severity`() async throws {
     await #expect(processExitsWith: .success) {
-      Self.enableExperimentalInterop()
       Self.setInteropMode(.complete)
       try #require(Event.installFallbackEventHandler())
 
@@ -232,7 +210,6 @@ struct EventHandlingInteropTests {
   @available(macOS 15.0, *)  // String(validating:as:) is unavailable on older macOS
   @Test func `Strict interop mode causes a process exit`() async throws {
     let result = await #expect(processExitsWith: .failure, observing: [\.standardErrorContent]) {
-      Self.enableExperimentalInterop()
       Self.setInteropMode(.strict)
       try #require(Event.installFallbackEventHandler())
 
@@ -252,7 +229,6 @@ struct EventHandlingInteropTests {
 
   @Test func `Handle fallback event warns issue about XCTest API usage`() async throws {
     await #expect(processExitsWith: .success) {
-      Self.enableExperimentalInterop()
       try #require(Event.installFallbackEventHandler())
 
       // Run the test, which should record two issues in response to the interop one
@@ -308,7 +284,6 @@ struct EventHandlingInteropTests {
   /// However, we don't want to clobber anything naturally reported as a warning.
   @Test func `Interop receive: warning issue stays as warning`() async throws {
     await #expect(processExitsWith: .success) {
-      Self.enableExperimentalInterop()
       Self.setInteropMode(.complete)
       try #require(Event.installFallbackEventHandler())
 

--- a/Tests/TestingTests/InteropModeTests.swift
+++ b/Tests/TestingTests/InteropModeTests.swift
@@ -12,17 +12,9 @@
 
 #if !SWT_NO_EXIT_TESTS && !SWT_NO_INTEROP
 @Suite struct `Unit tests for interop mode selection` {
-  @Test func `Installation not required if experimentalOptInKey not set`() async {
-    await #expect(processExitsWith: .success) {
-      Environment.setVariable("0", named: Interop.experimentalOptInKey)
-      #expect(Interop.Mode.limited.requiresInstallation == false)
-    }
-  }
-
   @Test(arguments: Interop.Mode.allCases)
   func `Not-none interop modes require installation`(mode: Interop.Mode) async {
     await #expect(processExitsWith: .success) { [mode] in
-      Environment.setVariable("1", named: Interop.experimentalOptInKey)
       switch mode {
       case .none:
         #expect(!mode.requiresInstallation)
@@ -33,7 +25,11 @@
   }
 
   @Test func `Default interop mode`() async {
-    #expect(Interop.Mode.current == .limited)
+    await #expect(processExitsWith: .success) {
+      // Explicitly disable any overrides if present
+      try #require(Environment.setVariable(nil, named: Interop.Mode.interopModeEnvKey))
+      #expect(Interop.Mode.current == .limited)
+    }
   }
 
   /// Run this test case in a separate process via exit tests since we will


### PR DESCRIPTION
Enable targeted interoperability by default

### Motivation:

Interoperability is a feature that makes it safer and easier than ever to migrate from XCTest to Swift Testing.

It does this by addressing the problem of "lossy without interop", where issues created by XCTest are normally not handled in a Swift Testing test.

Interop supports a few modes:

    class FooTests: XCTestCase {
        func testInterop() {
        // None:     No-op
        // Limited:  ❌ "Interop failure"
        // Complete: ❌ "Interop failure"
        // Strict:   ❌ "Interop failure"
        Issue.record("Interop failure")
        }
    }

    @Test func `Test Interop`() {
        // None:     No-op
        // Limited:  ⚠️ "Interop failure", ⚠️ Adopt Swift Testing primitives
        // Complete: ❌ "Interop failure", ⚠️ Adopt Swift Testing primitives
        // Strict:   💥 fatalError: Adopt Swift Testing primitives
        XCTFail("Interop failure")
    }

The default is "complete" for `swift-tools-version: 6.4`[^1] and "limited" otherwise.

Use env var `SWIFT_TESTING_XCTEST_INTEROP_MODE=<mode in lowercase>` to override this mode at runtime.

[^1]: https://github.com/swiftlang/swift-package-manager/pull/9857

To learn more, refer to the full proposal:
https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0021-targeted-interoperability-swift-testing-and-xctest.md

### Modifications:

* Remove SWT_EXPERIMENTAL_INTEROP_ENABLED flag and related checks. This ensures that interoperability Just Works when you use a toolchain that supports it.

* Add SWIFT_TESTING_XCTEST_INTEROP_MODE to EnvironmentVariables.md

Resolves rdar://177175523

## Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
