### PR TITLE
Make @_spi ABI visible to corelibs XCTest

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -166,3 +166,8 @@ _swift_testing_install_target(Testing)
 # Install the Swift cross-import overlay directory.
 _swift_testing_install_swiftcrossimport(Testing
   Testing.swiftcrossimport)
+
+# Make @_spi visible to other projects building against Testing in the toolchain (e.g. swift-corelibs-xctest)
+set_target_properties(Testing PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+set_property(GLOBAL APPEND PROPERTY SwiftTesting_EXPORTS Testing)

--- a/Sources/_TestDiscovery/CMakeLists.txt
+++ b/Sources/_TestDiscovery/CMakeLists.txt
@@ -30,4 +30,7 @@ if(NOT BUILD_SHARED_LIBS)
   # is linked into the main library and does not need to be installed separately.
   install(TARGETS _TestDiscovery
     ARCHIVE DESTINATION "${SwiftTesting_INSTALL_LIBDIR}")
+
+  # _TestDiscovery is a Testing dependency that needs to be exported
+  set_property(GLOBAL APPEND PROPERTY SwiftTesting_EXPORTS _TestDiscovery)
 endif()

--- a/Sources/_TestingInternals/CMakeLists.txt
+++ b/Sources/_TestingInternals/CMakeLists.txt
@@ -37,7 +37,7 @@ if(NOT BUILD_SHARED_LIBS)
     ARCHIVE DESTINATION "${SwiftTesting_INSTALL_LIBDIR}")
 
   # We don't necessarily want to export _TestingInternals, but it is unavoidable
-  # when building statically since _TestingInterop depends on it
+  # when building statically since _TestingInterop/Testing depends on it
   # https://gitlab.kitware.com/cmake/cmake/-/issues/20041
   set_property(GLOBAL APPEND PROPERTY SwiftTesting_EXPORTS _TestingInternals)
 endif()


### PR DESCRIPTION
### Motivation:

Allow the ABI type to be shared with corelibs XCTest to deduplicate some interoperability logic

### Modifications:

Update CMake build script so that @_spi visible symbols are included in the CMake module. This can then be found by swift-corelibs-xctest when building with CMake.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.