### PR TITLE
Adopt `pipe2()` on Darwin.

### DIFF
--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -577,12 +577,16 @@ extension FileHandle {
 // MARK: - Pipes
 
 extension FileHandle {
-#if os(Linux) && !SWT_NO_DYNAMIC_LINKING
+#if (SWT_TARGET_OS_APPLE || os(Linux)) && !SWT_NO_DYNAMIC_LINKING
   /// Create a pipe with flags.
   ///
-  /// This function declaration is provided because `pipe2()` is only declared
-  /// if `_GNU_SOURCE` is set, but setting it causes build errors due to
-  /// conflicts with Swift's Glibc module.
+  /// On Apple platforms, this function declaration is provided because
+  /// `pipe2()` requires a newer SDK than is currently available in Swift's CI
+  /// systems.
+  ///
+  /// On Linux, this function declaration is provided because `pipe2()` is only
+  /// declared if `_GNU_SOURCE` is set, but setting it causes build errors due
+  /// to conflicts with Swift's Glibc module.
   private static let _pipe2 = symbol(named: "pipe2").map {
     castCFunction(at: $0, to: (@convention(c) (UnsafeMutablePointer<CInt>, CInt) -> CInt).self)
   }
@@ -606,8 +610,8 @@ extension FileHandle {
     return _pipe(fds, 0, _O_BINARY | _O_NOINHERIT)
 #else
     func simulatePipe2Call(_ fds: UnsafeMutablePointer<CInt>) -> CInt {
-      // pipe2() is not available. Use pipe() instead and simulate O_CLOEXEC to the
-      // best of our ability.
+      // pipe2() is not available. Use pipe() instead and simulate O_CLOEXEC to
+      // the best of our ability.
       let result = pipe(fds)
       guard result == 0 else {
         return result
@@ -616,8 +620,8 @@ extension FileHandle {
         try setFD_CLOEXEC(true, onFileDescriptor: fds[0])
         try setFD_CLOEXEC(true, onFileDescriptor: fds[1])
       } catch {
-        // Failed to set FD_CLOEXEC on either end of the pipe. This is unexpected
-        // and may in practice be unreachable.
+        // Failed to set FD_CLOEXEC on either end of the pipe. This failure is
+        // unexpected and may in practice be unreachable.
         _close(fds[0])
         fds[0] = -1
         _close(fds[1])
@@ -627,10 +631,7 @@ extension FileHandle {
       return 0
     }
 
-#if SWT_TARGET_OS_APPLE
-    // pipe2() is not implemented on Darwin. BUG: rdar://138426570
-    return simulatePipe2Call(fds)
-#elseif os(Linux)
+#if SWT_TARGET_OS_APPLE || os(Linux)
 #if !SWT_NO_DYNAMIC_LINKING
     if let _pipe2 {
       return _pipe2(fds, O_CLOEXEC)


### PR DESCRIPTION
anyAppleOS 27 adds the `pipe2()` POSIX call, so we can now adopt it there.

Resolves rdar://155439498.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
