### PR TITLE
Add `FileHandle.read(until:)` to avoid blocking on slow exit test events.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -995,7 +995,7 @@ extension ExitTest {
         // and process it as a (minimal) event stream.
         backChannelWriteEnd.close()
         taskGroup.addTask(name: decorateTaskName("exit test", withAction: "processing events")) {
-          Self._processRecords(fromBackChannel: backChannelReadEnd)
+          await Self._processRecords(fromBackChannel: backChannelReadEnd)
           return nil
         }
 
@@ -1019,19 +1019,27 @@ extension ExitTest {
   /// - Parameters:
   ///   - backChannel: The file handle to read from. Reading continues until an
   ///     error is encountered or the end of the file is reached.
-  private static func _processRecords(fromBackChannel backChannel: borrowing FileHandle) {
-    let bytes: [UInt8]
-    do {
-      bytes = try backChannel.readToEnd()
-    } catch {
-      // NOTE: an error caught here indicates an I/O problem.
-      // TODO: should we record these issues as systemic instead?
-      Issue(for: error).record()
-      return
-    }
-
-    for recordJSON in bytes.split(whereSeparator: \.isASCIINewline) where !recordJSON.isEmpty {
+  private static func _processRecords(fromBackChannel backChannel: borrowing FileHandle) async {
+    var terminator: UInt8?
+    repeat {
+      let recordJSON: [UInt8]
       do {
+        (recordJSON, terminator) = try backChannel.read(until: \.isASCIINewline)
+      } catch {
+        // NOTE: an error caught here indicates an I/O problem.
+        // TODO: should we record these issues as systemic instead?
+        Issue(for: error).record()
+        return
+      }
+
+      // Allow other tasks to run after we may have blocked for some time on I/O
+      // with the child process.
+      await Task.yield()
+
+      do {
+        if recordJSON.isEmpty {
+          continue
+        }
         try recordJSON.withUnsafeBufferPointer { recordJSON in
           try Self._processRecord(.init(recordJSON), fromBackChannel: backChannel)
         }
@@ -1040,7 +1048,7 @@ extension ExitTest {
         // TODO: should we record these issues as systemic instead?
         Issue(for: error).record()
       }
-    }
+    } while terminator != nil
   }
 
   /// Decode a line of JSON read from a back channel file handle and handle it

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -459,22 +459,58 @@ extension FileHandle {
       result.reserveCapacity(size)
     }
 
-    try withUnsafeCFILEHandle { file in
-      try withUnsafeTemporaryAllocation(byteCount: 1024, alignment: 1) { buffer in
-        repeat {
-          let countRead = fread(buffer.baseAddress!, 1, buffer.count, file)
-          if 0 != ferror(file) {
-            throw CError(rawValue: swt_errno())
-          }
-          if countRead > 0 {
-            let endIndex = buffer.index(buffer.startIndex, offsetBy: countRead)
-            result.append(contentsOf: buffer[..<endIndex])
-          }
-        } while 0 == feof(file)
+    try withLock {
+      try withUnsafeCFILEHandle { file in
+        try withUnsafeTemporaryAllocation(byteCount: 1024, alignment: 1) { buffer in
+          repeat {
+            let countRead = fread(buffer.baseAddress!, 1, buffer.count, file)
+            if 0 != ferror(file) {
+              throw CError(rawValue: swt_errno())
+            }
+            if countRead > 0 {
+              let endIndex = buffer.index(buffer.startIndex, offsetBy: countRead)
+              result.append(contentsOf: buffer[..<endIndex])
+            }
+          } while 0 == feof(file)
+        }
       }
     }
 
     return result
+  }
+
+  /// Read until a character that matches the given predicate.
+  ///
+  /// - Parameters:
+  ///   - isTerminator: A predicate function that is called for each byte read
+  ///     from the file stream. If it returns `true`, the read ends.
+  ///
+  /// - Returns: A tuple containing: a copy of the contents of the file handle
+  ///   starting at the current offset and ending at either the end of the file
+  ///   stream or the first byte that matches `isTerminator`; and the terminator
+  ///   byte if one was encountered.
+  ///
+  /// - Throws: Any error that occurred while reading the file.
+  func read(until isTerminator: (UInt8) throws -> Bool) throws -> (bytesRead: [UInt8], terminator: UInt8?) {
+    var bytesRead = [UInt8]()
+    var terminator: UInt8?
+
+    try withLock {
+      try withUnsafeCFILEHandle { file in
+        while terminator == nil, let byteRead = UInt8(exactly: fgetc(file)) {
+          if try isTerminator(byteRead) {
+            terminator = byteRead
+          } else {
+            bytesRead.append(byteRead)
+          }
+        }
+        if 0 != ferror(file) {
+          throw CError(rawValue: swt_errno())
+        }
+      }
+    }
+
+    return (bytesRead, terminator)
   }
 }
 


### PR DESCRIPTION
If an exit test runs for a long time, we necessarily block until it terminates before the calling task resumes. We also wait until the end of the exit test to consume any events from its event stream (by calling `FileHandle.readToEnd()` and thus waiting for the write end of the pipe to close).

This PR breaks up reading from the exit test's event stream so that we read one line at a time, then yield before processing the event. The result is that we process events sooner after they occur and we allow other tasks to use the thread we're camped on at least for a little bit of time.

I'll also be able to use `read(until:)` in the harness.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
