### PR TITLE
Don't emit any console output or events if `--filter`/`--skip` is passed and there are zero matching tests.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -20,6 +20,8 @@ private import Synchronization
 ///   - args: A previously-parsed command-line arguments structure to interpret.
 ///     If `nil`, a new instance is created from the command-line arguments to
 ///     the current process.
+///   - forSwiftPackageManager: Whether or not this function is being called on
+///     behalf of Swift Package Manager (via `__swiftPMEntryPoint()`).
 ///   - eventHandler: An optional event handler. The testing library always
 ///     writes events to the standard error stream in addition to passing them
 ///     to this function.
@@ -29,7 +31,7 @@ private import Synchronization
 /// External callers cannot call this function directly. The can use
 /// ``ABI/v0/entryPoint-swift.type.property`` to get a reference to an
 /// ABI-stable version of this function.
-func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Handler?) async -> CInt {
+func entryPoint(passing args: __CommandLineArguments_v0?, forSwiftPackageManager: Bool = false, eventHandler: Event.Handler?) async -> CInt {
   let exitCode = Atomic(EXIT_SUCCESS)
 
   do {
@@ -55,6 +57,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
 
 #if !SWT_NO_FILE_IO
     // Configure the event recorder to write events to stderr.
+    let consoleOutputEnabled = Atomic(true)
     if configuration.verbosity > .min {
       // Check for experimental console output flag
       let useExperimentalConsoleOutput = (Environment.flag(named: "SWT_ENABLE_EXPERIMENTAL_CONSOLE_OUTPUT") == true)
@@ -69,7 +72,9 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
         }
 
         configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
-          eventRecorder.record(event, in: context)
+          if consoleOutputEnabled.load(ordering: .sequentiallyConsistent) {
+            eventRecorder.record(event, in: context)
+          }
           oldEventHandler(event, context)
         }
       }
@@ -81,7 +86,9 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
           try? FileHandle.stderr.write(string)
         }
         configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
-          eventRecorder.record(event, in: context)
+          if consoleOutputEnabled.load(ordering: .sequentiallyConsistent) {
+            eventRecorder.record(event, in: context)
+          }
           oldEventHandler(event, context)
         }
       }
@@ -127,6 +134,14 @@ func entryPoint(passing args: __CommandLineArguments_v0?, eventHandler: Event.Ha
       // Run the tests.
       let runner = await Runner(configuration: configuration)
       tests = runner.tests
+      if forSwiftPackageManager && tests.isEmpty, args.filter != nil || args.skip != nil {
+        // Swift Package Manager handles "no tests found/run" console output
+        // when the user applies any filtering. Don't bother logging to the
+        // console in this case. Note that if something is consuming the event
+        // stream, we still want to generate .runStarted etc., so we still call
+        // runner.run() for that purpose.
+        consoleOutputEnabled.store(false, ordering: .sequentiallyConsistent)
+      }
       await runner.run()
     }
 

--- a/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/SwiftPMEntryPoint.swift
@@ -59,7 +59,7 @@ public func __swiftPMEntryPoint(passing args: __CommandLineArguments_v0? = nil) 
   }
 #endif
 
-  return await entryPoint(passing: args, eventHandler: nil)
+  return await entryPoint(passing: args, forSwiftPackageManager: true, eventHandler: nil)
 }
 
 /// The entry point to the testing library used by Swift Package Manager.

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -163,6 +163,26 @@ struct SwiftPMTests {
     _ = try configurationForEntryPoint(withArguments: ["PATH", "--skip"])
   }
 
+#if !SWT_NO_EXIT_TESTS
+  @Test("--filter suppresses console output when no tests found")
+  func suppressConsoleOutputWhenFilteredToNothing() async {
+    await #expect(processExitsWith: .exitCode(EXIT_NO_TESTS_FOUND), observing: [\.standardErrorContent]) {
+      var args = __CommandLineArguments_v0()
+      args.filter = ["$^"] // match "nothing"
+      await __swiftPMEntryPoint(passing: args) as Never
+    }
+  }
+
+  @Test("--skip suppresses console output when no tests found")
+  func suppressConsoleOutputWhenSkippedToNothing() async {
+    await #expect(processExitsWith: .exitCode(EXIT_NO_TESTS_FOUND), observing: [\.standardErrorContent]) {
+      var args = __CommandLineArguments_v0()
+      args.skip = [".*"] // match "anything"
+      await __swiftPMEntryPoint(passing: args) as Never
+    }
+  }
+#endif
+
   @Test(".hidden trait", .tags(.traitRelated))
   func hidden() async throws {
     let configuration = try configurationForEntryPoint(withArguments: ["PATH"])

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -165,21 +165,23 @@ struct SwiftPMTests {
 
 #if !SWT_NO_EXIT_TESTS
   @Test("--filter suppresses console output when no tests found")
-  func suppressConsoleOutputWhenFilteredToNothing() async {
-    await #expect(processExitsWith: .exitCode(EXIT_NO_TESTS_FOUND), observing: [\.standardErrorContent]) {
+  func suppressConsoleOutputWhenFilteredToNothing() async throws {
+    let result = try await #require(processExitsWith: .exitCode(EXIT_NO_TESTS_FOUND), observing: [\.standardErrorContent]) {
       var args = __CommandLineArguments_v0()
       args.filter = ["$^"] // match "nothing"
       await __swiftPMEntryPoint(passing: args) as Never
     }
+    #expect(result.standardErrorContent.isEmpty)
   }
 
   @Test("--skip suppresses console output when no tests found")
-  func suppressConsoleOutputWhenSkippedToNothing() async {
-    await #expect(processExitsWith: .exitCode(EXIT_NO_TESTS_FOUND), observing: [\.standardErrorContent]) {
+  func suppressConsoleOutputWhenSkippedToNothing() async throws {
+    let result = try await #require(processExitsWith: .exitCode(EXIT_NO_TESTS_FOUND), observing: [\.standardErrorContent]) {
       var args = __CommandLineArguments_v0()
       args.skip = [".*"] // match "anything"
       await __swiftPMEntryPoint(passing: args) as Never
     }
+    #expect(result.standardErrorContent.isEmpty)
   }
 #endif
 


### PR DESCRIPTION
When SwiftPM triggers a test run with a filter, and no tests are run as a result of that filter, SwiftPM should be responsible for the ensuing console output.

Resolves rdar://178527194.
Resolves #1739.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
