### PR TITLE
Document interoperability in MigratingFromXCTest

### DIFF
--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -47,8 +47,6 @@ source file contains mixed test content.
 
 ### Use interoperability between Swift Testing and XCTest
 
-<!-- TODO: withKnownIssue and Test.cancel interop -->
-
 Interoperability is a feature that enables XCTest's assertions to work with
 Swift Testing, and Swift Testing's expectations to work with XCTest. You can use
 interoperability to share common test helpers between XCTest and Swift Testing
@@ -81,33 +79,37 @@ class UniqueElementsTests: XCTestCase {
 
 func assertUnique(_ elements: [Int]) {
   XCTAssertEqual(Set(elements).count, elements.count)
+
   // With interop: safely replace XCTAssertEqual with #expect
   // #expect(Set(elements).count == elements.count)
 }
 ```
 
+#### Modes
+
 Interoperability has a configurable mode that controls how it reports issues
-across test library boundaries.
+across test library boundaries. There are two directions of interop: Swift
+Testing API usage in XCTest test cases, and XCT
 
-- **None**: The feature is disabled.
-
-For the remaining modes, **Swift Testing API behaves as expected when used in
-XCTest**. This includes reporting any assertion failures as errors within an
-XCTest test case. As a result, any interop mode lets you incrementally migrate
-your assertions to Swift Testing.
+<!-- For all modes where interop is enabled, **Swift -->
+<!-- Testing API behaves as expected when used in XCTest**. This includes reporting -->
+<!-- any assertion failures as errors within an XCTest test case. As a result, any -->
+<!-- interop mode lets you incrementally migrate your assertions to Swift Testing. -->
 
 **XCTest API used in Swift Testing tests** behaves differently based on mode:
 
-- **Limited**: Surfaces all test failures the library previously ignored as
+- term None: The feature is disabled.
+
+- term Limited: Surfaces all test failures the library previously ignored as
   warnings. Also includes warnings for XCTest API usage in a Swift Testing test.
 
-- **Complete**: Surfaces all test failures the library previously ignored with
-  their original severity. Also includes warnings for XCTest API usage in a
-  Swift Testing test.
+- term Complete: Issues across both directions of test library boundaries are
+  reported and keep their original severity. Also includes warnings for XCTest
+  API usage in a Swift Testing test.
 
-- **Strict**:
+- term Strict:
   [`fatalError()`](https://developer.apple.com/documentation/swift/fatalerror(_:file:line:))
-  when a Swift Testing test uses XCTest API.
+  for failures from XCTest API.
 
 ```swift
 // Calling XCTest API from Swift Testing
@@ -694,6 +696,32 @@ to cancel the task associated with the current test:
   }
 }
 
+Interoperability allows ``Test/cancel(_:sourceLocation:)`` to also end XCTest
+test functions early. This lets you share cancellation logic between testing
+libraries using test helper functions:
+
+```swift
+func skipIfEmptyRegister() throws {
+  let cashRegister = CashRegister()
+  let drawer = cashRegister.open()
+  if drawer.isEmpty {
+    try Test.cancel("Cash register is empty")
+  }
+}
+
+// XCTest
+func testCashRegister() throws {
+  try skipIfEmptyRegister()
+  ...
+}
+
+// Swift Testing
+@Test func cashRegister() throws {
+  try skipIfEmptyRegister()
+  ...
+}
+```
+
 ### Annotate known issues
 
 A test may have a known issue that sometimes or always prevents it from passing.
@@ -829,6 +857,16 @@ of issues:
     ```
   }
 }
+
+Interoperability allows `withKnownIssue()` to also match XCTest issues:
+
+```swift
+@Test func `Mark an XCTest assertion failure as known`() {
+  withKnownIssue {
+    XCTFail("Interop failure")
+  }
+}
+```
 
 ### Run tests sequentially
 

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -51,14 +51,6 @@ You can use interoperability to share test helpers between XCTest and Swift
 Testing tests. Interoperability is a feature that enables XCTest's assertions to
 work with Swift Testing, and Swift Testing's expectations to work with XCTest.
 
-> Note: A **cross-library issue** is an issue created by an XCTest assertion in
-> a Swift Testing test case, or a Swift Testing expectation in an XCTest test
-> case.
->
-> An example of a "cross-library issue from XCTest" would be calling
-> [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert)
-> within a Swift Testing test.
-
 For example, you can replace
 [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert)
 with ``expect(_:_:sourceLocation:)`` in your XCTests and immediately get the
@@ -74,7 +66,6 @@ class UniqueElementsTests: XCTestCase {
 }
 
 @Test func `Duplicate elements`() {
-  // This is a cross-library issue from XCTest.
   // Without interoperability the test passes despite the `XCTAssertEqual` failure in the helper.
   // With interoperability, the test fails.
   assertUnique([1, 2, 1])
@@ -88,18 +79,19 @@ func assertUnique(_ elements: [Int]) {
 }
 ```
 
-### Change interoperability modes
+A *cross-library issue* is an issue created by an XCTest assertion in
+a Swift Testing test case, or a Swift Testing expectation in an XCTest test
+case.
 
-You can change how Swift Testing reports cross-library issues by adjusting the
-interoperability mode.
+In the example above, `assertUnique()` wraps
+[`XCTAssertEqual()`](https://developer.apple.com/documentation/xctest/xctassertequal(_:_:_:file:line:)).
+It creates a "cross-library issue from XCTest" when called in the `Duplicate
+elements` Swift Testing test case.
 
-The default interoperability mode depends on your toolchain. When you're using
-the Swift 6.4 toolchain or newer, the default mode is `limited`. If you're using
-the Swift 6.4 toolchain or newer and your package also declares
-`swift-tools-version: 6.4` or newer, the default mode is `complete`.
+### Select an interoperability mode
 
-To change the interoperability mode, set the `SWIFT_TESTING_XCTEST_INTEROP_MODE`
-environment variable to one of the following modes:
+Interoperability has multiple modes that control how Swift Testing reports
+cross-library issues:
 
 - term `none`: Interoperability is off. Swift Testing and XCTest ignore cross-library issues.
 - term `limited`: Cross-library issues from Swift Testing maintain their original
@@ -111,33 +103,45 @@ environment variable to one of the following modes:
   severity. Cross-library issues from XCTest are reported with
   [`fatalError()`](https://developer.apple.com/documentation/swift/fatalerror(_:file:line:)).
 
-```swift
-// Cross-library issues from XCTest
-@Test func `Test Interop`() {
-  // <Mode>:   <failure message>
-  // None:     No message
-  // Limited:  ⚠️ "Interop failure",
-  //           ⚠️ Replace XCTest API such as 'XCTAssert' with a Swift
-  //              Testing equivalent such as '#expect'.
-  // Complete: ❌ "Interop failure", ⚠️ Replace XCTest API...
-  // Strict:   💥 fatalError: Replace XCTest API...
-  XCTFail("Interop failure")
-}
-```
+The default interoperability mode depends on your toolchain and the
+`swift-tools-version` declared in your package.
+
+| Toolchain Version | `swift-tools-version` | Default Interoperability Mode |
+| ----------------- | --------------------- | ----------------------------- |
+| <6.4              | Any                   | `none`                        |
+| >=6.4             | <6.4                  | `limited`                     |
+| >=6.4             | >=6.4                 | `complete`                    |
+
+To explicitly choose a mode, set the `SWIFT_TESTING_XCTEST_INTEROP_MODE`
+environment variable to the name of the mode before running tests.
+
+As long as you don't set the mode to `none`, cross-library issues from Swift
+Testing maintain their original severity.
 
 ```swift
 // Cross-library issues from Swift Testing
 class InteropTests: XCTestCase {
   func testInterop() {
-    // <Mode>:   <failure message>
-    // None:     No message
-    // Limited:  ❌ "Interop failure"
-    // Complete: ❌ "Interop failure"
-    // Strict:   ❌ "Interop failure"
     Issue.record("Interop failure")
   }
 }
 ```
+
+You should consider the `complete` mode to ensure cross-library issues from
+XCTest maintain their original severity.
+
+```swift
+// Cross-library issues from XCTest
+@Test func `Test Interop`() {
+  XCTFail("Interop failure")
+}
+```
+| Mode       | Test Failure Message                            |
+| ---------- | ----------------------------------------------- |
+| `none`     | No message                                      |
+| `limited`  | ⚠️ "Interop failure", ⚠️ Replace XCTest API ... |
+| `complete` | ❌ "Interop failure", ⚠️ Replace XCTest API ... |
+| `strict`   | `fatalError`: Replace XCTest API ...            |
 
 ### Convert test classes
 

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -45,13 +45,14 @@ A single source file can contain tests written with XCTest as well as other
 tests written with the testing library. Import both XCTest and Testing if a
 source file contains mixed test content.
 
-### Interoperability between Swift Testing and XCTest
+### Use interoperability between Swift Testing and XCTest
 
 <!-- TODO: withKnownIssue and Test.cancel interop -->
 
 Interoperability is a feature that enables XCTest's assertions to work with
 Swift Testing, and Swift Testing's expectations to work with XCTest. You can use
-this to share common test helpers between XCTest and Swift Testing test cases.
+interoperability to share common test helpers between XCTest and Swift Testing
+test cases.
 
 For example, you can replace
 [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert)
@@ -85,28 +86,28 @@ func assertUnique(_ elements: [Int]) {
 }
 ```
 
-Interoperability has a configurable mode which controls how it reports issues
+Interoperability has a configurable mode that controls how it reports issues
 across test library boundaries.
 
-- **None**: the feature is disabled.
+- **None**: The feature is disabled.
 
-For the remaining modes, **Swift Testing API will behave as expected when used
-in XCTest**. This includes reporting any assertion failures as errors within an
-XCTest test case. As a result, any interop mode will enable you to incrementally
-migrate your assertions to Swift Testing.
+For the remaining modes, **Swift Testing API behaves as expected when used in
+XCTest**. This includes reporting any assertion failures as errors within an
+XCTest test case. As a result, any interop mode lets you incrementally migrate
+your assertions to Swift Testing.
 
 **XCTest API used in Swift Testing tests** behaves differently based on mode:
 
-- **Limited**: Surfaces all test failures that were previously ignored as
-  warnings. Also include warnings for XCTest API usage in a Swift Testing test.
+- **Limited**: Surfaces all test failures the library previously ignored as
+  warnings. Also includes warnings for XCTest API usage in a Swift Testing test.
 
-- **Complete**: Surfaces all test failures that were previously ignored with
-  their original severity. Also include warnings for XCTest API usage in a Swift
-  Testing test.
+- **Complete**: Surfaces all test failures the library previously ignored with
+  their original severity. Also includes warnings for XCTest API usage in a
+  Swift Testing test.
 
 - **Strict**:
   [`fatalError()`](https://developer.apple.com/documentation/swift/fatalerror(_:file:line:))
-  when XCTest API is used in a Swift Testing test.
+  when a Swift Testing test uses XCTest API.
 
 ```swift
 // Calling XCTest API from Swift Testing
@@ -140,9 +141,8 @@ When using the Swift 6.4 toolchain or newer, the default mode is `limited`. If
 the package also declares `swift-tools-version: 6.4` or newer, the default mode
 is `complete`.
 
-If you want to use the strict mode or opt-out of interop entirely, you'll need
-to override the default mode with the `SWIFT_TESTING_XCTEST_INTEROP_MODE`
-environment variable:
+To use strict mode or opt out of interop entirely, override the default mode
+with the `SWIFT_TESTING_XCTEST_INTEROP_MODE` environment variable:
 | Interop Mode | `SWIFT_TESTING_XCTEST_INTEROP_MODE` |
 | ------------ | ----------------------------------- |
 | None         | `none`                              |

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -23,7 +23,7 @@ convert XCTest-based content to use the testing library instead.
 
 ### Import the testing library
 
-XCTest and the testing library are available from different modules. Instead of 
+XCTest and the testing library are available from different modules. Instead of
 importing the XCTest module, import the Testing module:
 
 @Row {
@@ -41,8 +41,8 @@ importing the XCTest module, import the Testing module:
   }
 }
 
-A single source file can contain tests written with XCTest as well as other 
-tests written with the testing library. Import both XCTest and Testing if a 
+A single source file can contain tests written with XCTest as well as other
+tests written with the testing library. Import both XCTest and Testing if a
 source file contains mixed test content.
 
 ### Interoperability between Swift Testing and XCTest
@@ -309,7 +309,7 @@ As with XCTest, the testing library allows test functions to be marked `async`,
 For more information about test functions and how to declare and customize them,
 see <doc:DefiningTests>.
 
-### Check for expected values and outcomes 
+### Check for expected values and outcomes
 
 XCTest uses a family of approximately 40 functions to assert test requirements.
 These functions are collectively referred to as
@@ -438,7 +438,7 @@ their equivalents in the testing library:
 
 The testing library doesn’t provide an equivalent of
 [`XCTAssertEqual(_:_:accuracy:_:file:line:)`](https://developer.apple.com/documentation/xctest/3551607-xctassertequal).
-To compare two numeric values within a specified accuracy, 
+To compare two numeric values within a specified accuracy,
 use `isApproximatelyEqual()` from [swift-numerics](https://github.com/apple/swift-numerics).
 
 ### Continue or halt after test failures
@@ -619,7 +619,7 @@ and [`Sequence<Int>`](https://developer.apple.com/documentation/swift/sequence))
 can be used with ``confirmation(_:expectedCount:isolation:sourceLocation:_:)-l3il``.
 You must specify a lower bound for the number of confirmations because, without
 one, the testing library cannot tell if an issue should be recorded when there
-have been zero confirmations. 
+have been zero confirmations.
 
 ### Control whether a test runs
 
@@ -737,7 +737,7 @@ issue:
 - Note: The XCTest function [`XCTExpectFailure(_:options:)`](https://developer.apple.com/documentation/xctest/3727245-xctexpectfailure),
   which doesn't take a closure and which affects the remainder of the test,
   doesn't have a direct equivalent in the testing library. To mark an entire
-  test as having a known issue, wrap its body in a call to `withKnownIssue()`. 
+  test as having a known issue, wrap its body in a call to `withKnownIssue()`.
 
 If a test may fail intermittently, the call to
 `XCTExpectFailure(_:options:failingBlock:)` can be marked _non-strict_. When
@@ -764,7 +764,7 @@ instead:
     // After
     @Test func grillWorks() async {
       withKnownIssue(
-        "Grill may need fuel", 
+        "Grill may need fuel",
         isIntermittent: true
       ) {
         try FoodTruck.shared.grill.start()
@@ -822,7 +822,7 @@ of issues:
       } when: {
         FoodTruck.shared.hasGrill
       } matching: { issue in
-        issue.error != nil 
+        issue.error != nil
       }
       ...
     }
@@ -849,7 +849,7 @@ suite serially:
         try FoodTruck.shared.refrigerator.openDoor()
         XCTAssertEqual(FoodTruck.shared.refrigerator.lightState, .on)
       }
-      
+
       func testLightGoesOut() throws {
         try FoodTruck.shared.refrigerator.openDoor()
         try FoodTruck.shared.refrigerator.closeDoor()
@@ -867,7 +867,7 @@ suite serially:
         try FoodTruck.shared.refrigerator.openDoor()
         #expect(FoodTruck.shared.refrigerator.lightState == .on)
       }
-      
+
       @Test func lightGoesOut() throws {
         try FoodTruck.shared.refrigerator.openDoor()
         try FoodTruck.shared.refrigerator.closeDoor()

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -45,6 +45,111 @@ A single source file can contain tests written with XCTest as well as other
 tests written with the testing library. Import both XCTest and Testing if a 
 source file contains mixed test content.
 
+### Interoperability between Swift Testing and XCTest
+
+<!-- TODO: withKnownIssue and Test.cancel interop -->
+
+Interoperability is a feature that enables XCTest's assertions to work with
+Swift Testing, and Swift Testing's expectations to work with XCTest. You can use
+this to share common test helpers between XCTest and Swift Testing test cases.
+
+For example, you can replace
+[`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert)
+with ``expect(_:_:sourceLocation:)`` in your XCTests and immediately get the
+benefits of the newer, more ergonomic API. In the meantime, you can
+incrementally migrate the rest of your test infrastructure to use Swift Testing
+at your own pace.
+
+```swift
+// XCTest
+
+class UniqueElementsTests: XCTestCase {
+  func testDups() {
+    // Fails as expected
+    assertUnique([1, 2, 1])
+  }
+}
+
+// Swift Testing
+
+@Test func `Duplicate elements`() {
+  // *Without* interop: passes despite XCTAssertEqual failure in the helper
+  // With interop: fails as expected
+  assertUnique([1, 2, 1])
+}
+
+func assertUnique(_ elements: [Int]) {
+  XCTAssertEqual(Set(elements).count, elements.count)
+  // With interop: safely replace XCTAssertEqual with #expect
+  // #expect(Set(elements).count == elements.count)
+}
+```
+
+Interoperability has a configurable mode which controls how it reports issues
+across test library boundaries.
+
+- **None**: the feature is disabled.
+
+For the remaining modes, **Swift Testing API will behave as expected when used
+in XCTest**. This includes reporting any assertion failures as errors within an
+XCTest test case. As a result, any interop mode will enable you to incrementally
+migrate your assertions to Swift Testing.
+
+**XCTest API used in Swift Testing tests** behaves differently based on mode:
+
+- **Limited**: Surfaces all test failures that were previously ignored as
+  warnings. Also include warnings for XCTest API usage in a Swift Testing test.
+
+- **Complete**: Surfaces all test failures that were previously ignored with
+  their original severity. Also include warnings for XCTest API usage in a Swift
+  Testing test.
+
+- **Strict**:
+  [`fatalError()`](https://developer.apple.com/documentation/swift/fatalerror(_:file:line:))
+  when XCTest API is used in a Swift Testing test.
+
+```swift
+// Calling XCTest API from Swift Testing
+@Test func `Test Interop`() {
+  // <Mode>:   <failure message>
+  // None:     No message
+  // Limited:  ⚠️ "Interop failure",
+  //           ⚠️ Replace XCTest API such as 'XCTAssert' with a Swift
+  //              Testing equivalent such as '#expect'.
+  // Complete: ❌ "Interop failure", ⚠️ Replace XCTest API...
+  // Strict:   💥 fatalError: Replace XCTest API...
+  XCTFail("Interop failure")
+}
+```
+
+```swift
+// Calling Swift Testing API from XCTest
+class InteropTests: XCTestCase {
+  func testInterop() {
+    // <Mode>:   <failure message>
+    // None:     No message
+    // Limited:  ❌ "Interop failure"
+    // Complete: ❌ "Interop failure"
+    // Strict:   ❌ "Interop failure"
+    Issue.record("Interop failure")
+  }
+}
+```
+
+When using the Swift 6.4 toolchain or newer, the default mode is `limited`. If
+the package also declares `swift-tools-version: 6.4` or newer, the default mode
+is `complete`.
+
+If you want to use the strict mode or opt-out of interop entirely, you'll need
+to override the default mode with the `SWIFT_TESTING_XCTEST_INTEROP_MODE`
+environment variable:
+| Interop Mode | `SWIFT_TESTING_XCTEST_INTEROP_MODE` |
+| ------------ | ----------------------------------- |
+| None         | `none`                              |
+| Limited      | `limited`                           |
+| Complete     | `complete`                          |
+| Strict       | `strict`                            |
+
 ### Convert test classes
 
 XCTest groups related sets of test methods in test classes: classes that inherit

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -47,10 +47,16 @@ source file contains mixed test content.
 
 ### Use interoperability between Swift Testing and XCTest
 
-Interoperability is a feature that enables XCTest's assertions to work with
-Swift Testing, and Swift Testing's expectations to work with XCTest. You can use
-interoperability to share common test helpers between XCTest and Swift Testing
-test cases.
+You can use interoperability to share test helpers between XCTest and Swift
+Testing tests. Interoperability is a feature that enables XCTest's assertions to
+work with Swift Testing, and Swift Testing's expectations to work with XCTest.
+
+> Note: **Cross-library issue:** An issue created by an XCTest assertion in a Swift
+> Testing test case, or a Swift Testing expectation in an XCTest test case.
+>
+> An example of a "cross-library issue from XCTest" would be calling
+> [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert)
+> within a Swift Testing test.
 
 For example, you can replace
 [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert)
@@ -60,8 +66,6 @@ incrementally migrate the rest of your test infrastructure to use Swift Testing
 at your own pace.
 
 ```swift
-// XCTest
-
 class UniqueElementsTests: XCTestCase {
   func testDups() {
     // Fails as expected
@@ -69,10 +73,9 @@ class UniqueElementsTests: XCTestCase {
   }
 }
 
-// Swift Testing
-
 @Test func `Duplicate elements`() {
-  // *Without* interop: passes despite XCTAssertEqual failure in the helper
+  // Cross-library issue from XCTest
+  // Without interop: passes despite XCTAssertEqual failure in the helper
   // With interop: fails as expected
   assertUnique([1, 2, 1])
 }
@@ -87,32 +90,28 @@ func assertUnique(_ elements: [Int]) {
 
 #### Modes
 
-Interoperability has a configurable mode that controls how it reports issues
-across test library boundaries. There are two directions of interop: Swift
-Testing API usage in XCTest test cases, and XCT
+You can change how cross-library issues are reported by adjusting the
+interoperability mode.
 
-<!-- For all modes where interop is enabled, **Swift -->
-<!-- Testing API behaves as expected when used in XCTest**. This includes reporting -->
-<!-- any assertion failures as errors within an XCTest test case. As a result, any -->
-<!-- interop mode lets you incrementally migrate your assertions to Swift Testing. -->
+> Note: Default mode:
+> - `limited` when using the Swift 6.4 toolchain or newer.
+> - `complete` if the package also declares `swift-tools-version: 6.4` or newer.
 
-**XCTest API used in Swift Testing tests** behaves differently based on mode:
+- term None: The feature is disabled. All cross-library issues are ignored.
 
-- term None: The feature is disabled.
+- term Limited: Cross-library issues from Swift Testing maintain their original
+  severity. Cross-library issues from XCTest are warnings and are accompanied by
+  modernization hints.
 
-- term Limited: Surfaces all test failures the library previously ignored as
-  warnings. Also includes warnings for XCTest API usage in a Swift Testing test.
+- term Complete: All cross-library issues maintain their original severity.
+  Cross-library issues from XCTest are accompanied by modernization hints.
 
-- term Complete: Issues across both directions of test library boundaries are
-  reported and keep their original severity. Also includes warnings for XCTest
-  API usage in a Swift Testing test.
-
-- term Strict:
-  [`fatalError()`](https://developer.apple.com/documentation/swift/fatalerror(_:file:line:))
-  for failures from XCTest API.
+- term Strict: Cross-library issues from Swift Testing maintain their original
+  severity. Cross-library issues from XCTest are reported with
+  [`fatalError()`](https://developer.apple.com/documentation/swift/fatalerror(_:file:line:)).
 
 ```swift
-// Calling XCTest API from Swift Testing
+// Cross-library issues from XCTest
 @Test func `Test Interop`() {
   // <Mode>:   <failure message>
   // None:     No message
@@ -126,7 +125,7 @@ Testing API usage in XCTest test cases, and XCT
 ```
 
 ```swift
-// Calling Swift Testing API from XCTest
+// Cross-library issues from Swift Testing
 class InteropTests: XCTestCase {
   func testInterop() {
     // <Mode>:   <failure message>
@@ -139,12 +138,9 @@ class InteropTests: XCTestCase {
 }
 ```
 
-When using the Swift 6.4 toolchain or newer, the default mode is `limited`. If
-the package also declares `swift-tools-version: 6.4` or newer, the default mode
-is `complete`.
-
 To use strict mode or opt out of interop entirely, override the default mode
 with the `SWIFT_TESTING_XCTEST_INTEROP_MODE` environment variable:
+
 | Interop Mode | `SWIFT_TESTING_XCTEST_INTEROP_MODE` |
 | ------------ | ----------------------------------- |
 | None         | `none`                              |

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -83,10 +83,10 @@ A *cross-library issue* is an issue created by an XCTest assertion in
 a Swift Testing test case, or a Swift Testing expectation in an XCTest test
 case.
 
-In the example above, `assertUnique()` wraps
+In the example above, `assertUnique` wraps
 [`XCTAssertEqual()`](https://developer.apple.com/documentation/xctest/xctassertequal(_:_:_:file:line:)).
-It creates a "cross-library issue from XCTest" when called in the `Duplicate
-elements` Swift Testing test case.
+So, calling `assertUnique` in the `Duplicate
+elements` Swift Testing test case creates a _cross-library issue from XCTest_.
 
 ### Select an interoperability mode
 
@@ -106,17 +106,20 @@ cross-library issues:
 The default interoperability mode depends on your toolchain and the
 `swift-tools-version` declared in your package.
 
-| Toolchain Version | `swift-tools-version` | Default Interoperability Mode |
+| Toolchain version | `swift-tools-version` | Default interoperability mode |
 | ----------------- | --------------------- | ----------------------------- |
 | <6.4              | Any                   | `none`                        |
 | >=6.4             | <6.4                  | `limited`                     |
 | >=6.4             | >=6.4                 | `complete`                    |
 
-To explicitly choose a mode, set the `SWIFT_TESTING_XCTEST_INTEROP_MODE`
-environment variable to the name of the mode before running tests.
+To explicitly choose an interoperability mode, set the
+`SWIFT_TESTING_XCTEST_INTEROP_MODE` environment variable to the name of the mode
+before running tests.
 
-As long as you don't set the mode to `none`, cross-library issues from Swift
-Testing maintain their original severity.
+As long as you don't set the interoperability mode to `none`, cross-library
+issues from Swift Testing maintain their original severity. So, in the following
+example, the test failure message is `❌ "Interop failure"` -- except when the
+interoperability mode is `none`, then there is no test failure message.
 
 ```swift
 // Cross-library issues from Swift Testing
@@ -127,7 +130,7 @@ class InteropTests: XCTestCase {
 }
 ```
 
-You should consider the `complete` mode to ensure cross-library issues from
+Use `complete` mode to ensure cross-library issues from
 XCTest maintain their original severity.
 
 ```swift
@@ -136,12 +139,13 @@ XCTest maintain their original severity.
   XCTFail("Interop failure")
 }
 ```
-| Mode       | Test Failure Message                            |
-| ---------- | ----------------------------------------------- |
-| `none`     | No message                                      |
-| `limited`  | ⚠️ "Interop failure", ⚠️ Replace XCTest API ... |
-| `complete` | ❌ "Interop failure", ⚠️ Replace XCTest API ... |
-| `strict`   | `fatalError`: Replace XCTest API ...            |
+
+| Interoperability mode | Test failure message                            |
+| --------------------- | ----------------------------------------------- |
+| `none`                | No message                                      |
+| `limited`             | ⚠️ "Interop failure", ⚠️ Replace XCTest API ... |
+| `complete`            | ❌ "Interop failure", ⚠️ Replace XCTest API ... |
+| `strict`              | `fatalError`: Replace XCTest API ...            |
 
 ### Convert test classes
 
@@ -406,8 +410,9 @@ function. To record an unconditional issue using the testing library, use the
   }
 }
 
-The following table includes a list of the various [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert) functions and
-their equivalents in the testing library:
+The following table includes a list of the various
+[`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert)
+functions and their equivalents in the testing library:
 
 | XCTest | Swift Testing |
 |-|-|

--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -51,8 +51,9 @@ You can use interoperability to share test helpers between XCTest and Swift
 Testing tests. Interoperability is a feature that enables XCTest's assertions to
 work with Swift Testing, and Swift Testing's expectations to work with XCTest.
 
-> Note: **Cross-library issue:** An issue created by an XCTest assertion in a Swift
-> Testing test case, or a Swift Testing expectation in an XCTest test case.
+> Note: A **cross-library issue** is an issue created by an XCTest assertion in
+> a Swift Testing test case, or a Swift Testing expectation in an XCTest test
+> case.
 >
 > An example of a "cross-library issue from XCTest" would be calling
 > [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert)
@@ -61,52 +62,52 @@ work with Swift Testing, and Swift Testing's expectations to work with XCTest.
 For example, you can replace
 [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert)
 with ``expect(_:_:sourceLocation:)`` in your XCTests and immediately get the
-benefits of the newer, more ergonomic API. In the meantime, you can
-incrementally migrate the rest of your test infrastructure to use Swift Testing
-at your own pace.
+benefits of Swift Testing. In the meantime, you can incrementally migrate the
+rest of your test infrastructure to use Swift Testing at your own pace.
 
 ```swift
 class UniqueElementsTests: XCTestCase {
   func testDups() {
-    // Fails as expected
+    // This test is expected to fail.
     assertUnique([1, 2, 1])
   }
 }
 
 @Test func `Duplicate elements`() {
-  // Cross-library issue from XCTest
-  // Without interop: passes despite XCTAssertEqual failure in the helper
-  // With interop: fails as expected
+  // This is a cross-library issue from XCTest.
+  // Without interoperability the test passes despite the `XCTAssertEqual` failure in the helper.
+  // With interoperability, the test fails.
   assertUnique([1, 2, 1])
 }
 
 func assertUnique(_ elements: [Int]) {
   XCTAssertEqual(Set(elements).count, elements.count)
 
-  // With interop: safely replace XCTAssertEqual with #expect
-  // #expect(Set(elements).count == elements.count)
+  // With interoperability you can safely replace `XCTAssertEqual` with `#expect`.
+  // The replacement is: `#expect(Set(elements).count == elements.count)`.
 }
 ```
 
-#### Modes
+### Change interoperability modes
 
-You can change how cross-library issues are reported by adjusting the
+You can change how Swift Testing reports cross-library issues by adjusting the
 interoperability mode.
 
-> Note: Default mode:
-> - `limited` when using the Swift 6.4 toolchain or newer.
-> - `complete` if the package also declares `swift-tools-version: 6.4` or newer.
+The default interoperability mode depends on your toolchain. When you're using
+the Swift 6.4 toolchain or newer, the default mode is `limited`. If you're using
+the Swift 6.4 toolchain or newer and your package also declares
+`swift-tools-version: 6.4` or newer, the default mode is `complete`.
 
-- term None: The feature is disabled. All cross-library issues are ignored.
+To change the interoperability mode, set the `SWIFT_TESTING_XCTEST_INTEROP_MODE`
+environment variable to one of the following modes:
 
-- term Limited: Cross-library issues from Swift Testing maintain their original
+- term `none`: Interoperability is off. Swift Testing and XCTest ignore cross-library issues.
+- term `limited`: Cross-library issues from Swift Testing maintain their original
   severity. Cross-library issues from XCTest are warnings and are accompanied by
   modernization hints.
-
-- term Complete: All cross-library issues maintain their original severity.
+- term `complete`: All cross-library issues maintain their original severity.
   Cross-library issues from XCTest are accompanied by modernization hints.
-
-- term Strict: Cross-library issues from Swift Testing maintain their original
+- term `strict`: Cross-library issues from Swift Testing maintain their original
   severity. Cross-library issues from XCTest are reported with
   [`fatalError()`](https://developer.apple.com/documentation/swift/fatalerror(_:file:line:)).
 
@@ -137,16 +138,6 @@ class InteropTests: XCTestCase {
   }
 }
 ```
-
-To use strict mode or opt out of interop entirely, override the default mode
-with the `SWIFT_TESTING_XCTEST_INTEROP_MODE` environment variable:
-
-| Interop Mode | `SWIFT_TESTING_XCTEST_INTEROP_MODE` |
-| ------------ | ----------------------------------- |
-| None         | `none`                              |
-| Limited      | `limited`                           |
-| Complete     | `complete`                          |
-| Strict       | `strict`                            |
 
 ### Convert test classes
 
@@ -296,7 +287,7 @@ the presence of the `@Test` attribute:
 
 As with XCTest, the testing library allows test functions to be marked `async`,
 `throws`, or `async`-`throws`, and to be isolated to a global actor (for example, by using the
-`@MainActor` attribute.)
+`@MainActor` attribute).
 
 - Note: XCTest runs synchronous test methods on the main actor by default, while
   the testing library runs all test functions on an arbitrary task. If a test
@@ -411,7 +402,7 @@ function. To record an unconditional issue using the testing library, use the
   }
 }
 
-The following table includes a list of the various `XCTAssert()` functions and
+The following table includes a list of the various [`XCTAssert()`](https://developer.apple.com/documentation/xctest/1500669-xctassert) functions and
 their equivalents in the testing library:
 
 | XCTest | Swift Testing |


### PR DESCRIPTION
### Motivation:

Explain the new interoperability feature to anyone migrating from XCTest.

### Modifications:

Update MigratingFromXCTest docs. This is based heavily on the evolution
proposal in https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0021-targeted-interoperability-swift-testing-and-xctest.md

Resolves rdar://162896333

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.