### PR TITLE
[6.4.x] Adopt `pipe2()` on Darwin.

### DIFF
--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -577,12 +577,16 @@ extension FileHandle {
 // MARK: - Pipes
 
 extension FileHandle {
-#if os(Linux) && !SWT_NO_DYNAMIC_LINKING
+#if (SWT_TARGET_OS_APPLE || os(Linux)) && !SWT_NO_DYNAMIC_LINKING
   /// Create a pipe with flags.
   ///
-  /// This function declaration is provided because `pipe2()` is only declared
-  /// if `_GNU_SOURCE` is set, but setting it causes build errors due to
-  /// conflicts with Swift's Glibc module.
+  /// On Apple platforms, this function declaration is provided because
+  /// `pipe2()` requires a newer SDK than is currently available in Swift's CI
+  /// systems.
+  ///
+  /// On Linux, this function declaration is provided because `pipe2()` is only
+  /// declared if `_GNU_SOURCE` is set, but setting it causes build errors due
+  /// to conflicts with Swift's Glibc module.
   private static let _pipe2 = symbol(named: "pipe2").map {
     castCFunction(at: $0, to: (@convention(c) (UnsafeMutablePointer<CInt>, CInt) -> CInt).self)
   }
@@ -606,8 +610,8 @@ extension FileHandle {
     return _pipe(fds, 0, _O_BINARY | _O_NOINHERIT)
 #else
     func simulatePipe2Call(_ fds: UnsafeMutablePointer<CInt>) -> CInt {
-      // pipe2() is not available. Use pipe() instead and simulate O_CLOEXEC to the
-      // best of our ability.
+      // pipe2() is not available. Use pipe() instead and simulate O_CLOEXEC to
+      // the best of our ability.
       let result = pipe(fds)
       guard result == 0 else {
         return result
@@ -616,8 +620,8 @@ extension FileHandle {
         try setFD_CLOEXEC(true, onFileDescriptor: fds[0])
         try setFD_CLOEXEC(true, onFileDescriptor: fds[1])
       } catch {
-        // Failed to set FD_CLOEXEC on either end of the pipe. This is unexpected
-        // and may in practice be unreachable.
+        // Failed to set FD_CLOEXEC on either end of the pipe. This failure is
+        // unexpected and may in practice be unreachable.
         _close(fds[0])
         fds[0] = -1
         _close(fds[1])
@@ -627,10 +631,7 @@ extension FileHandle {
       return 0
     }
 
-#if SWT_TARGET_OS_APPLE
-    // pipe2() is not implemented on Darwin. BUG: rdar://138426570
-    return simulatePipe2Call(fds)
-#elseif os(Linux)
+#if SWT_TARGET_OS_APPLE || os(Linux)
 #if !SWT_NO_DYNAMIC_LINKING
     if let _pipe2 {
       return _pipe2(fds, O_CLOEXEC)


### PR DESCRIPTION
- **Explanation**: Adopts `pipe2()` on Darwin to eliminate a race condition when creating a pipe that can leak file descriptors.
- **Scope**: Exit tests
- **Issues**: rdar://155439498
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1760
- **Risk**: Low
- **Testing**: Existing test coverage as well as any internal XNU/Darwin test coverage for `pipe2()`
- **Reviewers**: @stmontgomery @harlanhaskins