### PR TITLE
Opt clients into per-test-case iteration by default

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -674,9 +674,6 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
   }
   configuration.repetitionPolicy = repetitionPolicy
 
-  // Opt in to per-test-case repetition
-  configuration.shouldUseLegacyPlanLevelRepetition = false
-
 #if !SWT_NO_EXIT_TESTS
   // Enable exit test handling via __swiftPMEntryPoint().
   configuration.exitTestHandler = ExitTest.handlerForEntryPoint()

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -338,9 +338,6 @@ public struct __CommandLineArguments_v0: Sendable {
   /// The value of the `--repeat-until` argument.
   public var repeatUntil: String?
 
-  /// Whether or not to use the per-test-case repetition mode.
-  var usePerTestCaseRepetition: Bool = false
-
   /// The value of the `--attachments-path` argument.
   public var attachmentsPath: String?
 }
@@ -547,9 +544,6 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   if let repeatUntil = args.argumentValue(forLabel: "--repeat-until") {
     result.repeatUntil = repeatUntil
   }
-  if args.contains("--experimental-per-test-case-repetition") {
-    result.usePerTestCaseRepetition = true
-  }
 
   return result
 }
@@ -681,7 +675,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
   configuration.repetitionPolicy = repetitionPolicy
 
   // Opt in to per-test-case repetition
-  configuration.shouldUseLegacyPlanLevelRepetition = !args.usePerTestCaseRepetition
+  configuration.shouldUseLegacyPlanLevelRepetition = false
 
 #if !SWT_NO_EXIT_TESTS
   // Enable exit test handling via __swiftPMEntryPoint().

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -134,7 +134,6 @@ public struct Configuration: Sendable {
 
   /// Whether to perform test repetition at the plan level or on a per-test-
   /// case basis.
-  @_spi(Experimental)
   public var shouldUseLegacyPlanLevelRepetition: Bool = false
 
   /// Whether or not, and how, to iterate the test plan repeatedly.

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -135,7 +135,7 @@ public struct Configuration: Sendable {
   /// Whether to perform test repetition at the plan level or on a per-test-
   /// case basis.
   @_spi(Experimental)
-  public var shouldUseLegacyPlanLevelRepetition: Bool = true
+  public var shouldUseLegacyPlanLevelRepetition: Bool = false
 
   /// Whether or not, and how, to iterate the test plan repeatedly.
   ///

--- a/Tests/TestingTests/LegacyPlanIterationTests.swift
+++ b/Tests/TestingTests/LegacyPlanIterationTests.swift
@@ -21,6 +21,7 @@ struct LegacyPlanIterationTests {
     await confirmation("N iterations started") { started in
       await confirmation("N iterations ended") { ended in
         var configuration = Configuration()
+        configuration.shouldUseLegacyPlanLevelRepetition = true
         configuration.eventHandler = { event, _ in
           if case .iterationStarted = event.kind {
             started()
@@ -42,6 +43,7 @@ struct LegacyPlanIterationTests {
     await confirmation("N iterations started", expectedCount: iterationCount) { started in
       await confirmation("N iterations ended", expectedCount: iterationCount) { ended in
         var configuration = Configuration()
+        configuration.shouldUseLegacyPlanLevelRepetition = true
         configuration.eventHandler = { event, _ in
           if case .iterationStarted = event.kind {
             started()
@@ -68,6 +70,7 @@ struct LegacyPlanIterationTests {
     await confirmation("N iterations started", expectedCount: iterationWithIssue + 1) { started in
       await confirmation("N iterations ended", expectedCount: iterationWithIssue + 1) { ended in
         var configuration = Configuration()
+        configuration.shouldUseLegacyPlanLevelRepetition = true
         configuration.eventHandler = { event, _ in
           if case let .iterationStarted(index) = event.kind {
             iterationIndex.store(index, ordering: .sequentiallyConsistent)
@@ -96,6 +99,7 @@ struct LegacyPlanIterationTests {
     await confirmation("N iterations started", expectedCount: iterationWithoutIssue + 1) { started in
       await confirmation("N iterations ended", expectedCount: iterationWithoutIssue + 1) { ended in
         var configuration = Configuration()
+        configuration.shouldUseLegacyPlanLevelRepetition = true
         configuration.eventHandler = { event, _ in
           if case let .iterationStarted(index) = event.kind {
             iterationIndex.store(index, ordering: .sequentiallyConsistent)

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -509,13 +509,10 @@ struct SwiftPMTests {
     #expect(configuration.repetitionPolicy.continuationCondition == .whileIssueRecorded)
   }
 
-  @Test("--experimental-per-test-case-repetition")
-  func experimentalPerTestCaseRepetition() throws {
+  @Test
+  func `Per-test-case iteration enabled by default`() throws {
     let defaultConfig = try configurationForEntryPoint(withArguments: ["PATH"])
-    #expect(defaultConfig.shouldUseLegacyPlanLevelRepetition)
-
-    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--experimental-per-test-case-repetition"])
-    #expect(!configuration.shouldUseLegacyPlanLevelRepetition)
+    #expect(!defaultConfig.shouldUseLegacyPlanLevelRepetition)
   }
 
   @Test("list subcommand")

--- a/Tests/TestingTests/TestCaseIterationTests.swift
+++ b/Tests/TestingTests/TestCaseIterationTests.swift
@@ -43,7 +43,6 @@ struct TestCaseIterationTests {
     await confirmation("N iterations started", expectedCount: iterationCount) { started in
       await confirmation("N iterations ended", expectedCount: iterationCount) { ended in
         var configuration = Configuration()
-        configuration.shouldUseLegacyPlanLevelRepetition = false
         configuration.eventHandler = { event, _ in
           if case .testCaseStarted = event.kind {
             started()
@@ -70,7 +69,6 @@ struct TestCaseIterationTests {
     await confirmation("N iterations started", expectedCount: iterationWithIssue) { started in
       await confirmation("N iterations ended", expectedCount: iterationWithIssue) { ended in
         var configuration = Configuration()
-        configuration.shouldUseLegacyPlanLevelRepetition = false
         configuration.eventHandler = { event, context in
           guard let iteration = context.iteration else { return }
           if case .testCaseStarted = event.kind {
@@ -98,7 +96,6 @@ struct TestCaseIterationTests {
     await confirmation("N iterations started", expectedCount: iterationWithoutIssue) { started in
       await confirmation("N iterations ended", expectedCount: iterationWithoutIssue) { ended in
         var configuration = Configuration()
-        configuration.shouldUseLegacyPlanLevelRepetition = false
         configuration.eventHandler = { event, context in
           guard let iteration = context.iteration else { return }
           if case .testCaseStarted = event.kind {


### PR DESCRIPTION
This enables the per-test-case iteration feature by default in Swift 6.4 mode.

Relevant SE proposal: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0024-per-test-case-repetitions.md