### PR TITLE
Add an overload of Issue.record that takes all its parts up-front

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -155,6 +155,27 @@ extension Issue {
     return issue.record()
   }
 
+  /// Records an issue by explicitly providing all information up-front.
+  ///
+  /// - Parameters:
+  ///   - comments: All comments that should be attached to the issue.
+  ///   - kind: The specific kind of issue being recorded.
+  ///   - severity: The severity of the issue being recorded.
+  ///   - sourceContext: The context in which this issue was originally recorded.
+  ///
+  /// - Returns: The issue that was recorded.
+  /// - Note: This is only intended for use in interoperability.
+  @_spi(ForToolsIntegrationOnly)
+  @discardableResult public static func record(
+    comments: [Comment] = [],
+    kind: Issue.Kind,
+    severity: Severity,
+    sourceContext: SourceContext
+  ) -> Self {
+    let issue = Issue(kind: kind, severity: severity, comments: comments, sourceContext: sourceContext)
+    return issue.record()
+  }
+
   /// Catch any error thrown from a closure and record it as an issue instead of
   /// allowing it to propagate to the caller.
   ///

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -159,7 +159,7 @@ extension Issue {
   ///
   /// - Parameters:
   ///   - comments: All comments that should be attached to the issue.
-  ///   - kind: The specific kind of issue being recorded.
+  ///   - error: An error that was caught and produced this issue, if any.
   ///   - severity: The severity of the issue being recorded.
   ///   - sourceContext: The context in which this issue was originally recorded.
   ///
@@ -168,10 +168,16 @@ extension Issue {
   @_spi(ForToolsIntegrationOnly)
   @discardableResult public static func record(
     comments: [Comment],
-    kind: Issue.Kind,
+    error: (any Error)?,
     severity: Severity,
     sourceContext: SourceContext
   ) -> Self {
+    let kind: Kind = if let error {
+      .errorCaught(error)
+    } else {
+      .unconditional
+    }
+
     let issue = Issue(kind: kind, severity: severity, comments: comments, sourceContext: sourceContext)
     return issue.record()
   }

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -159,26 +159,42 @@ extension Issue {
   ///
   /// - Parameters:
   ///   - comments: All comments that should be attached to the issue.
-  ///   - error: An error that was caught and produced this issue, if any.
   ///   - severity: The severity of the issue being recorded.
-  ///   - sourceContext: The context in which this issue was originally recorded.
+  ///   - sourceContext: The context in which this issue was originally
+  ///   recorded.
   ///
   /// - Returns: The issue that was recorded.
   /// - Note: This is only intended for use in interoperability.
   @_spi(ForToolsIntegrationOnly)
   @discardableResult public static func record(
     comments: [Comment],
-    error: (any Error)?,
     severity: Severity,
     sourceContext: SourceContext
   ) -> Self {
-    let kind: Kind = if let error {
-      .errorCaught(error)
-    } else {
-      .unconditional
-    }
+    let issue = Issue(kind: .unconditional, severity: severity, comments: comments, sourceContext: sourceContext)
+    return issue.record()
+  }
 
-    let issue = Issue(kind: kind, severity: severity, comments: comments, sourceContext: sourceContext)
+  /// Records an issue by explicitly providing all information up-front when a
+  /// running test unexpectedly catches an error.
+  ///
+  /// - Parameters:
+  ///   - comments: All comments that should be attached to the issue.
+  ///   - error: An error that was caught and produced this issue.
+  ///   - severity: The severity of the issue being recorded.
+  ///   - sourceContext: The context in which this issue was originally
+  ///   recorded.
+  ///
+  /// - Returns: The issue that was recorded.
+  /// - Note: This is only intended for use in interoperability.
+  @_spi(ForToolsIntegrationOnly)
+  @discardableResult public static func record(
+    comments: [Comment],
+    error: (any Error),
+    severity: Severity,
+    sourceContext: SourceContext
+  ) -> Self {
+    let issue = Issue(kind: .errorCaught(error), severity: severity, comments: comments, sourceContext: sourceContext)
     return issue.record()
   }
 

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -167,7 +167,7 @@ extension Issue {
   /// - Note: This is only intended for use in interoperability.
   @_spi(ForToolsIntegrationOnly)
   @discardableResult public static func record(
-    comments: [Comment] = [],
+    comments: [Comment],
     kind: Issue.Kind,
     severity: Severity,
     sourceContext: SourceContext

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1712,6 +1712,23 @@ final class IssueTests: XCTestCase {
     let issue = Issue(kind: .errorCaught(error), severity: .error, comments: [], sourceContext: .init())
     #expect(String(describing: issue).contains("RIGHT"))
   }
+
+  func testExplicitSourceContextWithoutLocation() async {
+    // This just ensures that `Issue.record` with an explicit sourceContext doesn't infer the location via #_sourceLocation.
+
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      guard case let .issueRecorded(issue) = event.kind else {
+        return
+      }
+      XCTAssertNil(issue.sourceLocation)
+    }
+
+    await Test {
+      let sourceContext = SourceContext(backtrace: .current(), sourceLocation: nil)
+      Issue.record(comments: [], kind: .unconditional, severity: .warning, sourceContext: sourceContext)
+    }.run(configuration: configuration)
+  }
 }
 #endif
 

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1731,7 +1731,7 @@ final class IssueTests: XCTestCase {
 
     await Test {
       let sourceContext = SourceContext(backtrace: .current(), sourceLocation: nil)
-      Issue.record(comments: [], error: nil, severity: .warning, sourceContext: sourceContext)
+      Issue.record(comments: [], severity: .warning, sourceContext: sourceContext)
     }.run(configuration: configuration)
   }
 

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1714,7 +1714,8 @@ final class IssueTests: XCTestCase {
   }
 
   func testExplicitSourceContextWithoutLocation() async {
-    // This just ensures that `Issue.record` with an explicit sourceContext doesn't infer the location via #_sourceLocation.
+    // This just ensures that `Issue.record` with an explicit sourceContext
+    // doesn't infer the location via #_sourceLocation.
 
     var configuration = Configuration()
     configuration.eventHandler = { event, _ in
@@ -1722,11 +1723,39 @@ final class IssueTests: XCTestCase {
         return
       }
       XCTAssertNil(issue.sourceLocation)
+      guard case .unconditional = issue.kind else {
+        XCTFail("Expected .unconditional issue kind")
+        return
+      }
     }
 
     await Test {
       let sourceContext = SourceContext(backtrace: .current(), sourceLocation: nil)
-      Issue.record(comments: [], kind: .unconditional, severity: .warning, sourceContext: sourceContext)
+      Issue.record(comments: [], error: nil, severity: .warning, sourceContext: sourceContext)
+    }.run(configuration: configuration)
+  }
+
+  func testExplicitIssueRecordingKind() async {
+    enum TestError: Error, Equatable {
+      case abc
+    }
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      guard case let .issueRecorded(issue) = event.kind else {
+        return
+      }
+      guard case .errorCaught(let error) = issue.kind,
+            let testError = error as? TestError
+      else {
+        XCTFail("Expected .errorCaught(TestError.abc) issue kind")
+        return
+      }
+      XCTAssertEqual(testError, TestError.abc)
+    }
+
+    await Test {
+      let sourceContext = SourceContext(backtrace: .current(), sourceLocation: nil)
+      Issue.record(comments: [], error: TestError.abc, severity: .warning, sourceContext: sourceContext)
     }.run(configuration: configuration)
   }
 }


### PR DESCRIPTION
This adds an overload of `Issue.record` that takes a `SourceContext` and propagates a client-provided backtrace and source location.

### Motivation:

This is useful for interop to make sure we don't use implicit locations and backtraces and instead use those captured when the issue was recorded.

### Modifications:

Just one additional overload guarded by `@_spi(ForToolsIntegrationOnly)` and a test for it.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.

rdar://178080757