### PR TITLE
Reduce key-path COW copies in Runner.Plan helpers

### DIFF
--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -199,9 +199,11 @@ extension Runner.Plan {
   private static func _recursivelySynthesizeSuites(in graph: inout Graph<String, Test?>, nameComponents: [String] = []) {
     // The recursive function. This is a local function to simplify the initial
     // call which does not need to pass the `sourceLocation:` inout argument.
-    func synthesizeSuites(in graph: inout Graph<String, Test?>, nameComponents: [String] = [], sourceLocation: inout SourceLocation?) {
+    func synthesizeSuites(in graph: inout Graph<String, Test?>, nameComponents: inout [String], sourceLocation: inout SourceLocation?) {
       for (key, var childGraph) in graph.children {
-        synthesizeSuites(in: &childGraph, nameComponents: nameComponents + [key], sourceLocation: &sourceLocation)
+        nameComponents.append(key)
+        synthesizeSuites(in: &childGraph, nameComponents: &nameComponents, sourceLocation: &sourceLocation)
+        nameComponents.removeLast()
         graph.children[key] = childGraph
       }
 
@@ -231,8 +233,9 @@ extension Runner.Plan {
       }
     }
 
+    var nameComponents = nameComponents
     var sourceLocation: SourceLocation?
-    synthesizeSuites(in: &graph, sourceLocation: &sourceLocation)
+    synthesizeSuites(in: &graph, nameComponents: &nameComponents, sourceLocation: &sourceLocation)
   }
 
   /// Given an array of tests, synthesize any containing suites that are not


### PR DESCRIPTION
## Motivation

After landing #1725, I went back through the rest of the codebase looking for the same "key-path COW" shape applied elsewhere — i.e. recursive functions that build a per-descent collection with `something + [key]` and pass it by value to the recursion.

`_recursivelySynthesizeSuites` in `Sources/Testing/Running/Runner.Plan.swift` is one such instance: it threads a `nameComponents: [String]` path down to every node and rebuilds it on every descent with `nameComponents + [key]`.

This is the same shape that #1725 fixed in `Graph._forEach` / `Graph._compactMapValues`:

> Each recursive call builds the descendant's key path with `var childKeyPath = keyPath; childKeyPath.append(key)`, and because `childKeyPath` is COW-shared with `keyPath`, the `append` always triggers a copy of the whole key path array. For a graph with `N` nodes at average depth `d`, this turns traversal into _O(N · d)_ instead of the _O(N)_ it should be.

This runs at plan construction (not during the test run), so the absolute savings are smaller than #1725 — but the pattern is the same, the fix is the same, and the existing tests cover the call site.

## Modifications

Pure mechanical match for #1725: thread `nameComponents` through an inner recursive function as `inout`. The for loop pushes the key, recurses, pops the key. By the time control returns to the lines that consume `nameComponents` (the suite-synthesis block at the bottom), the array is back to the value it had on entry.

No public API changes.

## Measurements

Isolated micro-benchmark of the recursive pattern at depths 3–6 with branching 3–5:

  | depth | branch | nodes | OLD | NEW | speedup |
  | --- | --- | --- | --- | --- | --- |
  | 3 | 3 | 40 | 0.011 ms | 0.002 ms | 4.47× |
  | 4 | 4 | 341 | 0.086 ms | 0.016 ms | 5.42× |
  | 5 | 4 | 1,365 | 0.355 ms | 0.062 ms | 5.68× |
  | 6 | 4 | 5,461 | 1.219 ms | 0.215 ms | 5.67× |
  | 4 | 5 | 781 | 0.151 ms | 0.030 ms | 5.10× |
  | 6 | 3 | 1,093 | 0.228 ms | 0.043 ms | 5.32× |

The speedup grows with depth, as expected from _O(N · d) → O(N)_.

This is a plan-construction helper, called once per test run — so the absolute wins are small. The change is the same kind of cleanup as #1725 in spirit.

All existing tests in `PlanTests`, `Runner.Plan.SnapshotTests`, `RunnerTests`, and the wider suite/trait/tag tests pass unchanged.

## Checklist

  - [x] Code and documentation follow the [Style Guide](https://github.com/swiftlang/swift-testing/blob/main/Documentation/StyleGuide.md)
  - [x] If public symbols are renamed or modified, DocC references should be updated — _no public API changes_