### PR TITLE
Fix build for SWT_NO_FILE_IO

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -134,6 +134,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, forSwiftPackageManager
       // Run the tests.
       let runner = await Runner(configuration: configuration)
       tests = runner.tests
+#if !SWT_NO_FILE_IO
       if forSwiftPackageManager && tests.isEmpty, args.filter != nil || args.skip != nil {
         // Swift Package Manager handles "no tests found/run" console output
         // when the user applies any filtering. Don't bother logging to the
@@ -142,6 +143,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, forSwiftPackageManager
         // runner.run() for that purpose.
         consoleOutputEnabled.store(false, ordering: .sequentiallyConsistent)
       }
+#endif
       await runner.run()
     }
 


### PR DESCRIPTION
### Motivation:

Fixes a build issue for environments where SWT_NO_FILE_IO is set.

### Modifications:

Guard consoleOutputEnabled with SWT_NO_FILE_IO. The variable isn't defined nor is it relevant in the no-file-io scenario.

Resolves rdar://179026281

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.