### PR TITLE
Resolve per-test actions concurrently during plan construction

### DIFF
--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -406,19 +406,11 @@ extension Runner.Plan {
     _recursivelyReduceTraits(in: &testGraph)
 #endif
 
-    // For each test value, determine the appropriate action for it.
-    testGraph = await testGraph.mapValues { keyPath, test in
-      // Skip any nil test, which implies this node is just a placeholder and
-      // not actual test content.
-      guard var test else {
-        return nil
-      }
-
-      // Walk all the traits and tell each to prepare to run the test.
-      // If any throw a `SkipInfo` error at this stage, stop walking further.
-      // But if any throw another kind of error, keep track of the first error
-      // but continue walking, because if any subsequent traits throw a
-      // `SkipInfo`, the error should not be recorded.
+    // Resolve a single test's action by preparing its traits and evaluating its
+    // test cases. Factored into a closure because it runs concurrently below, so
+    // it must not touch the shared `actionGraph`.
+    let resolveAction: @Sendable (Test) async -> (test: Test, action: Action) = { test in
+      var test = test
       var action = await _determineAction(for: &test)
 
       // If the test is parameterized but has no cases, mark it as skipped.
@@ -426,9 +418,48 @@ extension Runner.Plan {
         action = .skip(SkipInfo(comment: "No test cases found.", sourceContext: .init(backtrace: nil, sourceLocation: test.sourceLocation)))
       }
 
-      actionGraph.updateValue(action, at: keyPath)
+      return (test, action)
+    }
 
-      return test
+    // Gather the non-placeholder tests paired with their key paths.
+    var keyPathsAndTests = [(keyPath: [String], test: Test)]()
+    testGraph.forEach { keyPath, test in
+      if let test {
+        keyPathsAndTests.append((keyPath, test))
+      }
+    }
+
+    // Resolving each test's action is independent, so run it concurrently. This is
+    // planning work that runs once before any test, so it honors `--no-parallel`
+    // but is not throttled by `maximumParallelizationWidth` (which bounds how many
+    // test *cases* run at once). Actions are collected, then applied serially below.
+    var resolvedTests = [[String]: (test: Test, action: Action)](minimumCapacity: keyPathsAndTests.count)
+    if configuration.isParallelizationEnabled {
+      resolvedTests = await withTaskGroup(of: (keyPath: [String], resolved: (test: Test, action: Action)).self) { taskGroup in
+        for (keyPath, test) in keyPathsAndTests {
+          taskGroup.addTask {
+            (keyPath: keyPath, resolved: await resolveAction(test))
+          }
+        }
+        var resolvedTests = [[String]: (test: Test, action: Action)](minimumCapacity: keyPathsAndTests.count)
+        for await (keyPath, resolved) in taskGroup {
+          resolvedTests[keyPath] = resolved
+        }
+        return resolvedTests
+      }
+    } else {
+      // Parallelization is disabled (e.g. `--no-parallel`): resolve serially.
+      for (keyPath, test) in keyPathsAndTests {
+        resolvedTests[keyPath] = await resolveAction(test)
+      }
+    }
+
+    // Apply the resolved tests and their actions back into the graphs.
+    testGraph = testGraph.mapValues { keyPath, test in
+      test != nil ? (resolvedTests[keyPath]?.test ?? test) : nil
+    }
+    for (keyPath, resolved) in resolvedTests {
+      actionGraph.updateValue(resolved.action, at: keyPath)
     }
 
     // Now that we have allowed all the traits to update their corresponding

--- a/Tests/TestingTests/TestCancellationTests.swift
+++ b/Tests/TestingTests/TestCancellationTests.swift
@@ -125,6 +125,25 @@
     }
   }
 
+  @Test func `Cancelling one test while evaluating traits does not affect sibling tests`() async {
+    // Plan construction now resolves each test's action concurrently, so a test
+    // cancelling itself in a trait's `prepare(for:)` must not leak cancellation to
+    // the others being resolved at the same time.
+    await testCancellation(testSkipped: 1, issueRecorded: 7) { configuration in
+      var configuration = configuration
+      configuration.isParallelizationEnabled = true
+      var tests = [Test(CancelledTrait(), name: "Canceller") {
+        Issue.record("Cancelled test's body should not run")
+      }]
+      for i in 0 ..< 7 {
+        tests.append(Test(name: "Sibling\(i)") {
+          Issue.record("Sibling \(i) ran")
+        })
+      }
+      await Runner(testing: tests, configuration: configuration).run()
+    }
+  }
+
   @Test func `Cancelling the current task while evaluating traits skips the test`() async {
     await testCancellation(testSkipped: 1) { configuration in
       await Test(CancelledTrait(cancelsTask: true)) {


### PR DESCRIPTION
## Motivation

Test execution is already parallel, but plan construction isn't: `_constructStepGraph` resolves each test's action — running its traits' `prepare(for:)` and evaluating its test cases — **serially**, before any test runs. For typical suites that's immaterial, since planning is already sub-millisecond. But when many tests have **async-evaluated** conditions or traits (for example `.enabled(if: await …)`), this serial pre-phase runs every async evaluation back-to-back before the first test starts — and because execution is already parallel, that pre-phase can become the dominant cost of the run.

This PR resolves those actions concurrently, so the work that the run phase already parallelizes is no longer serialized one step earlier. It's a no-op for suites without async trait work, and it's distinct from the existing `// FIXME` in `_determineAction` (which is about parallelizing a single test's traits; this is the cross-test axis). How common the async-condition regime is in practice is a call I'd defer to you.

## Modifications

Gather the non-placeholder tests, resolve each test's action concurrently in a `withTaskGroup`, then apply the resolved tests and actions back into `testGraph`/`actionGraph`. Mutating the shared `actionGraph` is the only reason the original `await testGraph.mapValues { … }` loop had to be serial, so that mutation is hoisted out of the concurrent region; everything else is unchanged. Behavior is equivalent to the serial version — the same tests, actions, and graph structure result, and actions are applied serially after collection, so the outcome is independent of completion order. The existing suite passes and `swift build` succeeds.

- Honors `--no-parallel`: the serial path is taken when `isParallelizationEnabled` is `false`.
- Not throttled by `maximumParallelizationWidth` (which bounds how many test *cases* run at once), since this is one-time planning work rather than execution — happy to gate it on the width instead if you'd prefer.
- `prepare(for:)` and parameterized-argument closures now run concurrently *across tests*. Traits are `Sendable` and scope providers already run concurrently during execution, so well-behaved traits are unaffected; the only case this could surprise is an `@unchecked Sendable` trait whose synchronization assumed serial planning, which isn't a documented guarantee — flagging it explicitly.
- A test cancelling itself in a trait (`Test.cancel()`) is still isolated by `_determineAction`'s inner task group and does not affect siblings. Added a regression test that builds an eight-test plan where one test cancels in a trait and asserts the other seven still run.
- Uses structured `withTaskGroup` — the same primitive already used in `_determineAction` and the run loop — so no new unstructured tasks. Non-Darwin (Embedded / WASI / Windows) compilation is left to CI.

## Measurements

A synthetic measurement to size the mechanism — deliberately a worst case, not a real-world figure. 1000 free-function tests, each with a trait whose `prepare(for:)` awaits ~1 ms (modeling an async `.enabled(if: await …)` condition) and with empty bodies, measured by toggling `isParallelizationEnabled` on the same build:

| plan construction (1000 tests × ~1 ms async condition) | time |
|---|---|
| serial (today) | ~1.75 s |
| concurrent (this PR) | ~0.13 s |

The fraction is this large only because the bodies are empty, so plan construction is essentially the whole run, and the condition is pure suspension. With real test bodies the fraction shrinks accordingly, and suites with no async trait work see no change at all. The only claim here is that the serial phase is **not inherently sub-millisecond** once trait preparation is async — which is the case this PR addresses.

## Checklist:
- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.