### PR TITLE
Improve stringification support in Embedded Swift.

### DIFF
--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -262,6 +262,7 @@ extension Issue: CustomStringConvertible, CustomDebugStringConvertible {
   }
 }
 
+#if !hasFeature(Embedded)
 /// An empty protocol defining a type that conforms to `RangeExpression<Int>`.
 ///
 /// In the future, when our minimum deployment target supports casting a value
@@ -271,6 +272,7 @@ private protocol _RangeExpressionOverIntValues: RangeExpression & Sequence where
 extension ClosedRange<Int>: _RangeExpressionOverIntValues {}
 extension PartialRangeFrom<Int>: _RangeExpressionOverIntValues {}
 extension Range<Int>: _RangeExpressionOverIntValues {}
+#endif
 
 extension Issue.Kind: CustomStringConvertible {
   public var description: String {
@@ -289,6 +291,7 @@ extension Issue.Kind: CustomStringConvertible {
         "Expectation failed: \(expectation.evaluatedExpression.sourceCode)"
       }
     case let .confirmationMiscounted(actual: actual, expected: expected):
+#if !hasFeature(Embedded)
       if let expected = expected as? any _RangeExpressionOverIntValues {
         let lowerBound = expected.first { _ in true }
         if let lowerBound {
@@ -302,6 +305,9 @@ extension Issue.Kind: CustomStringConvertible {
         }
       }
       return "Confirmation was confirmed \(actual.counting("time")), but expected to be confirmed \(String(describingForTest: expected)) time(s)"
+#else
+      return "Confirmation was confirmed \(actual.counting("time"))"
+#endif
     case let .errorCaught(error):
       return "Caught error: \(String(describingForTest: error))"
     case let .timeLimitExceeded(timeLimitComponents):

--- a/Sources/Testing/SourceAttribution/CustomTestStringConvertible.swift
+++ b/Sources/Testing/SourceAttribution/CustomTestStringConvertible.swift
@@ -71,26 +71,34 @@ extension String {
   }
 
 #if hasFeature(Embedded)
-  /// Initialize this instance so that it can be presented in a test's output.
-  ///
-  /// - Parameters:
-  ///   - value: The value to describe.
-  ///
-  /// ## See Also
-  ///
-  /// - ``CustomTestStringConvertible``
-  public init(describingForTest value: some CustomTestStringConvertible) {
+  public init(describingForTest value: borrowing some CustomTestStringConvertible) {
     self = value.testDescription
   }
 
-  /// Initialize this instance so that it can be presented in a test's output.
-  ///
-  /// - Parameters:
-  ///   - value: The value to describe.
-  ///
-  /// ## See Also
-  ///
-  /// - ``CustomTestStringConvertible``
+  public init(describingForTest value: borrowing some CustomStringConvertible & CustomTestStringConvertible) {
+    self = value.testDescription
+  }
+
+  public init(describingForTest value: borrowing some CustomStringConvertible) {
+    self.init(describing: value)
+  }
+
+  public init(describingForTest value: borrowing some CustomDebugStringConvertible & CustomTestStringConvertible) {
+    self = value.testDescription
+  }
+
+  public init(describingForTest value: borrowing some CustomDebugStringConvertible) {
+    self = value.debugDescription // FIXME: use init(reflecting:) in Embedded Swift
+  }
+
+  public init(describingForTest value: borrowing some CustomStringConvertible & CustomDebugStringConvertible & CustomTestStringConvertible) {
+    self = value.testDescription
+  }
+
+  public init(describingForTest value: borrowing some CustomStringConvertible & CustomDebugStringConvertible) {
+    self.init(describing: value)
+  }
+
   @_disfavoredOverload
   @available(*, deprecated, message: "String representations of arbitrary values are not supported in Embedded Swift")
   @usableFromInline
@@ -99,14 +107,6 @@ extension String {
     self = "<unknown value>"
   }
 
-  /// Initialize this instance so that it can be presented in a test's output.
-  ///
-  /// - Parameters:
-  ///   - value: The value to describe.
-  ///
-  /// ## See Also
-  ///
-  /// - ``CustomTestStringConvertible``
   init(describingForTest value: (some ~Copyable & ~Escapable).Type) {
     // FIXME: need some sort of description functionality for types
     self = "<unknown type>"
@@ -121,6 +121,7 @@ extension String {
 
 // MARK: - Built-in implementations
 
+#if !hasFeature(Embedded)
 /// The _de facto_ implementation of ``CustomTestStringConvertible`` for a
 /// metatype value.
 ///
@@ -132,12 +133,18 @@ extension String {
 private func _testDescription(of type: any Any.Type) -> String {
   TypeInfo(describing: type).unqualifiedName
 }
+#endif
 
 extension Optional: CustomTestStringConvertible {
   public var testDescription: String {
     switch self {
     case let .some(unwrappedValue):
+#if !hasFeature(Embedded)
       String(describingForTest: unwrappedValue)
+#else
+      // FIXME: need some sort of description functionality for arbitrary values
+      "<unknown value>"
+#endif
     case nil:
       "nil"
     }
@@ -161,6 +168,7 @@ extension CustomTestStringConvertible where Self: StringProtocol {
 extension String: CustomTestStringConvertible {}
 extension Substring: CustomTestStringConvertible {}
 
+#if !hasFeature(Embedded)
 // MARK: - Ranges
 
 extension ClosedRange: CustomTestStringConvertible {
@@ -192,3 +200,4 @@ extension Range: CustomTestStringConvertible {
     "\(String(describingForTest: lowerBound)) ..< \(String(describingForTest: upperBound))"
   }
 }
+#endif

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -110,9 +110,53 @@ extension Comment: ExpressibleByStringInterpolation {
       rawValue += literal
     }
 
+#if !hasFeature(Embedded)
     @inlinable public mutating func appendInterpolation(_ value: (some Any)?) {
       rawValue += String(describingForTest: value)
     }
+#else
+    @inlinable public mutating func appendInterpolation(_ value: borrowing some CustomTestStringConvertible) {
+      rawValue += String(describingForTest: value)
+    }
+
+    @inlinable public mutating func appendInterpolation(_ value: borrowing some CustomStringConvertible & CustomTestStringConvertible) {
+      rawValue += String(describingForTest: value)
+    }
+
+    @inlinable public mutating func appendInterpolation(_ value: borrowing some CustomStringConvertible) {
+      rawValue += String(describingForTest: value)
+    }
+
+    @inlinable public mutating func appendInterpolation(_ value: borrowing some CustomDebugStringConvertible & CustomTestStringConvertible) {
+      rawValue += String(describingForTest: value)
+    }
+
+    @inlinable public mutating func appendInterpolation(_ value: borrowing some CustomDebugStringConvertible) {
+      rawValue += String(describingForTest: value)
+    }
+
+    @inlinable public mutating func appendInterpolation(_ value: borrowing some CustomStringConvertible & CustomDebugStringConvertible & CustomTestStringConvertible) {
+      rawValue += String(describingForTest: value)
+    }
+
+    @inlinable public mutating func appendInterpolation(_ value: borrowing some CustomStringConvertible & CustomDebugStringConvertible) {
+      rawValue += String(describingForTest: value)
+    }
+
+    @_disfavoredOverload
+    @available(*, deprecated, message: "String representations of arbitrary values are not supported in Embedded Swift")
+    mutating func appendInterpolation(_ value: borrowing some ~Copyable & ~Escapable) {
+      rawValue += String(describingForTest: value)
+    }
+
+    mutating func appendInterpolation(_ value: (some ~Copyable & ~Escapable).Type) {
+      rawValue += String(describingForTest: value)
+    }
+
+    mutating func appendInterpolation(_ value: any Error) {
+      rawValue += String(describingForTest: value)
+    }
+#endif
 
     @inlinable public mutating func appendInterpolation(_ value: (some StringProtocol)?) {
       // Special-case strings to not include the quotation marks added by


### PR DESCRIPTION
Add more concrete overloads of `String(describingForTest:)` and `appendInterpolation(_:)` to eliminate more string-related diagnostics. And a few other related changes.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
