### PR TITLE
Silence a Windows-only warning about unused `try`.

### DIFF
--- a/Tests/TestingTests/Support/FileHandleTests.swift
+++ b/Tests/TestingTests/Support/FileHandleTests.swift
@@ -73,7 +73,7 @@ struct FileHandleTests {
           throw Win32Error(rawValue: GetLastError())
         }
         let fileHandle = try FileHandle(unsafeWindowsHANDLE: windowsHANDLE, options: [.readAccess])
-        try fileHandle.withUnsafeWindowsHANDLE { ownedHANDLE in
+        fileHandle.withUnsafeWindowsHANDLE { ownedHANDLE in
           #expect(windowsHANDLE == ownedHANDLE)
         }
       }


### PR DESCRIPTION
Silences a warning emitted from a test target on Windows.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
