### PR TITLE
Clarify README parameterized-testing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ can write less code. And all tests integrate seamlessly with Swift Concurrency
 and run in parallel by default.
 
 ```swift
-@Test("Continents mentioned in videos", arguments: [
+@Test("Each video mentions 3 or fewer continents", arguments: [
     "A Beach",
     "By the Lake",
     "Camping in the Woods"
-])
+]) // Runs once per video name above, passing it as `videoName` each time
 func mentionedContinents(videoName: String) async throws {
     let videoLibrary = try await VideoLibrary()
     let video = try #require(await videoLibrary.video(named: videoName))


### PR DESCRIPTION
Clarify the parameterized-testing example in the README.

### Motivation:

Fixes #1778. The example under "Scalable coverage and execution" is meant to showcase how clear and expressive Swift Testing's parameterized tests are, but two things worked against that:
- The test's display name ("Continents mentioned in videos") didn't match what the assertion actually checks: a video mentioning zero continents would still pass, which contradicts what the name implies.
- It wasn't obvious how the `arguments` array maps to the `videoName` parameter on the function below it.

_Note: the same snippet also appears on [developer.apple.com/xcode/swift-testing/](https://developer.apple.com/xcode/swift-testing/#:~:text=Clear%2C%20expressive%20API), but that page isn't part of this repo, so this PR only updates the README._

### Modifications:

- Renamed the test to "Each video mentions 3 or fewer continents", matching the assertion it makes.
- Added a short comment tying the `arguments` array to the `videoName` parameter.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated. *(n/a — no public symbols changed)*