### PR TITLE
Silence a couple of (harmless) warnings.

### DIFF
--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -198,7 +198,9 @@ extension AnyAttachable: FileClonable {}
 
 // MARK: - Describing an attachment
 
+#if SWT_TARGET_OS_APPLE
 @_preInverseGenerics
+#endif
 extension Attachment: CustomStringConvertible where AttachableValue: ~Copyable {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.2)

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1019,12 +1019,14 @@ final class IssueTests: XCTestCase {
     let _: Any = try #require(throws: Never.self) {}
 
     // Casting to any Error throws an API misuse error because Never cannot be
-    // instantiated. NOTE: inner function needed for lexical context.
-    @__testing(semantics: "nomacrowarnings")
-    func castToAnyError() throws {
-      let _: any Error = try #require(throws: Never.self) {}
+    // instantiated. NOTE: inner function needed to avoid real compiler warning
+    // about the unreachable result.
+    func castToAnyError<E>(_: E.Type) throws where E: Error {
+      let _: any Error = try #require(throws: E.self) {}
     }
-    #expect(throws: APIMisuseError.self, performing: castToAnyError)
+    #expect(throws: APIMisuseError.self) {
+      try castToAnyError(Never.self)
+    }
   }
 
   func testFail() async throws {


### PR DESCRIPTION
Silence a warning about misuse of `@_preInverseGenerics` (confirmed the warning is spurious and will go away in a future compiler version) by removing it on non-ABI-stable platforms. Still warns on Darwin, but what can you do?

Silence a warning building a test for `try #require(throws: Never.self)` where the compiler is correctly warning, but we actually want to test the code path it is warning about.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
