### PR TITLE
Enable Android emulator testing with the snapshot toolchains employing swift-build in SwiftPM

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   create_merge_pr:
     name: Create PR to merge main into release branch
-    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.12
     with:
       head_branch: main
       base_branch: release/6.4.x

--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.12
     with:
       linux_swift_versions: '["nightly-main"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
@@ -32,3 +32,4 @@ jobs:
       android_sdk_versions: '["nightly-main"]'
       android_ndk_versions: '["r28c", "r29"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'
+      enable_android_sdk_checks: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.12
     with:
       linux_swift_versions: '["nightly-6.3"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
             ls -ld /Applications/*Xcode*
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.12
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.3"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
@@ -35,13 +35,15 @@ jobs:
       wasm_sdk_versions: '["6.3", "nightly-main", "nightly-6.3"]'
       enable_android_sdk_build: true
       android_ndk_versions: '["r28c", "r29"]'
+      android_sdk_versions: '["nightly-main", "nightly-6.4.x"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'
+      enable_android_sdk_checks: true
       enable_freebsd_checks: true
       freebsd_swift_versions: '["nightly-main"]'
       freebsd_os_versions: '["14.3"]'
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.12
     with:
       license_header_check_project_name: "Swift"
       docs_check_enabled: false


### PR DESCRIPTION
@marcprux found that [the trunk snapshot toolchain now successfully cross-compiles the tests for Android](https://github.com/swiftlang/swift-package-manager/issues/8094#issuecomment-4616423370), which I was able to reproduce locally with the latest 6.4 snapshot also. With the latest GitHub workflows using `swift-build` again for the 6.4 and trunk snapshots, swiftlang/github-workflows#269, let's see if the trunk tests run in the emulator.

We currently cross-compile this repo to Android using the defaults of 6.3, nightly-6.3, and trunk, and we'll probably add nightly-6.4 soon: can we drop cross-compiling for Android with 6.3 then? That will allow us to run the tests for 6.4 and trunk in the emulator, without any workarounds needed for 6.3 being unable to cross-compile these tests.