### PR TITLE
Don't send fallback events when interop mode is none

### DIFF
--- a/Sources/Testing/Events/Event+FallbackEventHandler.swift
+++ b/Sources/Testing/Events/Event+FallbackEventHandler.swift
@@ -234,7 +234,12 @@ extension Event {
   /// handler belongs to the testing library (and so shouldn't be called by us),
   /// the value of this property is `nil`.
   private static let _postToFallbackEventHandler: Event.Handler? = {
-    guard let fallbackEventHandler = _swift_testing_getFallbackEventHandler() else {
+    // If Swift Testing API is called when mode == none, XCTest might still have
+    // installed a fallback event handler. We should refuse to send any events.
+    guard
+      Interop.Mode.current != .none,
+      let fallbackEventHandler = _swift_testing_getFallbackEventHandler()
+    else {
       return nil
     }
 

--- a/Tests/TestingTests/EventHandlingInteropTests.swift
+++ b/Tests/TestingTests/EventHandlingInteropTests.swift
@@ -173,6 +173,22 @@ struct EventHandlingInteropTests {
     }
   }
 
+  @Test func `Don't post to fallback handler if interop mode set to none`() async {
+    await #expect(processExitsWith: .success) {
+      Self.setInteropMode(.none)
+
+      try #require(_swift_testing_installFallbackEventHandler(Self.unusableHandler))
+
+      // Force the event to be handled by the fallback event handler
+      Configuration.removeAll()
+      await Task.detached {
+        Event.post(.issueRecorded(Issue(kind: .system)), configuration: nil)
+      }.value
+
+      // unusableHandler fatalErrors if called, so success means no event was posted
+    }
+  }
+
   @Test func `Limited interop mode uses warning severity`() async throws {
     await #expect(processExitsWith: .success) {
       Self.setInteropMode(.limited)


### PR DESCRIPTION
### Motivation:

Today, XCTest doesn't have any mode checking logic so it can't actually opt-out of interop.

That's because Swift Testing will happily send fallback events, regardless of the mode, if it detects a fallback event handler is installed.

Note that Swift Testing already refuses to *receive* fallback events when the interop mode is none.

### Modifications:

Add a check for interop mode != none when resolving the _postToFallbackEventHandler closure.

Resolves rdar://178774969

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.