### PR TITLE
Enable some `FileHandle` tests on Linux, FreeBSD, and OpenBSD.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -379,9 +379,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
       // Enabled to allow tests to be added to ~Escapable suites.
       .enableExperimentalFeature("Lifetimes"),
 
-      // Enabled to allow the use of the `@_extern(c)` attribute.
-      .enableExperimentalFeature("Extern"),
-
       .enableUpcomingFeature("InferIsolatedConformances"),
 
       // When building as a package, the macro plugin always builds as an

--- a/Package.swift
+++ b/Package.swift
@@ -379,6 +379,9 @@ extension Array where Element == PackageDescription.SwiftSetting {
       // Enabled to allow tests to be added to ~Escapable suites.
       .enableExperimentalFeature("Lifetimes"),
 
+      // Enabled to allow the use of the `@_extern(c)` attribute.
+      .enableExperimentalFeature("Extern"),
+
       .enableUpcomingFeature("InferIsolatedConformances"),
 
       // When building as a package, the macro plugin always builds as an

--- a/Sources/_TestingInternals/include/TestSupport.h
+++ b/Sources/_TestingInternals/include/TestSupport.h
@@ -53,12 +53,16 @@ static const int *_Nullable swt_EX_IOERR(void) {
 }
 
 #if defined(__linux__)
+#if defined(__cookie_io_functions_t_defined)
+typedef cookie_io_functions_t SWT_cookie_io_functions_t;
+#else
 typedef struct {
   ssize_t (* _Nullable read)(void *_Nullable cookie, char *buf, size_t nbytes);
   void *_Nullable write;
   void *_Nullable seek;
   ssize_t (* _Nullable close)(void *_Nullable cookie);
 } SWT_cookie_io_functions_t;
+#endif
 #endif
 
 SWT_ASSUME_NONNULL_END

--- a/Sources/_TestingInternals/include/TestSupport.h
+++ b/Sources/_TestingInternals/include/TestSupport.h
@@ -58,8 +58,8 @@ typedef cookie_io_functions_t SWT_cookie_io_functions_t;
 #else
 typedef struct {
   ssize_t (* _Nullable read)(void *_Nullable cookie, char *buf, size_t nbytes);
-  void *_Nullable write;
-  void *_Nullable seek;
+  ssize_t (* _Nullable write)(void *_Nullable cookie, const char *buf, size_t nbytes);
+  int (* _Nullable seek)(void *_Nullable cookie, off_t *pos, int w);
   ssize_t (* _Nullable close)(void *_Nullable cookie);
 } SWT_cookie_io_functions_t;
 #endif

--- a/Sources/_TestingInternals/include/TestSupport.h
+++ b/Sources/_TestingInternals/include/TestSupport.h
@@ -52,7 +52,7 @@ static const int *_Nullable swt_EX_IOERR(void) {
 #endif
 }
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(__USE_MISC)
 typedef struct {
   ssize_t (* read)(void *cookie, char *buf, size_t nbytes);
   void *write;

--- a/Sources/_TestingInternals/include/TestSupport.h
+++ b/Sources/_TestingInternals/include/TestSupport.h
@@ -54,10 +54,10 @@ static const int *_Nullable swt_EX_IOERR(void) {
 
 #if defined(__linux__)
 typedef struct {
-  ssize_t (* read)(void *cookie, char *buf, size_t nbytes);
-  void *write;
-  void *seek;
-  ssize_t (* close)(void *cookie);
+  ssize_t (* _Nullable read)(void *cookie, char *buf, size_t nbytes);
+  void *_Nullable write;
+  void *_Nullable seek;
+  ssize_t (* _Nullable close)(void *cookie);
 } SWT_cookie_io_functions_t;
 #endif
 

--- a/Sources/_TestingInternals/include/TestSupport.h
+++ b/Sources/_TestingInternals/include/TestSupport.h
@@ -54,10 +54,10 @@ static const int *_Nullable swt_EX_IOERR(void) {
 
 #if defined(__linux__)
 typedef struct {
-  ssize_t (* _Nullable read)(void *cookie, char *buf, size_t nbytes);
+  ssize_t (* _Nullable read)(void *_Nullable cookie, char *buf, size_t nbytes);
   void *_Nullable write;
   void *_Nullable seek;
-  ssize_t (* _Nullable close)(void *cookie);
+  ssize_t (* _Nullable close)(void *_Nullable cookie);
 } SWT_cookie_io_functions_t;
 #endif
 

--- a/Sources/_TestingInternals/include/TestSupport.h
+++ b/Sources/_TestingInternals/include/TestSupport.h
@@ -52,6 +52,21 @@ static const int *_Nullable swt_EX_IOERR(void) {
 #endif
 }
 
+#if defined(__linux__)
+typedef struct {
+  ssize_t (* read)(void *cookie, char *buf, size_t nbytes);
+  void *write;
+  void *seek;
+  ssize_t (* close)(void *cookie);
+} cookie_io_functions_t;
+
+SWT_IMPORT_FROM_STDLIB FILE *fopencookie(
+  void *cookie,
+  const char *modes,
+  cookie_io_functions_t funcs
+);
+#endif
+
 SWT_ASSUME_NONNULL_END
 
 #endif

--- a/Sources/_TestingInternals/include/TestSupport.h
+++ b/Sources/_TestingInternals/include/TestSupport.h
@@ -52,19 +52,13 @@ static const int *_Nullable swt_EX_IOERR(void) {
 #endif
 }
 
-#if defined(__linux__) && !defined(__USE_MISC)
+#if defined(__linux__)
 typedef struct {
   ssize_t (* read)(void *cookie, char *buf, size_t nbytes);
   void *write;
   void *seek;
   ssize_t (* close)(void *cookie);
-} cookie_io_functions_t;
-
-SWT_IMPORT_FROM_STDLIB FILE *fopencookie(
-  void *cookie,
-  const char *modes,
-  cookie_io_functions_t funcs
-);
+} SWT_cookie_io_functions_t;
 #endif
 
 SWT_ASSUME_NONNULL_END

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -300,14 +300,14 @@ func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> Fil
   return FileHandle(unsafeCFILEHandle: file, closeWhenDone: false)
 }
 #elseif os(Linux)
-typealias cookie_io_functions_t = (
+private typealias cookie_io_functions_t = (
   read: (@convention(c) (_ cookie: UnsafeMutableRawPointer?, _ buf: UnsafeMutablePointer<CChar>, _ nbytes: Int) -> Int)?,
   write: UnsafeRawPointer?,
   seek: UnsafeRawPointer?,
   close: (@convention(c) (_ cookie: UnsafeMutableRawPointer?) -> Int)?
 )
 
-@_extern(c) func fopencookie(
+@_extern(c) private func fopencookie(
   _ cookie: UnsafeMutableRawPointer?,
   _ modes: UnsafePointer<CChar>,
   _ funcs: cookie_io_functions_t

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -63,7 +63,7 @@ struct FileHandleTests {
   }
 #endif
 
-#if SWT_TARGET_OS_APPLE
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD)
   @Test("close() function")
   func closeFunction() async throws {
     try await confirmation("File handle closed") { closed in
@@ -158,9 +158,8 @@ struct FileHandleTests {
     #expect(readEnd.isPipe as Bool)
     #expect(writeEnd.isPipe as Bool)
   }
-#endif
 
-#if SWT_TARGET_OS_APPLE && !SWT_NO_PIPES
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD)
   @Test("Can close ends of a pipe")
   func closeEndsOfPipe() async throws {
     try await confirmation("File handle closed", expectedCount: 2) { closed in
@@ -177,6 +176,7 @@ struct FileHandleTests {
       pipe2WriteEnd.close()
     }
   }
+#endif
 #endif
 
   @Test("/dev/null is not a TTY or pipe")
@@ -281,7 +281,7 @@ func temporaryDirectory() throws -> String {
 #endif
 }
 
-#if SWT_TARGET_OS_APPLE
+#if SWT_TARGET_OS_APPLE || os(FreeBSD) || os(OpenBSD)
 func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> FileHandle {
   let context = Unmanaged.passRetained(confirmation as AnyObject).toOpaque()
   let file = try #require(
@@ -297,6 +297,19 @@ func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> Fil
       }
     ) as SWT_FILEHandle?
   )
+  return FileHandle(unsafeCFILEHandle: file, closeWhenDone: false)
+}
+#elseif os(Linux)
+func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> FileHandle {
+  let context = Unmanaged.passRetained(confirmation as AnyObject).toOpaque()
+  var functions = cookie_io_functions_t()
+  functions.read = { _, _, _ in 0 }
+  functions.close = { context in
+    let confirmation = Unmanaged<AnyObject>.fromOpaque(context!).takeRetainedValue() as! Confirmation
+    confirmation()
+    return 0
+  }
+  let file = try #require(fopencookie(context, "rb", functions))
   return FileHandle(unsafeCFILEHandle: file, closeWhenDone: false)
 }
 #endif

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -63,7 +63,7 @@ struct FileHandleTests {
   }
 #endif
 
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD)
+#if SWT_TARGET_OS_APPLE || (os(Linux) && !SWT_NO_DYNAMIC_LINKING) || os(FreeBSD) || os(OpenBSD)
   @Test("close() function")
   func closeFunction() async throws {
     try await confirmation("File handle closed") { closed in
@@ -159,7 +159,7 @@ struct FileHandleTests {
     #expect(writeEnd.isPipe as Bool)
   }
 
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD)
+#if SWT_TARGET_OS_APPLE || (os(Linux) && !SWT_NO_DYNAMIC_LINKING) || os(FreeBSD) || os(OpenBSD)
   @Test("Can close ends of a pipe")
   func closeEndsOfPipe() async throws {
     try await confirmation("File handle closed", expectedCount: 2) { closed in
@@ -299,10 +299,13 @@ func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> Fil
   )
   return FileHandle(unsafeCFILEHandle: file, closeWhenDone: false)
 }
-#elseif os(Linux)
+#elseif os(Linux) && !SWT_NO_DYNAMIC_LINKING
 func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> FileHandle {
+  let fopencookie = symbol(named: "fopencookie").map {
+    castCFunction(at: $0, to: (@convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>, SWT_cookie_io_functions_t) -> SWT_FILEHandle?).self)
+  }
   let context = Unmanaged.passRetained(confirmation as AnyObject).toOpaque()
-  var functions = cookie_io_functions_t()
+  var functions = SWT_cookie_io_functions_t()
   functions.read = { _, _, _ in 0 }
   functions.close = { context in
     let confirmation = Unmanaged<AnyObject>.fromOpaque(context!).takeRetainedValue() as! Confirmation

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -302,16 +302,13 @@ func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> Fil
 #elseif os(Linux)
 func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> FileHandle {
   let context = Unmanaged.passRetained(confirmation as AnyObject).toOpaque()
-  let functions: cookie_io_functions_t = (
-    read: { _, _, _ in 0 },
-    write: nil,
-    seek: nil,
-    close: { context in
-      let confirmation = Unmanaged<AnyObject>.fromOpaque(context!).takeRetainedValue() as! Confirmation
-      confirmation()
-      return 0
-    }
-  )
+  var functions = cookie_io_functions_t()
+  functions.read = { _, _, _ in 0 }
+  functions.close = { context in
+    let confirmation = Unmanaged<AnyObject>.fromOpaque(context!).takeRetainedValue() as! Confirmation
+    confirmation()
+    return 0
+  }
   let file = try #require(fopencookie(context, "rb", functions))
   return FileHandle(unsafeCFILEHandle: file, closeWhenDone: false)
 }

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -315,13 +315,16 @@ typealias cookie_io_functions_t = (
 
 func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> FileHandle {
   let context = Unmanaged.passRetained(confirmation as AnyObject).toOpaque()
-  var functions = cookie_io_functions_t()
-  functions.read = { _, _, _ in 0 }
-  functions.close = { context in
-    let confirmation = Unmanaged<AnyObject>.fromOpaque(context!).takeRetainedValue() as! Confirmation
-    confirmation()
-    return 0
-  }
+  let functions: cookie_io_functions_t = (
+    read: { _, _, _ in 0 },
+    write: nil,
+    seek: nil,
+    close: { context in
+      let confirmation = Unmanaged<AnyObject>.fromOpaque(context!).takeRetainedValue() as! Confirmation
+      confirmation()
+      return 0
+    }
+  )
   let file = try #require(fopencookie(context, "rb", functions))
   return FileHandle(unsafeCFILEHandle: file, closeWhenDone: false)
 }

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -300,19 +300,6 @@ func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> Fil
   return FileHandle(unsafeCFILEHandle: file, closeWhenDone: false)
 }
 #elseif os(Linux)
-private typealias cookie_io_functions_t = (
-  read: (@convention(c) (_ cookie: UnsafeMutableRawPointer?, _ buf: UnsafeMutablePointer<CChar>, _ nbytes: Int) -> Int)?,
-  write: UnsafeRawPointer?,
-  seek: UnsafeRawPointer?,
-  close: (@convention(c) (_ cookie: UnsafeMutableRawPointer?) -> Int)?
-)
-
-@_extern(c) private func fopencookie(
-  _ cookie: UnsafeMutableRawPointer?,
-  _ modes: UnsafePointer<CChar>,
-  _ funcs: cookie_io_functions_t
-) -> SWT_FILEHandle?
-
 func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> FileHandle {
   let context = Unmanaged.passRetained(confirmation as AnyObject).toOpaque()
   let functions: cookie_io_functions_t = (

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -63,7 +63,7 @@ struct FileHandleTests {
   }
 #endif
 
-#if SWT_TARGET_OS_APPLE || (os(Linux) && SWT_GNU_SOURCE_DEFINED) || os(FreeBSD) || os(OpenBSD)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD)
   @Test("close() function")
   func closeFunction() async throws {
     try await confirmation("File handle closed") { closed in
@@ -159,7 +159,7 @@ struct FileHandleTests {
     #expect(writeEnd.isPipe as Bool)
   }
 
-#if SWT_TARGET_OS_APPLE || (os(Linux) && SWT_GNU_SOURCE_DEFINED) || os(FreeBSD) || os(OpenBSD)
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD)
   @Test("Can close ends of a pipe")
   func closeEndsOfPipe() async throws {
     try await confirmation("File handle closed", expectedCount: 2) { closed in
@@ -299,7 +299,20 @@ func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> Fil
   )
   return FileHandle(unsafeCFILEHandle: file, closeWhenDone: false)
 }
-#elseif os(Linux) && SWT_GNU_SOURCE_DEFINED
+#elseif os(Linux)
+typealias cookie_io_functions_t = (
+  read: (@convention(c) (_ cookie: UnsafeMutableRawPointer?, _ buf: UnsafeMutablePointer<CChar>, _ nbytes: Int) -> Int)?,
+  write: UnsafeRawPointer?,
+  seek: UnsafeRawPointer?,
+  close: (@convention(c) (_ cookie: UnsafeMutableRawPointer?) -> Int)?
+)
+
+@_extern(c) func fopencookie(
+  _ cookie: UnsafeMutableRawPointer?,
+  _ modes: UnsafePointer<CChar>,
+  _ funcs: cookie_io_functions_t
+) -> SWT_FILEHandle?
+
 func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> FileHandle {
   let context = Unmanaged.passRetained(confirmation as AnyObject).toOpaque()
   var functions = cookie_io_functions_t()

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -304,6 +304,9 @@ func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> Fil
   let fopencookie = symbol(named: "fopencookie").map {
     castCFunction(at: $0, to: (@convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>, SWT_cookie_io_functions_t) -> SWT_FILEHandle?).self)
   }
+  guard let fopencookie else {
+    try Test.cancel("fopencookie() not available")
+  }
   let context = Unmanaged.passRetained(confirmation as AnyObject).toOpaque()
   var functions = SWT_cookie_io_functions_t()
   functions.read = { _, _, _ in 0 }

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -63,7 +63,7 @@ struct FileHandleTests {
   }
 #endif
 
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD)
+#if SWT_TARGET_OS_APPLE || (os(Linux) && SWT_GNU_SOURCE_DEFINED) || os(FreeBSD) || os(OpenBSD)
   @Test("close() function")
   func closeFunction() async throws {
     try await confirmation("File handle closed") { closed in
@@ -159,7 +159,7 @@ struct FileHandleTests {
     #expect(writeEnd.isPipe as Bool)
   }
 
-#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD)
+#if SWT_TARGET_OS_APPLE || (os(Linux) && SWT_GNU_SOURCE_DEFINED) || os(FreeBSD) || os(OpenBSD)
   @Test("Can close ends of a pipe")
   func closeEndsOfPipe() async throws {
     try await confirmation("File handle closed", expectedCount: 2) { closed in
@@ -299,7 +299,7 @@ func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> Fil
   )
   return FileHandle(unsafeCFILEHandle: file, closeWhenDone: false)
 }
-#elseif os(Linux)
+#elseif os(Linux) && SWT_GNU_SOURCE_DEFINED
 func fileHandleForCloseMonitoring(with confirmation: Confirmation) throws -> FileHandle {
   let context = Unmanaged.passRetained(confirmation as AnyObject).toOpaque()
   var functions = cookie_io_functions_t()


### PR DESCRIPTION
Enables those tests that rely on `funopen()` on FreeBSD and OpenBSD, which have said function.

On Linux, we have `fopencookie()` instead, but it's guarded by `_GNU_SOURCE` so it isn't always available (e.g. it builds for me on Ubuntu 24.04 but doesn't build in our CI). For the purposes of testing these code paths, I've hard-coded the declaration of `fopencookie()` in our test target.

Android theoretically has `funopen()` and WASI theoretically has `fopencookie()`, but neither is testable at the moment so I've left them out for now. Windows does not have an equivalent API.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
