### PR TITLE
Testing: adjust type information

### DIFF
--- a/Sources/Testing/Support/CError.swift
+++ b/Sources/Testing/Support/CError.swift
@@ -100,7 +100,7 @@ extension Win32Error: CustomStringConvertible {
           DWORD(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK),
           nil,
           rawValue,
-          DWORD(swt_MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT)),
+          DWORD(swt_MAKELANGID(WORD(LANG_NEUTRAL), WORD(SUBLANG_DEFAULT))),
           buffer.baseAddress,
           0,
           nil

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -118,7 +118,7 @@ SWT_DEFINE_ATOMIC_OPERATIONS(void const *_Nullable)
 ///
 /// This function is provided because `MAKELANGID()` is a complex macro and
 /// cannot be imported directly into Swift.
-static LANGID swt_MAKELANGID(unsigned short p, unsigned short s) {
+static LANGID swt_MAKELANGID(WORD p, WORD s) {
   return MAKELANGID(p, s);
 }
 

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -118,7 +118,7 @@ SWT_DEFINE_ATOMIC_OPERATIONS(void const *_Nullable)
 ///
 /// This function is provided because `MAKELANGID()` is a complex macro and
 /// cannot be imported directly into Swift.
-static LANGID swt_MAKELANGID(int p, int s) {
+static LANGID swt_MAKELANGID(unsigned short p, unsigned short s) {
   return MAKELANGID(p, s);
 }
 


### PR DESCRIPTION
The parameter is meant to be WORD, which is UInt16. Adjust this to enable use of APINotes to adjust the typing for the entire ecosystem to the canonical types.