### PR TITLE
Revert "[6.4.x] Adopt `objc_copyImageHeaders()` for safer image discovery on Darwin (#1762)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -405,7 +405,6 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("AvailabilityMacro=_typedThrowsAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"),
       .enableExperimentalFeature("AvailabilityMacro=_transferableAPI:macOS 15.2, iOS 18.2, watchOS 11.2, tvOS 18.2, visionOS 2.2"),
       .enableExperimentalFeature("AvailabilityMacro=_castingWithNonCopyableGenerics:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"),
-      .enableExperimentalFeature("AvailabilityMacro=_objcCopyImageHeadersAPI:macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0"),
 
       .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0"),
     ]

--- a/Sources/_TestDiscovery/SectionBounds.swift
+++ b/Sources/_TestDiscovery/SectionBounds.swift
@@ -69,40 +69,6 @@ extension SectionBounds.Kind {
   }
 }
 
-/// Find the section bounds of the given kind in the given Mach header.
-///
-/// - Parameters:
-///   - kind: Which kind of metadata section to find.
-///   - mh: The Mach header of the image to inspect.
-///
-/// - Returns: A new instance of ``SectionBounds`` for the given inputs, or
-///   `nil` if one is not present.
-private func _findSectionBounds(_ kind: SectionBounds.Kind, in mh: UnsafePointer<mach_header>) -> SectionBounds? {
-#if _pointerBitWidth(_64)
-  let mh = UnsafeRawPointer(mh).assumingMemoryBound(to: mach_header_64.self)
-#endif
-
-  // Ignore this Mach header if it is in the shared cache. On platforms that
-  // support it (Darwin), most system images are contained in this range.
-  // System images can be expected not to contain test declarations, so we
-  // don't need to walk them.
-  guard 0 == mh.pointee.flags & MH_DYLIB_IN_CACHE else {
-    return nil
-  }
-
-  // If this image contains the Swift section(s) we need, construct the
-  // resulting value.
-  let (segmentName, sectionName) = kind.segmentAndSectionName
-  var size = CUnsignedLong(0)
-  guard let start = getsectiondata(mh, segmentName.utf8Start, sectionName.utf8Start, &size), size > 0 else {
-    return nil
-  }
-
-  let buffer = UnsafeRawBufferPointer(start: start, count: Int(clamping: size))
-  return SectionBounds(imageAddress: mh, buffer: buffer)
-}
-
-#if _runtime(_ObjC)
 /// An array containing all of the test content section bounds known to the
 /// testing library.
 ///
@@ -139,8 +105,26 @@ private let _startCollectingSectionBounds: Void = {
   _ = _sectionBounds
 
   func addSectionBounds(from mh: UnsafePointer<mach_header>) {
+#if _pointerBitWidth(_64)
+    let mh = UnsafeRawPointer(mh).assumingMemoryBound(to: mach_header_64.self)
+#endif
+
+    // Ignore this Mach header if it is in the shared cache. On platforms that
+    // support it (Darwin), most system images are contained in this range.
+    // System images can be expected not to contain test declarations, so we
+    // don't need to walk them.
+    guard 0 == mh.pointee.flags & MH_DYLIB_IN_CACHE else {
+      return
+    }
+
+    // If this image contains the Swift section(s) we need, acquire the lock and
+    // store the section's bounds.
     for kind in SectionBounds.Kind.allCases {
-      if let sb = _findSectionBounds(kind, in: mh) {
+      let (segmentName, sectionName) = kind.segmentAndSectionName
+      var size = CUnsignedLong(0)
+      if let start = getsectiondata(mh, segmentName.utf8Start, sectionName.utf8Start, &size), size > 0 {
+        let buffer = UnsafeRawBufferPointer(start: start, count: Int(clamping: size))
+        let sb = SectionBounds(imageAddress: mh, buffer: buffer)
         _sectionBounds.withUnsafeMutablePointers { sectionBounds, lock in
           pthread_mutex_lock(lock)
           defer {
@@ -152,11 +136,16 @@ private let _startCollectingSectionBounds: Void = {
     }
   }
 
+#if _runtime(_ObjC)
   objc_addLoadImageFunc { mh in
     addSectionBounds(from: mh)
   }
-}()
+#else
+  _dyld_register_func_for_add_image { mh, _ in
+    addSectionBounds(from: mh!)
+  }
 #endif
+}()
 
 /// The Apple-specific implementation of ``SectionBounds/all(_:)``.
 ///
@@ -166,17 +155,6 @@ private let _startCollectingSectionBounds: Void = {
 /// - Returns: An array of structures describing the bounds of all known test
 ///   content sections in the current process.
 private func _sectionBounds(_ kind: SectionBounds.Kind) -> some RandomAccessCollection<SectionBounds> {
-#if _runtime(_ObjC)
-  if #available(_objcCopyImageHeadersAPI, *) {
-    var imageCount = UInt32(0)
-    let imageHeaders = swt_objc_copyImageHeaders(&imageCount)
-    defer {
-      free(imageHeaders)
-    }
-    return UnsafeBufferPointer(start: imageHeaders, count: Int(clamping: imageCount))
-      .compactMap { _findSectionBounds(kind, in: $0) }
-  }
-
   _startCollectingSectionBounds
   return _sectionBounds.withUnsafeMutablePointers { sectionBounds, lock in
     pthread_mutex_lock(lock)
@@ -185,12 +163,6 @@ private func _sectionBounds(_ kind: SectionBounds.Kind) -> some RandomAccessColl
     }
     return sectionBounds.pointee[kind.rawValue]
   }
-#else
-  let imageCount = _dyld_image_count()
-  return (0 ..< imageCount)
-    .compactMap(_dyld_get_image_header)
-    .compactMap { _findSectionBounds(kind, in: $0) }
-#endif
 }
 
 #elseif (os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)) && !SWT_NO_DYNAMIC_LINKING

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -84,22 +84,6 @@ static mach_port_t swt_mach_task_self(void) {
 }
 #endif
 
-#if defined(__APPLE__) && defined(__OBJC2__) && !SWT_NO_DYNAMIC_LINKING
-/// Get an array of Mach headers that are loaded into the current process and
-/// contain Objective-C or Swift code.
-///
-/// This function is provided because the testing library still needs to
-/// build with older Apple SDKs that do not contain a declaration of the runtime
-/// `objc_copyImageHeaders()` function.
-///
-/// - Bug: This declaration should be removed once Apple has shipped an updated
-///   SDK that includes `objc_copyImageHeaders()`.
-static struct mach_header const *_Nonnull *_Nullable swt_objc_copyImageHeaders(unsigned int *_Nullable outCount) {
-  __auto_type objc_copyImageHeaders = (__typeof__(&swt_objc_copyImageHeaders))dlsym(RTLD_DEFAULT, "objc_copyImageHeaders");
-  return (* objc_copyImageHeaders)(outCount);
-}
-#endif
-
 #if defined(__APPLE__)
 /// Define the minimal set of atomic operations supported and used by the
 /// testing library for a given C type.

--- a/cmake/modules/shared/AvailabilityDefinitions.cmake
+++ b/cmake/modules/shared/AvailabilityDefinitions.cmake
@@ -15,5 +15,4 @@ add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_typedThrowsAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_transferableAPI:macOS 15.2, iOS 18.2, watchOS 11.2, tvOS 18.2, visionOS 2.2\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_castingWithNonCopyableGenerics:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0\">"
-  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_objcCopyImageHeadersAPI:macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0\">")


### PR DESCRIPTION
This reverts commit 6ea1964a358beff469ee955e2d82602107d39828.

I think we should get this in quickly as it is likely blocking 6.4 pulls on the compiler validation CI. We can take our time with trunk if wanted.

See #1766 and #1767 for more info.