### PR TITLE
Quote `WASI` in `CMAKE_SYSTEM_NAME STREQUAL` checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ project(SwiftTesting
   LANGUAGES CXX Swift)
 
 if(NOT APPLE)
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "WASI")
     find_package(dispatch CONFIG)
   endif()
   find_package(Foundation CONFIG)

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -136,7 +136,7 @@ target_link_libraries(Testing PRIVATE
   _TestingInternals
   _TestingInterop)
 if(NOT APPLE)
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "WASI")
     target_link_libraries(Testing PUBLIC
       dispatch)
   endif()

--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -60,7 +60,7 @@ if(SWT_TESTING_LIBRARY_VERSION)
   add_compile_definitions("$<$<COMPILE_LANGUAGE:CXX>:SWT_TESTING_LIBRARY_VERSION=\"${SWT_TESTING_LIBRARY_VERSION}\">")
 endif()
 
-if((NOT BUILD_SHARED_LIBS) AND (NOT CMAKE_SYSTEM_NAME STREQUAL WASI))
+if((NOT BUILD_SHARED_LIBS) AND (NOT CMAKE_SYSTEM_NAME STREQUAL "WASI"))
   # When building a static library, Interop is not supported at this time
   add_compile_definitions("SWT_NO_INTEROP")
 endif()


### PR DESCRIPTION
Quote the `WASI` operand in three `CMAKE_SYSTEM_NAME STREQUAL WASI` comparisons so that CMake compares against the literal string instead of dereferencing `WASI` as a variable when it is defined (recent CMake's `Platform/WASI-Initialize.cmake` sets `WASI` to 1), which otherwise inverts the WASI build guards.

This means that the build behaves correctly with both CMake 3 and CMake 4, which differ in their handling of these conditions:

- CMake 4.3.3: `Modules/Platform/WASI-Initialize.cmake` has `set(WASI 1)`.
- CMake 3.30.2 (used on CI): that file does not exist, and nothing under `Modules/Platform/` ever sets a `WASI` variable.
