### PR TITLE
Expose a non-underscored version of `#_sourceLocation` as SPI.

### DIFF
--- a/Sources/Testing/SourceAttribution/SourceLocation+Macro.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation+Macro.swift
@@ -8,16 +8,60 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-/// Get the current source location as a compile-time constant.
+/// Get the current source location.
 ///
-/// - Returns: The source location at which this macro is applied.
+/// - Returns: This expression's location in the current Swift source file.
 ///
-/// You can use this macro in place of `#fileID`, `#filePath`, `#line`, and
-/// `#column` as a default argument to a function. It expands to an instance of
-/// ``SourceLocation`` referring to the location of the macro invocation itself
-/// (similar to how `#fileID` expands to the ID of the file containing the
-/// `#fileID` invocation).
+/// At compile time, the testing library expands this macro to an instance of
+/// ``SourceLocation`` referring to the location of the macro invocation itself.
+/// If you want to create an instance of ``SourceLocation`` from specific file
+/// ID, file path, line, and column values, use ``SourceLocation/init(fileID:filePath:line:column:)``
+/// instead.
+///
+/// You can use this expression macro in place of [`#fileID`](https://developer.apple.com/documentation/swift/fileid()),
+/// [`#filePath`](https://developer.apple.com/documentation/swift/filepath()),
+/// [`#line`](https://developer.apple.com/documentation/swift/line()), and
+/// [`#column`](https://developer.apple.com/documentation/swift/column()) as a
+/// default argument to a function.
+///
+/// ```swift
+/// func cookBurger(sourceLocation: SourceLocation = #_sourceLocation) {
+///   // ...
+/// }
+/// ```
 @freestanding(expression) public macro _sourceLocation() -> SourceLocation = #externalMacro(module: "TestingMacros", type: "SourceLocationMacro")
+
+/// Get the current source location.
+///
+/// - Returns: This expression's location in the current Swift source file.
+///
+/// At compile time, the testing library expands this macro to an instance of
+/// ``SourceLocation`` referring to the location of the macro invocation itself.
+/// If you want to create an instance of ``SourceLocation`` from specific file
+/// ID, file path, line, and column values, use ``SourceLocation/init(fileID:filePath:line:column:)``
+/// instead.
+///
+/// - Important: You must specify a module selector when you use this expression
+///   macro to avoid conflicting with the Swift compiler's [`#sourceLocation(file:line:)`](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/statements/#Line-Control-Statement)
+///   statement.
+///
+///   ```swift
+///   let here = #Testing::sourceLocation
+///   ```
+///
+/// You can use this expression macro in place of [`#fileID`](https://developer.apple.com/documentation/swift/fileid()),
+/// [`#filePath`](https://developer.apple.com/documentation/swift/filepath()),
+/// [`#line`](https://developer.apple.com/documentation/swift/line()), and
+/// [`#column`](https://developer.apple.com/documentation/swift/column()) as a
+/// default argument to a function.
+///
+/// ```swift
+/// func cookBurger(sourceLocation: SourceLocation = #Testing::sourceLocation) {
+///   // ...
+/// }
+/// ```
+@_spi(Experimental)
+@freestanding(expression) public macro sourceLocation() -> SourceLocation = #externalMacro(module: "TestingMacros", type: "SourceLocationMacro")
 
 extension SourceLocation {
   /// Get the current source location as an instance of ``SourceLocation``.

--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -95,6 +95,6 @@ the test when the code doesn't satisfy a requirement, use
 ### Representing source locations
 
 - ``SourceLocation``
-<!-- - ``_sourceLocation()`` -->
+<!-- - ``sourceLocation()`` -->
 <!-- - ``SourceContext`` -->
 <!-- - ``Backtrace`` -->

--- a/Sources/TestingMacros/SourceLocationMacro.swift
+++ b/Sources/TestingMacros/SourceLocationMacro.swift
@@ -11,10 +11,11 @@
 public import SwiftSyntax
 public import SwiftSyntaxMacros
 
-/// A type describing the expansion of the `#_sourceLocation` macro.
+/// A type describing the expansion of the `#_sourceLocation` and
+/// `#Testing::sourceLocation` macros.
 ///
-/// This type is used to implement the `#_sourceLocation` attribute macro.
-/// Do not use it directly.
+/// This type is used to implement the `#_sourceLocation` and
+/// `#Testing::sourceLocation` expression macros. Do not use it directly.
 public struct SourceLocationMacro: ExpressionMacro, Sendable {
   public static func expansion(
     of macro: some FreestandingMacroExpansionSyntax,

--- a/Tests/TestingTests/SourceLocationTests.swift
+++ b/Tests/TestingTests/SourceLocationTests.swift
@@ -14,20 +14,20 @@
 struct SourceLocationTests {
   @Test("SourceLocation.description property")
   func sourceLocationDescription() {
-    let sourceLocation = #_sourceLocation
+    let sourceLocation = #Testing::sourceLocation
     _ = String(describing: sourceLocation)
     _ = String(reflecting: sourceLocation)
   }
 
   @Test("SourceLocation.fileID property")
   func sourceLocationFileID() {
-    let sourceLocation = #_sourceLocation
+    let sourceLocation = #Testing::sourceLocation
     #expect(sourceLocation.fileID.hasSuffix("/SourceLocationTests.swift"))
   }
 
   @Test("SourceLocation.fileName property")
   func sourceLocationFileName() {
-    var sourceLocation = #_sourceLocation
+    var sourceLocation = #Testing::sourceLocation
     #expect(sourceLocation.fileName == "SourceLocationTests.swift")
 
     sourceLocation.fileID = "FakeModule/FakeFileID"
@@ -36,7 +36,7 @@ struct SourceLocationTests {
 
   @Test("SourceLocation.moduleName property")
   func sourceLocationModuleName() {
-    var sourceLocation = #_sourceLocation
+    var sourceLocation = #Testing::sourceLocation
     #expect(!sourceLocation.moduleName.contains("/"))
     #expect(!sourceLocation.moduleName.isEmpty)
 
@@ -100,7 +100,7 @@ struct SourceLocationTests {
 
   @Test("SourceLocation.line and .column properties")
   func sourceLocationLineAndColumn() {
-    var sourceLocation = #_sourceLocation
+    var sourceLocation = #Testing::sourceLocation
     #expect(sourceLocation.line > 0)
     #expect(sourceLocation.line < 500)
     #expect(sourceLocation.column > 0)
@@ -132,11 +132,11 @@ struct SourceLocationTests {
   @Test("SourceLocation.fileID property must be well-formed")
   func sourceLocationFileIDWellFormed() async {
     await #expect(processExitsWith: .failure) {
-      var sourceLocation = #_sourceLocation
+      var sourceLocation = #Testing::sourceLocation
       sourceLocation.fileID = ""
     }
     await #expect(processExitsWith: .failure) {
-      var sourceLocation = #_sourceLocation
+      var sourceLocation = #Testing::sourceLocation
       sourceLocation.fileID = "ABC"
     }
   }
@@ -144,11 +144,11 @@ struct SourceLocationTests {
   @Test("SourceLocation.line and column properties must be positive")
   func sourceLocationLineAndColumnPositive() async {
     await #expect(processExitsWith: .failure) {
-      var sourceLocation = #_sourceLocation
+      var sourceLocation = #Testing::sourceLocation
       sourceLocation.line = -1
     }
     await #expect(processExitsWith: .failure) {
-      var sourceLocation = #_sourceLocation
+      var sourceLocation = #Testing::sourceLocation
       sourceLocation.column = -1
     }
   }
@@ -156,7 +156,7 @@ struct SourceLocationTests {
 
   @Test("SourceLocation.filePath property")
   func sourceLocationFilePath() {
-    var sourceLocation = #_sourceLocation
+    var sourceLocation = #Testing::sourceLocation
     #expect(sourceLocation.filePath == #filePath)
 
     sourceLocation.filePath = "A"
@@ -166,7 +166,7 @@ struct SourceLocationTests {
   @available(swift, deprecated: 6.3)
   @Test("SourceLocation._filePath property")
   func sourceLocation_filePath() {
-    var sourceLocation = #_sourceLocation
+    var sourceLocation = #Testing::sourceLocation
     #expect(sourceLocation._filePath == #filePath)
 
     sourceLocation._filePath = "A"
@@ -236,5 +236,13 @@ struct SourceLocationTests {
         #expect(Bool(false), sourceLocation: SourceLocation(fileID: "A/B", filePath: "", line: lineNumber, column: 1))
       }.run(configuration: configuration)
     }
+  }
+
+  @Test("#_sourceLocation and #Testing::sourceLocation are equivalent")
+  func newAndOldMacrosAreEquivalent() {
+    let lhs = #_sourceLocation
+    var rhs = #Testing::sourceLocation
+    rhs.line -= 1
+    #expect(lhs == rhs)
   }
 }

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -67,6 +67,9 @@ struct FileHandleTests {
         nil
       )
     )
+    if windowsHANDLE == INVALID_HANDLE_VALUE {
+      throw Win32Error(rawValue: GetLastError())
+    }
     let fileHandle = try FileHandle(unsafeWindowsHANDLE: windowsHANDLE, options: [.readAccess])
     try fileHandle.withUnsafeWindowsHANDLE { ownedHANDLE in
       #expect(windowsHANDLE == ownedHANDLE)

--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -56,23 +56,27 @@ struct FileHandleTests {
 #if os(Windows)
   @Test("Can init from Windows file HANDLE")
   func initFromFileHANDLE() throws {
-    let windowsHANDLE = try #require(
-      CreateFileA(
-        "NUL",
-        GENERIC_READ,
-        DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE),
-        nil,
-        DWORD(OPEN_ALWAYS),
-        DWORD(FILE_ATTRIBUTE_NORMAL),
-        nil
-      )
-    )
-    if windowsHANDLE == INVALID_HANDLE_VALUE {
-      throw Win32Error(rawValue: GetLastError())
-    }
-    let fileHandle = try FileHandle(unsafeWindowsHANDLE: windowsHANDLE, options: [.readAccess])
-    try fileHandle.withUnsafeWindowsHANDLE { ownedHANDLE in
-      #expect(windowsHANDLE == ownedHANDLE)
+    try withTemporaryPath { path in
+      try path.withCString(encodedAs: UTF16.self) { path in
+        let windowsHANDLE = try #require(
+          CreateFileW(
+            path,
+            GENERIC_READ,
+            DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE),
+            nil,
+            DWORD(OPEN_ALWAYS),
+            DWORD(FILE_ATTRIBUTE_NORMAL),
+            nil
+          )
+        )
+        if windowsHANDLE == INVALID_HANDLE_VALUE {
+          throw Win32Error(rawValue: GetLastError())
+        }
+        let fileHandle = try FileHandle(unsafeWindowsHANDLE: windowsHANDLE, options: [.readAccess])
+        try fileHandle.withUnsafeWindowsHANDLE { ownedHANDLE in
+          #expect(windowsHANDLE == ownedHANDLE)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This PR clones `#_sourceLocation` to `#Testing::sourceLocation` guarded by `@_spi(Experimental)`. Because `#sourceLocation(file:line:)` is a compiler-side statement and not a macro, developers currently can't just write `#sourceLocation` and must specify a module selector. This is still (hopefully) better than the underscored `#_sourceLocation`.

Example usage:

```swift
func foo(sourceLocation: SourceLocation = #Testing::sourceLocation) {
  print("Called from \(sourceLocation.fileID)")
}
```

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
