### PR TITLE
Update GHA workflows to test against 6.4 nightlies.

### DIFF
--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -22,7 +22,7 @@ jobs:
       linux_static_sdk_versions: '["nightly-main"]'
       windows_swift_versions: '["nightly-main"]'
       enable_macos_checks: true
-      macos_xcode_versions: '["swift_6.3"]'
+      macos_xcode_versions: '["swift_6.4"]'
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["nightly-main"]'
       enable_freebsd_checks: true

--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
       linux_swift_versions: '["nightly-main"]'
-      linux_os_versions: '["amazonlinux2", "jammy"]'
+      linux_os_versions: '["jammy"]'
       linux_static_sdk_versions: '["nightly-main"]'
       windows_swift_versions: '["nightly-main"]'
       enable_macos_checks: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -1,4 +1,4 @@
-name: main branch, 6.3 toolchain
+name: main branch, 6.4 toolchain
 
 permissions:
   contents: read
@@ -22,7 +22,7 @@ jobs:
       linux_static_sdk_versions: '["6.4", "nightly-6.4"]'
       windows_swift_versions: '["6.4", "nightly-6.4"]'
       enable_macos_checks: true
-      macos_xcode_versions: '["swift_6.3"]'
+      macos_xcode_versions: '["swift_6.4"]'
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["6.4", "nightly-6.4"]'
       enable_android_sdk_build: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -19,14 +19,14 @@ jobs:
     with:
       linux_swift_versions: '["nightly-6.4.x"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
-      linux_static_sdk_versions: '["6.4", "nightly-6.4.x"]'
-      windows_swift_versions: '["6.4", "nightly-6.4.x"]'
+      linux_static_sdk_versions: '["nightly-6.4.x"]'
+      windows_swift_versions: '["nightly-6.4.x"]'
       enable_macos_checks: true
       macos_xcode_versions: '["swift_6.4"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["6.4", "nightly-6.4.x"]'
+      wasm_sdk_versions: '["nightly-6.4.x"]'
       enable_android_sdk_build: true
-      android_sdk_versions: '["6.4", "nightly-6.4.x"]'
+      android_sdk_versions: '["nightly-6.4.x"]'
       android_ndk_versions: '["r28c", "r29"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'
 #       enable_freebsd_checks: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -17,18 +17,18 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
-      linux_swift_versions: '["nightly-6.3"]'
+      linux_swift_versions: '["nightly-6.4"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
-      linux_static_sdk_versions: '["6.3", "nightly-6.3"]'
-      windows_swift_versions: '["6.3", "nightly-6.3"]'
+      linux_static_sdk_versions: '["6.4", "nightly-6.4"]'
+      windows_swift_versions: '["6.4", "nightly-6.4"]'
       enable_macos_checks: true
       macos_xcode_versions: '["swift_6.3"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["6.3", "nightly-6.3"]'
+      wasm_sdk_versions: '["6.4", "nightly-6.4"]'
       enable_android_sdk_build: true
-      android_sdk_versions: '["6.3", "nightly-6.3"]'
+      android_sdk_versions: '["6.4", "nightly-6.4"]'
       android_ndk_versions: '["r28c", "r29"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'
 #       enable_freebsd_checks: true
-#       freebsd_swift_versions: '["nightly-6.3"]'
+#       freebsd_swift_versions: '["nightly-6.4"]'
 #       freebsd_os_versions: '["14.3"]'

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -17,18 +17,18 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
-      linux_swift_versions: '["nightly-6.4"]'
+      linux_swift_versions: '["nightly-6.4.x"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
-      linux_static_sdk_versions: '["6.4", "nightly-6.4"]'
-      windows_swift_versions: '["6.4", "nightly-6.4"]'
+      linux_static_sdk_versions: '["6.4", "nightly-6.4.x"]'
+      windows_swift_versions: '["6.4", "nightly-6.4.x"]'
       enable_macos_checks: true
       macos_xcode_versions: '["swift_6.4"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["6.4", "nightly-6.4"]'
+      wasm_sdk_versions: '["6.4", "nightly-6.4.x"]'
       enable_android_sdk_build: true
-      android_sdk_versions: '["6.4", "nightly-6.4"]'
+      android_sdk_versions: '["6.4", "nightly-6.4.x"]'
       android_ndk_versions: '["r28c", "r29"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'
 #       enable_freebsd_checks: true
-#       freebsd_swift_versions: '["nightly-6.4"]'
+#       freebsd_swift_versions: '["nightly-6.4.x"]'
 #       freebsd_os_versions: '["14.3"]'

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
       linux_swift_versions: '["nightly-6.4.x"]'
-      linux_os_versions: '["amazonlinux2", "jammy"]'
+      linux_os_versions: '["jammy"]'
       linux_static_sdk_versions: '["nightly-6.4.x"]'
       windows_swift_versions: '["nightly-6.4.x"]'
       enable_macos_checks: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,16 +23,16 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
-      linux_swift_versions: '["nightly-main", "nightly-6.3"]'
+      linux_swift_versions: '["nightly-main", "nightly-6.4"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
-      linux_static_sdk_versions: '["6.3", "nightly-main", "nightly-6.3"]'
-      windows_swift_versions: '["6.3", "nightly-main", "nightly-6.3"]'
+      linux_static_sdk_versions: '["6.4", "nightly-main", "nightly-6.4"]'
+      windows_swift_versions: '["6.4", "nightly-main", "nightly-6.4"]'
       enable_macos_checks: true
       macos_xcode_versions: '["swift_6.3"]'
       enable_ios_checks: true
       ios_host_xcode_versions: '["swift_6.3"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["6.3", "nightly-main", "nightly-6.3"]'
+      wasm_sdk_versions: '["6.4", "nightly-main", "nightly-6.4"]'
       enable_android_sdk_build: true
       android_ndk_versions: '["r28c", "r29"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
-      linux_os_versions: '["amazonlinux2", "jammy"]'
+      linux_os_versions: '["jammy"]'
       linux_static_sdk_versions: '["nightly-main", "nightly-6.4.x"]'
       windows_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       enable_macos_checks: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,9 +28,9 @@ jobs:
       linux_static_sdk_versions: '["6.4", "nightly-main", "nightly-6.4"]'
       windows_swift_versions: '["6.4", "nightly-main", "nightly-6.4"]'
       enable_macos_checks: true
-      macos_xcode_versions: '["swift_6.3"]'
+      macos_xcode_versions: '["swift_6.4"]'
       enable_ios_checks: true
-      ios_host_xcode_versions: '["swift_6.3"]'
+      ios_host_xcode_versions: '["swift_6.4"]'
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["6.4", "nightly-main", "nightly-6.4"]'
       enable_android_sdk_build: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,16 +23,16 @@ jobs:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
-      linux_swift_versions: '["nightly-main", "nightly-6.4"]'
+      linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
-      linux_static_sdk_versions: '["6.4", "nightly-main", "nightly-6.4"]'
-      windows_swift_versions: '["6.4", "nightly-main", "nightly-6.4"]'
+      linux_static_sdk_versions: '["6.4", "nightly-main", "nightly-6.4.x"]'
+      windows_swift_versions: '["6.4", "nightly-main", "nightly-6.4.x"]'
       enable_macos_checks: true
       macos_xcode_versions: '["swift_6.4"]'
       enable_ios_checks: true
       ios_host_xcode_versions: '["swift_6.4"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["6.4", "nightly-main", "nightly-6.4"]'
+      wasm_sdk_versions: '["6.4", "nightly-main", "nightly-6.4.x"]'
       enable_android_sdk_build: true
       android_ndk_versions: '["r28c", "r29"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,14 +25,14 @@ jobs:
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       linux_os_versions: '["amazonlinux2", "jammy"]'
-      linux_static_sdk_versions: '["6.4", "nightly-main", "nightly-6.4.x"]'
-      windows_swift_versions: '["6.4", "nightly-main", "nightly-6.4.x"]'
+      linux_static_sdk_versions: '["nightly-main", "nightly-6.4.x"]'
+      windows_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       enable_macos_checks: true
       macos_xcode_versions: '["swift_6.4"]'
       enable_ios_checks: true
       ios_host_xcode_versions: '["swift_6.4"]'
       enable_wasm_sdk_build: true
-      wasm_sdk_versions: '["6.4", "nightly-main", "nightly-6.4.x"]'
+      wasm_sdk_versions: '["nightly-main", "nightly-6.4.x"]'
       enable_android_sdk_build: true
       android_ndk_versions: '["r28c", "r29"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'


### PR DESCRIPTION
This PR updates all platforms to build and test against 6.4 instead of 6.3. We still test against main too.

Amazon Linux 2 workflows are removed as we no longer support Amazon Linux 2.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
