### PR TITLE
TaskLocal test trait

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -130,6 +130,7 @@ add_library(Testing
   Traits/Tags/Tag+Macro.swift
   Traits/Tags/Tag+Predefined.swift
   Traits/TimeLimitTrait.swift
+  Traits/TaskLocalTrait.swift
   Traits/Trait.swift)
 target_link_libraries(Testing PRIVATE
   _TestDiscovery

--- a/Sources/Testing/Testing.docc/Traits.md
+++ b/Sources/Testing/Testing.docc/Traits.md
@@ -69,4 +69,5 @@ types that customize the behavior of your tests.
 - ``ParallelizationTrait``
 - ``Tag``
 - ``Tag/List``
+- ``TaskLocalTrait``
 - ``TimeLimitTrait``

--- a/Sources/Testing/Testing.docc/Traits/Trait.md
+++ b/Sources/Testing/Testing.docc/Traits/Trait.md
@@ -42,3 +42,4 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 - ``Trait/scopeProvider(for:testCase:)-cjmg``
 - ``Trait/TestScopeProvider``
 - ``Trait/prepare(for:)-3s3zo``
+- ``Trait/taskLocal(_:withValue:)``

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -1,6 +1,20 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025–2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
 extension Trait {
-  /// Constructs a trait that overrides a task local value for the duration of a test
+  /// Constructs a trait that binds a task local value for the duration of a test
   /// or suite.
+  ///
+  /// - Parameters:
+  ///   - taskLocal: The task local to bind the value to.
+  ///   - value: The value to set.
   ///
   /// ```swift
   /// @Suite(.taskLocal($myValue, 42))
@@ -9,11 +23,7 @@ extension Trait {
   /// }
   /// ```
   ///
-  /// - Note: The task local must be defined outside the test target where the trait is used.
-  ///
-  /// - Parameters:
-  ///   - taskLocal: The task local to override.
-  ///   - value: The value to set.
+  /// - Note: You must define the task local outside the test target where the trait is used.
   public static func taskLocal<Value>(
     _ taskLocal: TaskLocal<Value>,
     _ value: Value
@@ -23,14 +33,15 @@ extension Trait {
   }
 }
 
-/// A type that that overrides a task local value for the scope of a test.
+/// A type that that binds a task local value for the duration of a test or suite.
 ///
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
 public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {
-  public var isRecursive: Bool { true }
+  /// This trait's task local.
+  fileprivate var taskLocal: TaskLocal<Value>
 
-  fileprivate let taskLocal: TaskLocal<Value>
-  fileprivate let value: Value
+  /// This trait's value.
+  fileprivate var value: Value
 
   public func provideScope(
     for test: Test,

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -24,7 +24,7 @@ extension Trait {
   /// ```
   ///
   /// - Note: You must define the task local outside the test target where the trait is used.
-  public static func taskLocal<Value>(
+  public static func taskLocal<Value: Sendable>(
     _ taskLocal: TaskLocal<Value>,
     _ value: Value
   ) -> Self
@@ -36,7 +36,7 @@ extension Trait {
 /// A type that that binds a task local value for the duration of a test or suite.
 ///
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
-public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {
+public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestTrait, TestScoping {
   /// This trait's task local.
   fileprivate var taskLocal: TaskLocal<Value>
 

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -14,14 +14,12 @@ extension Trait {
   ///
   /// - Parameters:
   ///   - taskLocal: The task local to bind the value to.
-  ///   - value: The value to set.
+  ///   - value: The value to bind to `taskLocal`.
   ///
-  /// ```swift
-  /// @Suite(.taskLocal($myValue, 42))
-  /// struct MyTests {
-  ///   // ...
-  /// }
-  /// ```
+  ///     This value will only be evaluated if the test this
+  ///     trait is applied to runs, and it will be unbound from
+  ///     the task local and released once the trait is finished
+  ///     providing scope for the test.
   ///
   /// - Note: You must define the task local outside the test target where the trait is used.
   public static func taskLocal<Value: Sendable>(

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -1,0 +1,42 @@
+extension Trait {
+  /// Constructs a trait that overrides a task local value for the duration of a test
+  /// or suite.
+  ///
+  /// ```swift
+  /// @Suite(.taskLocal($myValue, 42))
+  /// struct MyTests {
+  ///   // ...
+  /// }
+  /// ```
+  ///
+  /// - Note: The task local must be defined outside the test target where the trait is used.
+  ///
+  /// - Parameters:
+  ///   - taskLocal: The task local to override.
+  ///   - value: The value to set.
+  public static func taskLocal<Value>(
+    _ taskLocal: TaskLocal<Value>,
+    _ value: Value
+  ) -> Self
+  where Self == TaskLocalTrait<Value> {
+    TaskLocalTrait(taskLocal: taskLocal, value: value)
+  }
+}
+
+/// A type that that overrides a task local value for the scope of a test.
+///
+/// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
+public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {
+  public let isRecursive = true
+
+  fileprivate let taskLocal: TaskLocal<Value>
+  fileprivate let value: Value
+
+  public func provideScope(
+    for test: Test,
+    testCase: Test.Case?,
+    performing function: @concurrent () async throws -> Void
+  ) async throws {
+    try await taskLocal.withValue(value, operation: function)
+  }
+}

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -46,7 +46,7 @@ public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestTrait, TestScopin
   public func provideScope(
     for test: Test,
     testCase: Test.Case?,
-    performing function: @concurrent () async throws -> Void
+    performing function: @Sendable () async throws -> Void
   ) async throws {
     try await taskLocal.withValue(value()) {
       try await function()

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -27,7 +27,7 @@ extension Trait {
 ///
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
 public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrait {
-  public let isRecursive = true
+  public var isRecursive: Bool { true }
 
   fileprivate let taskLocal: TaskLocal<Value>
   fileprivate let value: Value

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2025–2026 Apple Inc. and the Swift project authors
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -51,3 +51,7 @@ public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestScoping, TestTrai
     try await taskLocal.withValue(value, operation: function)
   }
 }
+
+#if DEBUG
+  @TaskLocal var dummyLocal = false
+#endif

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -26,7 +26,7 @@ extension Trait {
   /// - Note: You must define the task local outside the test target where the trait is used.
   public static func taskLocal<Value: Sendable>(
     _ taskLocal: TaskLocal<Value>,
-    _ value: Value
+    _ value: @autoclosure @escaping @Sendable () throws -> Value
   ) -> Self
   where Self == TaskLocalTrait<Value> {
     TaskLocalTrait(taskLocal: taskLocal, value: value)
@@ -41,14 +41,14 @@ public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestTrait, TestScopin
   fileprivate var taskLocal: TaskLocal<Value>
 
   /// This trait's value.
-  fileprivate var value: Value
+  fileprivate var value: @Sendable () throws -> Value
 
   public func provideScope(
     for test: Test,
     testCase: Test.Case?,
     performing function: @concurrent () async throws -> Void
   ) async throws {
-    try await taskLocal.withValue(value, operation: function)
+    try await taskLocal.withValue(value(), operation: function)
   }
 }
 

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -43,15 +43,15 @@ public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestTrait, TestScopin
   /// This trait's value.
   fileprivate var value: @Sendable () throws -> Value
 
+  public var isRecursive: Bool { true }
+
   public func provideScope(
     for test: Test,
     testCase: Test.Case?,
     performing function: @concurrent () async throws -> Void
   ) async throws {
-    try await taskLocal.withValue(value(), operation: function)
+    try await taskLocal.withValue(value()) {
+      try await function()
+    }
   }
 }
-
-#if DEBUG
-  @TaskLocal var dummyLocal = false
-#endif

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -24,7 +24,7 @@ extension Trait {
   /// - Note: You must define the task local outside the test target where the trait is used.
   public static func taskLocal<Value: Sendable>(
     _ taskLocal: TaskLocal<Value>,
-    _ value: @autoclosure @escaping @Sendable () throws -> Value
+    withValue value: @autoclosure @escaping @Sendable () throws -> Value
   ) -> Self
   where Self == TaskLocalTrait<Value> {
     TaskLocalTrait(taskLocal: taskLocal, value: value)

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -8,9 +8,80 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+/// A type that that binds a task local value for the duration of a test or
+/// suite.
+///
+/// When an instance of this trait is applied to a suite, it is recursively
+/// inherited by all child suites and tests.
+///
+/// To add this trait to a test, use ``Trait/taskLocal(_:withValue:)``.
+///
+/// @Metadata {
+///   @Available(Swift, introduced: 6.5)
+/// }
+public struct TaskLocalTrait<Value>: SuiteTrait, TestTrait where Value: Sendable {
+  /// This trait's task local.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public var taskLocal: TaskLocal<Value>
+
+  /// A closure which returns a value this trait's task local will be bound to.
+  private var _value: @Sendable () throws -> Value
+
+  fileprivate init(taskLocal: TaskLocal<Value>, value: @escaping @Sendable () throws -> Value) {
+    self.taskLocal = taskLocal
+    self._value = value
+  }
+
+  /// Evaluate this trait's bound value.
+  ///
+  /// - Returns: The result of invoking the `value` closure passed to
+  ///   ``Trait/taskLocal(_:withValue:)``.
+  ///
+  /// - Throws: Whatever is thrown when invoking the `value` closure passed to
+  ///   ``Trait/taskLocal(_:withValue:)``.
+  ///
+  /// Each call to this function invokes the closure that was passed to
+  /// ``Trait/taskLocal(_:withValue:)``. The resulting value isn't cached or
+  /// stored by this trait, so repeated calls may produce different values or
+  /// cause side effects to occur more than once.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public func evaluate() async throws -> Value {
+    try _value()
+  }
+
+  public var isRecursive: Bool {
+    true
+  }
+}
+
+// MARK: - TestScoping
+
+/// @Metadata {
+///   @Available(Swift, introduced: 6.5)
+/// }
+extension TaskLocalTrait: TestScoping {
+  public func provideScope(
+    for test: Test,
+    testCase: Test.Case?,
+    performing function: @Sendable () async throws -> Void
+  ) async throws {
+    try await taskLocal.withValue(evaluate()) {
+      try await function()
+    }
+  }
+}
+
+// MARK: -
+
 extension Trait {
-  /// Constructs a trait that binds a task local value for the duration of a test
-  /// or suite.
+  /// Constructs a trait that binds a task local value for the duration of a
+  /// test or suite.
   ///
   /// - Parameters:
   ///   - taskLocal: The task local to bind the value to.
@@ -21,40 +92,16 @@ extension Trait {
   ///     the task local and released once the trait is finished
   ///     providing scope for the test.
   ///
-  /// - Note: You must define the task local outside the test target where the trait is used.
-  public static func taskLocal<Value: Sendable>(
+  /// - Note: You must define the task local outside the test target where the
+  ///   trait is used.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public static func taskLocal<Value>(
     _ taskLocal: TaskLocal<Value>,
     withValue value: @autoclosure @escaping @Sendable () throws -> Value
-  ) -> Self
-  where Self == TaskLocalTrait<Value> {
+  ) -> Self where Value: Sendable, Self == TaskLocalTrait<Value> {
     TaskLocalTrait(taskLocal: taskLocal, value: value)
-  }
-}
-
-/// A type that that binds a task local value for the duration of a test or suite.
-///
-/// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
-public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestTrait, TestScoping {
-  /// This trait's task local.
-  public var taskLocal: TaskLocal<Value>
-
-  /// This trait's value.
-  fileprivate var value: @Sendable () throws -> Value
-
-  /// Evaluate this trait's bound value.
-  public func evaluate() async throws -> Value {
-    try value()
-  }
-
-  public var isRecursive: Bool { true }
-
-  public func provideScope(
-    for test: Test,
-    testCase: Test.Case?,
-    performing function: @Sendable () async throws -> Void
-  ) async throws {
-    try await taskLocal.withValue(value()) {
-      try await function()
-    }
   }
 }

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -11,8 +11,9 @@
 /// A type that that binds a task local value for the duration of a test or
 /// suite.
 ///
-/// When an instance of this trait is applied to a suite, it is recursively
-/// inherited by all child suites and tests.
+/// When you apply an instance of this trait to a test suite, the testing
+/// library recursively applies it to all test suites and test functions within
+/// it.
 ///
 /// To add this trait to a test, use ``Trait/taskLocal(_:withValue:)``.
 ///
@@ -20,7 +21,7 @@
 ///   @Available(Swift, introduced: 6.5)
 /// }
 public struct TaskLocalTrait<Value>: SuiteTrait, TestTrait where Value: Sendable {
-  /// This trait's task local.
+  /// This trait's task-local value key.
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.5)
@@ -55,6 +56,9 @@ public struct TaskLocalTrait<Value>: SuiteTrait, TestTrait where Value: Sendable
     try _value()
   }
 
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
   public var isRecursive: Bool {
     true
   }
@@ -62,10 +66,10 @@ public struct TaskLocalTrait<Value>: SuiteTrait, TestTrait where Value: Sendable
 
 // MARK: - TestScoping
 
-/// @Metadata {
-///   @Available(Swift, introduced: 6.5)
-/// }
 extension TaskLocalTrait: TestScoping {
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
   public func provideScope(
     for test: Test,
     testCase: Test.Case?,
@@ -87,13 +91,12 @@ extension Trait {
   ///   - taskLocal: The task local to bind the value to.
   ///   - value: The value to bind to `taskLocal`.
   ///
-  ///     This value will only be evaluated if the test this
-  ///     trait is applied to runs, and it will be unbound from
-  ///     the task local and released once the trait is finished
-  ///     providing scope for the test.
+  ///     The testing library evaluates this value when the test this trait is
+  ///     applied to runs. The value is bound to `taskLocal`, the test runs, and
+  ///     then the value is unbound.
   ///
-  /// - Note: You must define the task local outside the test target where the
-  ///   trait is used.
+  /// - Note: You must define the task local outside the module where you use
+  ///   this trait.
   ///
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.5)
@@ -101,7 +104,7 @@ extension Trait {
   public static func taskLocal<Value>(
     _ taskLocal: TaskLocal<Value>,
     withValue value: @autoclosure @escaping @Sendable () throws -> Value
-  ) -> Self where Value: Sendable, Self == TaskLocalTrait<Value> {
+  ) -> Self where Self == TaskLocalTrait<Value> {
     TaskLocalTrait(taskLocal: taskLocal, value: value)
   }
 }

--- a/Sources/Testing/Traits/TaskLocalTrait.swift
+++ b/Sources/Testing/Traits/TaskLocalTrait.swift
@@ -36,10 +36,15 @@ extension Trait {
 /// To add this trait to a test, use ``Trait/taskLocal(_:_:)``.
 public struct TaskLocalTrait<Value: Sendable>: SuiteTrait, TestTrait, TestScoping {
   /// This trait's task local.
-  fileprivate var taskLocal: TaskLocal<Value>
+  public var taskLocal: TaskLocal<Value>
 
   /// This trait's value.
   fileprivate var value: @Sendable () throws -> Value
+
+  /// Evaluate this trait's bound value.
+  public func evaluate() async throws -> Value {
+    try value()
+  }
 
   public var isRecursive: Bool { true }
 

--- a/Tests/TestingTests/Traits/TaskLocalTraitTests.swift
+++ b/Tests/TestingTests/Traits/TaskLocalTraitTests.swift
@@ -1,0 +1,22 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+@Suite("Task Local Tests", .tags(.traitRelated))
+struct TaskLocalTests {
+  @Test(
+    ".taskLocal trait",
+    .taskLocal($dummyLocal, true)
+  )
+  func taskLocalBinding() throws {
+    #expect(dummyLocal == true)
+  }
+}

--- a/Tests/TestingTests/Traits/TaskLocalTraitTests.swift
+++ b/Tests/TestingTests/Traits/TaskLocalTraitTests.swift
@@ -14,9 +14,28 @@
 struct TaskLocalTests {
   @Test(
     ".taskLocal trait",
-    .taskLocal($dummyLocal, true)
+    .taskLocal(local, true)
   )
   func taskLocalBinding() throws {
-    #expect(dummyLocal == true)
+    #expect(local.wrappedValue == true)
+  }
+
+  @Suite(.serialized, .taskLocal(stateLocal, State())) struct MutableLocal {
+    @Test func run1() {
+      #expect(stateLocal.wrappedValue.count == 0)
+      stateLocal.wrappedValue.count += 1
+      #expect(stateLocal.wrappedValue.count == 1)
+    }
+    @Test func run2() {
+      #expect(stateLocal.wrappedValue.count == 0)
+      stateLocal.wrappedValue.count += 1
+      #expect(stateLocal.wrappedValue.count == 1)
+    }
   }
 }
+
+private let local = TaskLocal(wrappedValue: false)
+private class State: @unchecked Sendable {
+  var count = 0
+}
+private let stateLocal = TaskLocal(wrappedValue: State())

--- a/Tests/TestingTests/Traits/TaskLocalTraitTests.swift
+++ b/Tests/TestingTests/Traits/TaskLocalTraitTests.swift
@@ -14,13 +14,13 @@
 struct TaskLocalTests {
   @Test(
     ".taskLocal trait",
-    .taskLocal(local, true)
+    .taskLocal(local, withValue: true)
   )
   func taskLocalBinding() throws {
     #expect(local.wrappedValue == true)
   }
 
-  @Suite(.serialized, .taskLocal(stateLocal, State())) struct MutableLocal {
+  @Suite(.serialized, .taskLocal(stateLocal, withValue: State())) struct MutableLocal {
     @Test func run1() {
       #expect(stateLocal.wrappedValue.count == 0)
       stateLocal.wrappedValue.count += 1

--- a/Tests/TestingTests/Traits/TaskLocalTraitTests.swift
+++ b/Tests/TestingTests/Traits/TaskLocalTraitTests.swift
@@ -10,17 +10,15 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-@Suite("Task Local Tests", .tags(.traitRelated))
-struct TaskLocalTests {
-  @Test(
-    ".taskLocal trait",
-    .taskLocal(local, withValue: true)
-  )
-  func taskLocalBinding() throws {
+@Suite(.tags(.traitRelated))
+struct `TaskLocalTrait tests` {
+  @Test(.taskLocal(local, withValue: true))
+  func `.taskLocal trait`() throws {
     #expect(local.wrappedValue == true)
   }
 
-  @Suite(.serialized, .taskLocal(stateLocal, withValue: State())) struct MutableLocal {
+  @Suite(.serialized, .taskLocal(stateLocal, withValue: State()))
+  struct `Mutable task local values` {
     @Test func run1() {
       #expect(stateLocal.wrappedValue.count == 0)
       stateLocal.wrappedValue.count += 1
@@ -32,10 +30,21 @@ struct TaskLocalTests {
       #expect(stateLocal.wrappedValue.count == 1)
     }
   }
+
+  @Test func `evaluate()`() async throws {
+    let trait = TaskLocalTrait.taskLocal(stateLocal, withValue: State(count: 99))
+    let state = try await trait.evaluate()
+    #expect(state.count == 99)
+  }
 }
+
+// MARK: - Fixtures
 
 private let local = TaskLocal(wrappedValue: false)
 private class State: @unchecked Sendable {
-  var count = 0
+  var count: Int
+  init(count: Int = 0) {
+    self.count = count
+  }
 }
 private let stateLocal = TaskLocal(wrappedValue: State())


### PR DESCRIPTION
Adds a `.taskLocal` test trait for overriding task locals in tests

Resolves rdar://140371736

### Motivation:

Proposal here: [ST-0026: TaskLocal test trait](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0026-task-local-test-trait.md)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
