### PR TITLE
Specify Xcode 27 availability for API introduced in Swift 6.4.

### DIFF
--- a/Sources/Overlays/_Testing_CoreTransferable/Attachments/Attachment+Transferable.swift
+++ b/Sources/Overlays/_Testing_CoreTransferable/Attachments/Attachment+Transferable.swift
@@ -16,6 +16,7 @@ public import UniformTypeIdentifiers
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.4)
+///   @Available(Xcode, introduced: 27.0)
 /// }
 @available(_transferableAPI, *)
 extension Attachment {
@@ -55,6 +56,7 @@ extension Attachment {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.4)
+  ///   @Available(Xcode, introduced: 27.0)
   /// }
   public init<T>(
     exporting transferableValue: T,

--- a/Sources/Overlays/_Testing_CoreTransferable/Attachments/_AttachableTransferableWrapper.swift
+++ b/Sources/Overlays/_Testing_CoreTransferable/Attachments/_AttachableTransferableWrapper.swift
@@ -24,6 +24,7 @@ import UniformTypeIdentifiers
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.4)
+///   @Available(Xcode, introduced: 27.0)
 /// }
 @available(_transferableAPI, *)
 public struct _AttachableTransferableWrapper<T>: Sendable where T: Transferable & Sendable {
@@ -53,11 +54,13 @@ public struct _AttachableTransferableWrapper<T>: Sendable where T: Transferable 
 
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.4)
+///   @Available(Xcode, introduced: 27.0)
 /// }
 @available(_transferableAPI, *)
 extension _AttachableTransferableWrapper: AttachableWrapper {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.4)
+  ///   @Available(Xcode, introduced: 27.0)
   /// }
   public var wrappedValue: T {
     _transferableValue
@@ -65,6 +68,7 @@ extension _AttachableTransferableWrapper: AttachableWrapper {
 
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.4)
+  ///   @Available(Xcode, introduced: 27.0)
   /// }
   public func withUnsafeBytes<R>(for attachment: borrowing Attachment<Self>, _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
     try _bytes.withUnsafeBytes(body)
@@ -72,6 +76,7 @@ extension _AttachableTransferableWrapper: AttachableWrapper {
 
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.4)
+  ///   @Available(Xcode, introduced: 27.0)
   /// }
   public borrowing func preferredName(for attachment: borrowing Attachment<Self>, basedOn suggestedName: String) -> String {
     let baseName = _transferableValue.suggestedFilename ?? suggestedName

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -193,6 +193,7 @@ extension ABI {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.4)
+  ///   @Available(Xcode, introduced: 27.0)
   /// }
   public enum v6_4: Sendable, Version, _Version {
     public static var versionNumber: VersionNumber {

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -92,6 +92,7 @@ extension ABI {
     ///
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.4)
+    ///   @Available(Xcode, introduced: 27.0)
     /// }
     var tags: [String]?
 
@@ -99,6 +100,7 @@ extension ABI {
     ///
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.4)
+    ///   @Available(Xcode, introduced: 27.0)
     /// }
     var bugs: [Bug]?
 
@@ -106,6 +108,7 @@ extension ABI {
     ///
     /// @Metadata {
     ///   @Available(Swift, introduced: 6.4)
+    ///   @Available(Xcode, introduced: 27.0)
     /// }
     var timeLimit: Double?
   }

--- a/Sources/Testing/SourceAttribution/CustomTestReflectable.swift
+++ b/Sources/Testing/SourceAttribution/CustomTestReflectable.swift
@@ -18,6 +18,7 @@
 ///
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.4)
+///   @Available(Xcode, introduced: 27.0)
 /// }
 @_unavailableInEmbedded
 public protocol CustomTestReflectable {
@@ -29,6 +30,7 @@ public protocol CustomTestReflectable {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.4)
+  ///   @Available(Xcode, introduced: 27.0)
   /// }
   var customTestMirror: Mirror { get }
 #endif
@@ -37,6 +39,7 @@ public protocol CustomTestReflectable {
 #if !hasFeature(Embedded)
 /// @Metadata {
 ///   @Available(Swift, introduced: 6.4)
+///   @Available(Xcode, introduced: 27.0)
 /// }
 extension Mirror {
   /// Initialize this instance so that it can be presented in a test's output.
@@ -50,6 +53,7 @@ extension Mirror {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.4)
+  ///   @Available(Xcode, introduced: 27.0)
   /// }
   public init(reflectingForTest subject: some CustomTestReflectable) {
     self = subject.customTestMirror
@@ -66,6 +70,7 @@ extension Mirror {
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.4)
+  ///   @Available(Xcode, introduced: 27.0)
   /// }
   public init(reflectingForTest subject: some Any) {
     if let subject = subject as? any CustomTestReflectable {


### PR DESCRIPTION
Xcode 27 includes Swift 6.4.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
