### PR TITLE
Small doc wording change modes + cross-library issues from Swift Testing

### DIFF
--- a/Sources/Testing/Testing.docc/MigratingFromXCTest.md
+++ b/Sources/Testing/Testing.docc/MigratingFromXCTest.md
@@ -116,7 +116,7 @@ To explicitly choose an interoperability mode, set the
 `SWIFT_TESTING_XCTEST_INTEROP_MODE` environment variable to the name of the mode
 before running tests.
 
-As long as you don't set the interoperability mode to `none`, cross-library
+In the `limited`, `complete`, and `strict` interoperability modes, cross-library
 issues from Swift Testing maintain their original severity. So, in the following
 example, the test failure message is `❌ "Interop failure"` -- except when the
 interoperability mode is `none`, then there is no test failure message.


### PR DESCRIPTION
### Motivation:

Replace negative sentence structure ("when you don't do x then y") with a positive structure that's easier to understand.

### Modifications:

Small patch for the MigratingFromXCTest documentation.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.