### PR TITLE
docs: Expand discussion on when to use #expect vs. #require

### DIFF
--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -54,6 +54,36 @@ the test when the code doesn't satisfy a requirement, use
 ``require(_:_:sourceLocation:)-5l63q`` throws an instance of
 ``ExpectationFailedError`` when your code fails to satisfy the requirement.
 
+### Decide between an expectation and a requirement
+
+``expect(_:_:sourceLocation:)`` and ``require(_:_:sourceLocation:)-5l63q``
+check the same kinds of conditions, but they differ in what happens when a
+check fails:
+
+- ``expect(_:_:sourceLocation:)`` records an issue and then _continues_
+  running the rest of the test. Use it when a single failed check doesn't
+  prevent the remaining checks in the test from producing meaningful results,
+  so that one test run can report several independent failures at once.
+- ``require(_:_:sourceLocation:)-5l63q`` records an issue and then throws an
+  error, which _ends_ the current test. Because it throws, you call it with
+  `try`. Use it when the rest of the test can't run meaningfully unless the
+  condition holds, to avoid reporting a cascade of failures that all stem from
+  the same root cause.
+
+As a rule of thumb, reach for ``expect(_:_:sourceLocation:)`` by default, and
+switch to ``require(_:_:sourceLocation:)-5l63q`` when continuing the test after
+the failure would be pointless or misleading. For example, if you fetch a value
+and every later check depends on it, require the value so that the test stops at
+the source of the problem instead of producing further failures that the
+original failure caused.
+
+The same distinction applies when you work with optionals.
+``require(_:_:sourceLocation:)-6w9oo`` unwraps an optional and returns its
+value, or records an issue and ends the test if the value is `nil`, which lets
+you use the unwrapped value safely in the rest of the test. If you only want to
+check that a value isn't `nil` without using it afterward, and you want the test
+to keep running, use ``expect(_:_:sourceLocation:)`` instead.
+
 ## Topics
 
 ### Checking expectations


### PR DESCRIPTION
Expand the Expectations article with guidance on choosing between `#expect` and `#require`.

### Motivation:

The [Expectations article](https://github.com/swiftlang/swift-testing/blob/main/Sources/Testing/Testing.docc/Expectations.md#validate-your-codes-result) briefly describes the behavioral difference between `#expect` and `#require`, but doesn't elaborate on how to decide which one to use. People regularly ask for advice about this, so the article should discuss the trade-off more thoroughly.

Fixes #935.

### Modifications:

- Added a new "Decide between an expectation and a requirement" section to `Sources/Testing/Testing.docc/Expectations.md`.
- The section explains the behavioral difference (`#expect` records an issue and continues; `#require` records an issue and throws, ending the test) and gives a rule of thumb for choosing between them.
- It also covers the optional-unwrapping overload of `#require`, contrasting it with using `#expect` for a non-`nil` check when you don't need the unwrapped value and want the test to keep running.
- All DocC symbol references use the same disambiguated links already used elsewhere in the article (`require(_:_:sourceLocation:)-5l63q` and `require(_:_:sourceLocation:)-6w9oo`).

### Result:

The Expectations article now provides actionable guidance for deciding between `#expect` and `#require`. Documentation-only change; the `Testing` target continues to build cleanly.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated. (No symbols changed; existing disambiguated DocC references reused.)
