### PR TITLE
Adopt `objc_copyImageHeaders()` for safer image discovery on Darwin (take 3)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -405,6 +405,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       .enableExperimentalFeature("AvailabilityMacro=_typedThrowsAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"),
       .enableExperimentalFeature("AvailabilityMacro=_transferableAPI:macOS 15.2, iOS 18.2, watchOS 11.2, tvOS 18.2, visionOS 2.2"),
       .enableExperimentalFeature("AvailabilityMacro=_castingWithNonCopyableGenerics:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"),
+      .enableExperimentalFeature("AvailabilityMacro=_objcCopyImageHeadersAPI:macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0"),
 
       .enableExperimentalFeature("AvailabilityMacro=_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0"),
     ]

--- a/Sources/_TestDiscovery/SectionBounds.swift
+++ b/Sources/_TestDiscovery/SectionBounds.swift
@@ -93,66 +93,6 @@ private func _findSectionBounds(_ kind: SectionBounds.Kind, in mh: UnsafePointer
   return SectionBounds(imageAddress: mh, buffer: buffer)
 }
 
-/// An array containing all of the test content section bounds known to the
-/// testing library.
-///
-/// Indices into this array are equivalent to the `rawValue` values of instances
-/// of ``SectionBounds/Kind``.
-private nonisolated(unsafe) let _sectionBounds = {
-  // We generate a contiguous array here rather than a dictionary because the
-  // former has less overall bridging with the Objective-C runtime (reducing the
-  // risk of reentrance while holding the libobjc lock) and because the set of
-  // keys or indices is closed, so an array lookup is always more efficient than
-  // a hashtable lookup.
-  let kindCount = SectionBounds.Kind.allCases.count
-  let result = ManagedBuffer<ContiguousArray<ContiguousArray<SectionBounds>>, pthread_mutex_t>.create(
-    minimumCapacity: 1,
-    makingHeaderWith: { _ in .init(repeating: [], count: kindCount) }
-  )
-
-  result.withUnsafeMutablePointers { sectionBounds, lock in
-    _ = pthread_mutex_init(lock, nil)
-
-    let imageCount = Int(clamping: _dyld_image_count())
-    for kind in SectionBounds.Kind.allCases {
-      sectionBounds.pointee[kind.rawValue].reserveCapacity(imageCount)
-    }
-  }
-
-  return result
-}()
-
-/// A call-once function that initializes `_sectionBounds` and starts listening
-/// for loaded Mach headers.
-private let _startCollectingSectionBounds: Void = {
-  // Ensure _sectionBounds is initialized before we touch libobjc or dyld.
-  _ = _sectionBounds
-
-  func addSectionBounds(from mh: UnsafePointer<mach_header>) {
-    for kind in SectionBounds.Kind.allCases {
-      if let sb = _findSectionBounds(kind, in: mh) {
-        _sectionBounds.withUnsafeMutablePointers { sectionBounds, lock in
-          pthread_mutex_lock(lock)
-          defer {
-            pthread_mutex_unlock(lock)
-          }
-          sectionBounds.pointee[kind.rawValue].append(sb)
-        }
-      }
-    }
-  }
-
-#if _runtime(_ObjC)
-  objc_addLoadImageFunc { mh in
-    addSectionBounds(from: mh)
-  }
-#else
-  _dyld_register_func_for_add_image { mh, _ in
-    addSectionBounds(from: mh)
-  }
-#endif
-}()
-
 /// The Apple-specific implementation of ``SectionBounds/all(_:)``.
 ///
 /// - Parameters:
@@ -160,7 +100,7 @@ private let _startCollectingSectionBounds: Void = {
 ///
 /// - Returns: An array of structures describing the bounds of all known test
 ///   content sections in the current process.
-private func _sectionBounds(_ kind: SectionBounds.Kind) -> ContiguousArray<SectionBounds> {
+private func _sectionBounds(_ kind: SectionBounds.Kind) -> [SectionBounds] {
 #if _runtime(_ObjC)
   if #available(_objcCopyImageHeadersAPI, *) {
     var imageCount = UInt32(0)
@@ -168,21 +108,47 @@ private func _sectionBounds(_ kind: SectionBounds.Kind) -> ContiguousArray<Secti
       defer {
         free(imageHeaders)
       }
-      let sectionBounds = UnsafeBufferPointer(start: imageHeaders, count: Int(clamping: imageCount))
+      return UnsafeBufferPointer(start: imageHeaders, count: Int(clamping: imageCount))
         .compactMap { _findSectionBounds(kind, in: $0) }
-      return ContiguousArray(sectionBounds)
     }
+  }
+
+  var imageCount = UInt32(0)
+  if let imageNames = swt_objc_copyImageNames(&imageCount) {
+    defer {
+      free(imageNames)
+    }
+    return UnsafeBufferPointer(start: imageNames, count: Int(clamping: imageCount))
+      .compactMap { imageName in
+        guard let handle = dlopen(imageName, RTLD_NOLOAD | RTLD_LAZY) else {
+          return nil
+        }
+        defer {
+          dlclose(handle)
+        }
+        guard let mh = _dyld_get_dlopen_image_header(handle) else {
+          return nil
+        }
+        return _findSectionBounds(kind, in: mh)
+      }
   }
 #endif
 
-  _startCollectingSectionBounds
-  return _sectionBounds.withUnsafeMutablePointers { sectionBounds, lock in
-    pthread_mutex_lock(lock)
-    defer {
-      pthread_mutex_unlock(lock)
-    }
-    return sectionBounds.pointee[kind.rawValue]
-  }
+  // Fall back to a linear walk of all loaded images known to dyld using an
+  // older, thread-unsafe API.
+  //
+  // There is an inherent race condition here because an image might be loaded
+  // or unloaded on another thread while we're running this loop (hence using
+  // Objective-C API whenever possible).
+  //
+  // Unloading images is uncommon on Darwin in the first place. In a typical
+  // test process, this code will run after the initial image load operation and
+  // before any significant third-party code starts to run, so we should be in a
+  // period of dyld quiesence and should not encounter any unloaded images
+  // unless we're very unlucky.
+  return (0 ..< _dyld_image_count())
+    .compactMap(_dyld_get_image_header)
+    .compactMap { _findSectionBounds(kind, in: $0) }
 }
 
 #elseif objectFormat(ELF) && !SWT_NO_DYNAMIC_LINKING

--- a/Sources/_TestDiscovery/SectionBounds.swift
+++ b/Sources/_TestDiscovery/SectionBounds.swift
@@ -60,6 +60,39 @@ extension SectionBounds.Kind {
   }
 }
 
+/// Find the section bounds of the given kind in the given Mach header.
+///
+/// - Parameters:
+///   - kind: Which kind of metadata section to find.
+///   - mh: The Mach header of the image to inspect.
+///
+/// - Returns: A new instance of ``SectionBounds`` for the given inputs, or
+///   `nil` if one is not present.
+private func _findSectionBounds(_ kind: SectionBounds.Kind, in mh: UnsafePointer<mach_header>) -> SectionBounds? {
+#if _pointerBitWidth(_64)
+  let mh = UnsafeRawPointer(mh).assumingMemoryBound(to: mach_header_64.self)
+#endif
+
+  // Ignore this Mach header if it is in the shared cache. On platforms that
+  // support it (Darwin), most system images are contained in this range.
+  // System images can be expected not to contain test declarations, so we
+  // don't need to walk them.
+  guard 0 == mh.pointee.flags & MH_DYLIB_IN_CACHE else {
+    return nil
+  }
+
+  // If this image contains the Swift section(s) we need, construct the
+  // resulting value.
+  let (segmentName, sectionName) = kind.segmentAndSectionName
+  var size = CUnsignedLong(0)
+  guard let start = getsectiondata(mh, segmentName.utf8Start, sectionName.utf8Start, &size), size > 0 else {
+    return nil
+  }
+
+  let buffer = UnsafeRawBufferPointer(start: start, count: Int(clamping: size))
+  return SectionBounds(imageAddress: mh, buffer: buffer)
+}
+
 /// An array containing all of the test content section bounds known to the
 /// testing library.
 ///
@@ -96,26 +129,8 @@ private let _startCollectingSectionBounds: Void = {
   _ = _sectionBounds
 
   func addSectionBounds(from mh: UnsafePointer<mach_header>) {
-#if _pointerBitWidth(_64)
-    let mh = UnsafeRawPointer(mh).assumingMemoryBound(to: mach_header_64.self)
-#endif
-
-    // Ignore this Mach header if it is in the shared cache. On platforms that
-    // support it (Darwin), most system images are contained in this range.
-    // System images can be expected not to contain test declarations, so we
-    // don't need to walk them.
-    guard 0 == mh.pointee.flags & MH_DYLIB_IN_CACHE else {
-      return
-    }
-
-    // If this image contains the Swift section(s) we need, acquire the lock and
-    // store the section's bounds.
     for kind in SectionBounds.Kind.allCases {
-      let (segmentName, sectionName) = kind.segmentAndSectionName
-      var size = CUnsignedLong(0)
-      if let start = getsectiondata(mh, segmentName.utf8Start, sectionName.utf8Start, &size), size > 0 {
-        let buffer = UnsafeRawBufferPointer(start: start, count: Int(clamping: size))
-        let sb = SectionBounds(imageAddress: mh, buffer: buffer)
+      if let sb = _findSectionBounds(kind, in: mh) {
         _sectionBounds.withUnsafeMutablePointers { sectionBounds, lock in
           pthread_mutex_lock(lock)
           defer {
@@ -133,7 +148,7 @@ private let _startCollectingSectionBounds: Void = {
   }
 #else
   _dyld_register_func_for_add_image { mh, _ in
-    addSectionBounds(from: mh!)
+    addSectionBounds(from: mh)
   }
 #endif
 }()
@@ -145,7 +160,21 @@ private let _startCollectingSectionBounds: Void = {
 ///
 /// - Returns: An array of structures describing the bounds of all known test
 ///   content sections in the current process.
-private func _sectionBounds(_ kind: SectionBounds.Kind) -> some RandomAccessCollection<SectionBounds> {
+private func _sectionBounds(_ kind: SectionBounds.Kind) -> ContiguousArray<SectionBounds> {
+#if _runtime(_ObjC)
+  if #available(_objcCopyImageHeadersAPI, *) {
+    var imageCount = UInt32(0)
+    if let imageHeaders = swt_objc_copyImageHeaders(&imageCount) {
+      defer {
+        free(imageHeaders)
+      }
+      let sectionBounds = UnsafeBufferPointer(start: imageHeaders, count: Int(clamping: imageCount))
+        .compactMap { _findSectionBounds(kind, in: $0) }
+      return ContiguousArray(sectionBounds)
+    }
+  }
+#endif
+
   _startCollectingSectionBounds
   return _sectionBounds.withUnsafeMutablePointers { sectionBounds, lock in
     pthread_mutex_lock(lock)

--- a/Sources/_TestingInternals/include/Includes.h
+++ b/Sources/_TestingInternals/include/Includes.h
@@ -150,6 +150,10 @@
 #if !SWT_NO_FILE_CLONING
 #include <sys/clonefile.h>
 #endif
+
+#if defined(__OBJC2__)
+#include <objc/runtime.h>
+#endif
 #endif
 
 #if defined(__linux__)

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -95,12 +95,46 @@ static mach_port_t swt_mach_task_self(void) {
 /// - Bug: This declaration should be removed once Apple has shipped an updated
 ///   SDK that includes `objc_copyImageHeaders()`.
 static struct mach_header const *_Nonnull *_Nullable swt_objc_copyImageHeaders(unsigned int *_Nullable outCount) {
-  __auto_type objc_copyImageHeaders = (__typeof__(&swt_objc_copyImageHeaders))dlsym(RTLD_DEFAULT, "objc_copyImageHeaders");
-  if (objc_copyImageHeaders) {
-    return (* objc_copyImageHeaders)(outCount);
+  if (__builtin_available(anyAppleOS 27.0, *)) {
+    __auto_type objc_copyImageHeaders = (__typeof__(&swt_objc_copyImageHeaders))dlsym(RTLD_DEFAULT, "objc_copyImageHeaders");
+    if (objc_copyImageHeaders) {
+      return (* objc_copyImageHeaders)(outCount);
+    }
   }
   return 0;
 }
+
+/// Get an array of the names of Mach images that are loaded into the current
+/// process and contain Objective-C or Swift code.
+///
+/// This function is provided because `objc_copyImageNames()` is unreliable when
+/// TSAN or XOJIT is enabled in the current process:
+///
+///   - If TSAN is enabled, calling `dlclose()` in a loop becomes a quadratic
+///     operation.
+///   - If XOJIT is enabled, it inserts multiple images into the dyld image list
+///     with the same name, so we cannot call `dlopen()` for all loaded images.
+static const char *_Nonnull *_Nullable swt_objc_copyImageNames(unsigned int *_Nullable outCount) {
+  if (dlsym(RTLD_DEFAULT, "__tsan_acquire") != 0) {
+    // TSAN appears to be enabled.
+    return 0;
+  }
+
+  if (getenv("XCODE_RUNNING_FOR_PLAYGROUNDS") != 0) {
+    // XOJIT appears to be enabled.
+    return 0;
+  }
+
+  return objc_copyImageNames(outCount);
+}
+
+/// Get the Mach header corresponding to the given `dlopen()` handle.
+///
+/// This declaration is provided because the function is only _declared_ in the
+/// anyAppleOS 27 SDKs and newer, but is _exported_ in all anyAppleOS releases
+/// we support.
+SWT_IMPORT_FROM_STDLIB const struct mach_header *_Nullable _dyld_get_dlopen_image_header(void *handle)
+__API_AVAILABLE(macos(13.0), ios(16.0), watchos(9.0), tvos(16.0));
 #endif
 
 #if defined(__APPLE__)

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -95,11 +95,9 @@ static mach_port_t swt_mach_task_self(void) {
 /// - Bug: This declaration should be removed once Apple has shipped an updated
 ///   SDK that includes `objc_copyImageHeaders()`.
 static struct mach_header const *_Nonnull *_Nullable swt_objc_copyImageHeaders(unsigned int *_Nullable outCount) {
-  if (__builtin_available(anyAppleOS 27.0, *)) {
-    __auto_type objc_copyImageHeaders = (__typeof__(&swt_objc_copyImageHeaders))dlsym(RTLD_DEFAULT, "objc_copyImageHeaders");
-    if (objc_copyImageHeaders) {
-      return (* objc_copyImageHeaders)(outCount);
-    }
+  __auto_type objc_copyImageHeaders = (__typeof__(&swt_objc_copyImageHeaders))dlsym(RTLD_DEFAULT, "objc_copyImageHeaders");
+  if (objc_copyImageHeaders) {
+    return (* objc_copyImageHeaders)(outCount);
   }
   return 0;
 }

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -84,6 +84,25 @@ static mach_port_t swt_mach_task_self(void) {
 }
 #endif
 
+#if defined(__APPLE__) && defined(__OBJC2__) && !SWT_NO_DYNAMIC_LINKING
+/// Get an array of Mach headers that are loaded into the current process and
+/// contain Objective-C or Swift code.
+///
+/// This function is provided because the testing library still needs to
+/// build with older Apple SDKs that do not contain a declaration of the runtime
+/// `objc_copyImageHeaders()` function.
+///
+/// - Bug: This declaration should be removed once Apple has shipped an updated
+///   SDK that includes `objc_copyImageHeaders()`.
+static struct mach_header const *_Nonnull *_Nullable swt_objc_copyImageHeaders(unsigned int *_Nullable outCount) {
+  __auto_type objc_copyImageHeaders = (__typeof__(&swt_objc_copyImageHeaders))dlsym(RTLD_DEFAULT, "objc_copyImageHeaders");
+  if (objc_copyImageHeaders) {
+    return (* objc_copyImageHeaders)(outCount);
+  }
+  return 0;
+}
+#endif
+
 #if defined(__APPLE__)
 /// Define the minimal set of atomic operations supported and used by the
 /// testing library for a given C type.

--- a/cmake/modules/shared/AvailabilityDefinitions.cmake
+++ b/cmake/modules/shared/AvailabilityDefinitions.cmake
@@ -15,4 +15,5 @@ add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_typedThrowsAPI:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_transferableAPI:macOS 15.2, iOS 18.2, watchOS 11.2, tvOS 18.2, visionOS 2.2\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_castingWithNonCopyableGenerics:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0\">"
+  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_objcCopyImageHeadersAPI:macOS 27.0, iOS 27.0, watchOS 27.0, tvOS 27.0, visionOS 27.0\">"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -define-availability -Xfrontend \"_distantFuture:macOS 99.0, iOS 99.0, watchOS 99.0, tvOS 99.0, visionOS 99.0\">")


### PR DESCRIPTION
macOS/iOS/etc. 27 introduce new API in libobjc called `objc_copyImageHeaders()` that can be used to gather all Mach headers for loaded images containing ObjC or Swift code. This API is safer than our current code because it does not need to acquire or hold a global lock while also holding the libobjc lock (which is touched frequently/indirectly by the Swift runtime).

`objc_copyImageHeaders()` is forward-declared as CI doesn't have new-enough SDKs yet.

We must maintain code paths for earlier Apple OSes as well as Apple configurations that disable Objective-C interop. For earlier Apple OSes, we use a circuitous path through `objc_copyImageNames()` and `dlopen()`. For no-Objective-C configurations, which are not customer-facing, dyld has lower-level API we can call.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
