### PR TITLE
Avoid casts to `any ___Trait` in Embedded Swift.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -142,7 +142,7 @@ extension Event.HumanReadableOutputRecorder {
   /// - Returns: A formatted string representing the comments attached to `test`,
   ///   or `nil` if there are none.
   private func _formattedComments(for test: Test) -> [Message] {
-    _formattedComments(test.comments(from: Comment.self))
+    _formattedComments(test.traits.compactMap { $0.__as(Comment.self) })
   }
 
   /// Get the total number of issues recorded in a graph of test data

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -136,7 +136,7 @@ extension Runner.Plan {
   /// node.
   private static func _recursivelyApplyTraits(_ parentTraits: [any SuiteTrait] = [], to testGraph: inout Graph<String, Test?>) {
     let traits: [any SuiteTrait] = parentTraits + (testGraph.value?.traits ?? []).lazy
-      .compactMap { $0 as? any SuiteTrait }
+      .compactMap { $0.__as((any SuiteTrait).self) }
       .filter(\.isRecursive)
 
     testGraph.children = testGraph.children.mapValues { child in
@@ -147,6 +147,7 @@ extension Runner.Plan {
     }
   }
 
+#if !hasFeature(Embedded)
   /// Recursively deduplicate traits on the given test by calling
   /// ``ReducibleTrait/reduce(_:)`` across all nodes in the graph.
   ///
@@ -186,6 +187,7 @@ extension Runner.Plan {
       return test
     }
   }
+#endif
 
   /// Recursively synthesize test instances representing suites for all missing
   /// values in the specified test graph.
@@ -396,11 +398,13 @@ extension Runner.Plan {
     // filtered out.
     _recursivelyApplyTraits(to: &testGraph)
 
+#if !hasFeature(Embedded)
     // Recursively reduce traits in the graph.
     //
     // As with `_recursivelyApplyTraits(to:)`, we must call this function before
     // calling `prepare(for:)` to ensure correct operation.
     _recursivelyReduceTraits(in: &testGraph)
+#endif
 
     // For each test value, determine the appropriate action for it.
     testGraph = await testGraph.mapValues { keyPath, test in

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -155,7 +155,7 @@ extension Runner {
     // second-to-last invokes the last, etc. and ultimately the first trait is
     // the first one to be invoked.
     let executeAllTraits = test.traits.lazy
-      .compactMap { $0 as? IssueHandlingTrait }
+      .compactMap { $0.__as(IssueHandlingTrait.self) }
       .reversed()
       .map { $0.provideScope(performing:) }
       .reduce(body) { executeAllTraits, provideScope in

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -94,9 +94,9 @@ public struct Test: Sendable {
       // traits to test suites.
       func traitsAreCorrectlyTyped() -> Bool {
         if isSuite {
-          return newValue.allSatisfy { $0 is any SuiteTrait }
+          return newValue.allSatisfy { $0.__as((any SuiteTrait).self) != nil }
         } else {
-          return newValue.allSatisfy { $0 is any TestTrait }
+          return newValue.allSatisfy { $0.__as((any TestTrait).self) != nil }
         }
       }
       precondition(traitsAreCorrectlyTyped(), "Programmatically added an inapplicable trait to test \(self)")

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -8,8 +8,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import _TestingInternals
-
 /// A type that represents a comment related to a test.
 ///
 /// Use this type to provide context or background information about a

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -8,6 +8,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+private import _TestingInternals
+
 /// A type that represents a comment related to a test.
 ///
 /// Use this type to provide context or background information about a
@@ -144,6 +146,12 @@ extension Comment: TestTrait, SuiteTrait {
   public var comments: [Comment] {
     [self]
   }
+
+#if hasFeature(Embedded)
+  public func __as(_: Comment.Type) -> Comment? {
+    self
+  }
+#endif
 }
 
 @_spi(Experimental)
@@ -174,19 +182,5 @@ extension Test {
   /// The complete set of comments about this test from all of its traits.
   public var comments: [Comment] {
     traits.flatMap(\.comments)
-  }
-
-  /// The complete set of comments about this test from all traits of a certain
-  /// type.
-  ///
-  /// - Parameters:
-  ///   - traitType: The type of ``Trait`` whose comments should be returned.
-  ///
-  /// - Returns: The comments found for the specified test trait type.
-  @_spi(Experimental)
-  public func comments<T>(from traitType: T.Type) -> [Comment] where T: Trait {
-    traits.lazy
-      .compactMap { $0 as? T }
-      .flatMap(\.comments)
   }
 }

--- a/Sources/Testing/Traits/IssueHandlingTrait.swift
+++ b/Sources/Testing/Traits/IssueHandlingTrait.swift
@@ -65,6 +65,12 @@ public struct IssueHandlingTrait: TestTrait, SuiteTrait {
   public var isRecursive: Bool {
     true
   }
+
+#if hasFeature(Embedded)
+  public func __as(_: IssueHandlingTrait.Type) -> IssueHandlingTrait? {
+    self
+  }
+#endif
 }
 
 /// @Metadata {

--- a/Sources/Testing/Traits/ParallelizationTrait.swift
+++ b/Sources/Testing/Traits/ParallelizationTrait.swift
@@ -104,6 +104,7 @@ extension ParallelizationTrait {
   }
 }
 
+#if !hasFeature(Embedded)
 // MARK: -
 
 @_spi(Experimental)
@@ -133,6 +134,7 @@ extension ParallelizationTrait: ReducibleTrait {
     }
   }
 }
+#endif
 
 // MARK: - TestScoping
 

--- a/Sources/Testing/Traits/ReducibleTrait.swift
+++ b/Sources/Testing/Traits/ReducibleTrait.swift
@@ -8,6 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if !hasFeature(Embedded)
 /// A protocol describing traits that can be reduced into other traits of the
 /// same conforming type.
 @_spi(Experimental)
@@ -29,3 +30,4 @@ public protocol ReducibleTrait: Trait {
   /// to child suites and test functions.
   func reduce(into other: Self) -> Self?
 }
+#endif

--- a/Sources/Testing/Traits/Tags/Tag.List.swift
+++ b/Sources/Testing/Traits/Tags/Tag.List.swift
@@ -51,6 +51,12 @@ extension Tag.List: TestTrait, SuiteTrait {
   public var isRecursive: Bool {
     true
   }
+
+#if hasFeature(Embedded)
+  public func __as(_: Tag.List.Type) -> Tag.List? {
+    self
+  }
+#endif
 }
 
 extension Trait where Self == Tag.List {

--- a/Sources/Testing/Traits/Tags/Tag.swift
+++ b/Sources/Testing/Traits/Tags/Tag.swift
@@ -143,7 +143,7 @@ extension Test {
   /// Tags are associated with tests using the ``Trait/tags(_:)`` function.
   public var tags: Set<Tag> {
     traits.lazy
-      .compactMap { $0 as? Tag.List }
+      .compactMap { $0.__as(Tag.List.self) }
       .map(\.tags)
       .reduce(into: []) { $0.formUnion($1) }
   }

--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -109,6 +109,38 @@ public protocol Trait: Sendable {
   ///   @Available(Xcode, introduced: 16.3)
   /// }
   func scopeProvider(for test: Test, testCase: Test.Case?) -> TestScopeProvider?
+
+#if hasFeature(Embedded)
+  /// Get this value as an instance of ``TestTrait``.
+  ///
+  /// - Warning: This function is used to implement traits under Embedded Swift.
+  ///   Do not use it or provide an implementation for it.
+  func __as(_: (any TestTrait).Type) -> (any TestTrait)?
+
+  /// Get this value as an instance of ``SuiteTrait``.
+  ///
+  /// - Warning: This function is used to implement traits under Embedded Swift.
+  ///   Do not use it or provide an implementation for it.
+  func __as(_: (any SuiteTrait).Type) -> (any SuiteTrait)?
+
+  /// Get this value as an instance of ``Tag/List``.
+  ///
+  /// - Warning: This function is used to implement traits under Embedded Swift.
+  ///   Do not use it or provide an implementation for it.
+  func __as(_: Comment.Type) -> Comment?
+
+  /// Get this value as an instance of ``IssueHandlingTrait``.
+  ///
+  /// - Warning: This function is used to implement traits under Embedded Swift.
+  ///   Do not use it or provide an implementation for it.
+  func __as(_: IssueHandlingTrait.Type) -> IssueHandlingTrait?
+
+  /// Get this value as an instance of ``Tag/List``.
+  ///
+  /// - Warning: This function is used to implement traits under Embedded Swift.
+  ///   Do not use it or provide an implementation for it.
+  func __as(_: Tag.List.Type) -> Tag.List?
+#endif
 }
 
 /// A protocol that tells the test runner to run custom code before or after it
@@ -285,3 +317,45 @@ extension SuiteTrait {
     false
   }
 }
+
+#if !hasFeature(Embedded)
+extension Trait {
+  func __as<T>(_: T.Type) -> T? {
+    self as? T
+  }
+}
+#else
+extension Trait {
+  public func __as(_: (any TestTrait).Type) -> (any TestTrait)? {
+    nil
+  }
+
+  public func __as(_: (any SuiteTrait).Type) -> (any SuiteTrait)? {
+    nil
+  }
+
+  public func __as(_: Comment.Type) -> Comment? {
+    nil
+  }
+
+  public func __as(_: IssueHandlingTrait.Type) -> IssueHandlingTrait? {
+    nil
+  }
+
+  public func __as(_: Tag.List.Type) -> Tag.List? {
+    nil
+  }
+}
+
+extension Trait where Self: TestTrait {
+  public func __as(_: (any TestTrait).Type) -> (any TestTrait)? {
+    self
+  }
+}
+
+extension Trait where Self: SuiteTrait {
+  public func __as(_: (any SuiteTrait).Type) -> (any SuiteTrait)? {
+    self
+  }
+}
+#endif

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -720,7 +720,11 @@ final class RunnerTests: XCTestCase {
     // emitted.
     let plan = await Runner.Plan(selecting: ObsoletedTests.self)
     for step in plan.steps where !step.test.isSuite {
-      XCTAssertNotNil(step.test.comments(from: ConditionTrait.self).map(\.rawValue).first { $0.contains("999.0") })
+      let conditionComments = step.test.traits
+        .compactMap { $0.__as(ConditionTrait.self) }
+        .flatMap(\.comments)
+        .map(\.rawValue)
+      XCTAssertNotNil(conditionComments.first { $0.contains("999.0") })
     }
   }
 #endif

--- a/Tests/TestingTests/Traits/CommentTests.swift
+++ b/Tests/TestingTests/Traits/CommentTests.swift
@@ -39,7 +39,7 @@ struct CommentTests {
 
     let example3 = try #require(plan.steps.map(\.test).first { $0.name == "example3()" })
     #expect(example3.comments == ["H", "I"])
-    #expect(example3.comments(from: Comment.self) == ["H"])
+    #expect(example3.traits.compactMap { $0.__as(Comment.self) } == ["H"])
 
     let innerType = try #require(plan.steps.map(\.test).first { $0.name == "Inner" })
     #expect(innerType.comments == ["// J"])


### PR DESCRIPTION
This PR adds helper members on `Trait` to allow casting between the different refining protocols and concrete trait types without relying on `as?` in Embedded Swift.

I have left an `as? TimeLimitTrait` cast unmodified as I expect we won't support time limits in Embedded Swift and will probably just stub out that whole type.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
