### PR TITLE
Ensure `SWT_NO_ABI_JSON_SCHEMA` is checked everywhere we use `ABI.Record` etc.

### DIFF
--- a/Sources/Overlays/_Testing_Foundation/Events/Clock+Date.swift
+++ b/Sources/Overlays/_Testing_Foundation/Events/Clock+Date.swift
@@ -27,6 +27,7 @@ extension Date {
     self.init(timeIntervalSince1970: instant.durationSince1970 / .seconds(1))
   }
 
+#if !SWT_NO_ABI_JSON_SCHEMA
   /// Initialize this date to equal an instant from the testing library's event
   /// stream.
   ///
@@ -39,5 +40,6 @@ extension Date {
   public init?<V>(decoding instant: ABI.EncodedInstant<V>) {
     self.init(timeIntervalSince1970: instant.since1970)
   }
+#endif
 }
 #endif

--- a/Sources/Testing/Events/Event+FallbackEventHandler.swift
+++ b/Sources/Testing/Events/Event+FallbackEventHandler.swift
@@ -11,6 +11,9 @@
 private import _TestingInternals
 
 #if !SWT_NO_INTEROP
+#if SWT_NO_ABI_JSON_SCHEMA
+#error("Platform-specific misconfiguration: support for the fallback event handler (XCTest interop) requires support for the ABI JSON schema")
+#endif
 #if SWT_NO_CODABLE
 #error("Platform-specific misconfiguration: support for the fallback event handler (XCTest interop) requires support for 'Codable'")
 #endif

--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -374,6 +374,7 @@ extension Event.ConsoleOutputRecorder {
     return _record(messages, tags: context.test?.tags)
   }
 
+#if !SWT_NO_ABI_JSON_SCHEMA
   /// Record the specified event by generating a representation of it in this
   /// instance's output format and writing it to this instance's destination.
   ///
@@ -395,6 +396,7 @@ extension Event.ConsoleOutputRecorder {
     let messages = _humanReadableOutputRecorder.record(event, in: &context, configuration: configuration)
     return _record(messages, tags: nil)
   }
+#endif
 
   /// Get a message warning the user of some condition in the library that may
   /// affect test results.

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -650,6 +650,7 @@ extension Event.HumanReadableOutputRecorder {
     return record(event, in: eventContext, configuration: configuration)
   }
 
+#if !SWT_NO_ABI_JSON_SCHEMA
   /// Record the specified event by generating zero or more messages that
   /// describe it.
   ///
@@ -686,6 +687,7 @@ extension Event.HumanReadableOutputRecorder {
       return record(event, in: eventContext, configuration: configuration)
     }
   }
+#endif
 }
 
 extension Test.ID {

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-#if !SWT_NO_CODABLE
+#if !SWT_NO_ABI_JSON_SCHEMA
 @Suite struct `ABI.EncodedEvent Tests` {
   /// Creates an EncodedEvent from a JSON string.
   ///

--- a/Tests/TestingTests/ABI.EncodedTestTests.swift
+++ b/Tests/TestingTests/ABI.EncodedTestTests.swift
@@ -10,6 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
+#if !SWT_NO_ABI_JSON_SCHEMA
 @Suite struct `ABI.EncodedTest Tests` {
   let fixture = ABI.EncodedTest<ABI.CurrentVersion>(
     kind: .function,
@@ -17,7 +18,6 @@
     sourceLocation: .init(),
     id: .init(encoding: .init([])))  // Blank placeholder; should be set in each test case
 
-#if !SWT_NO_CODABLE
   /// Creates an EncodedTest.ID from a string.
   ///
   /// It doesn't really "decode" anything and just stores the string, so this
@@ -96,5 +96,5 @@
 
     #expect(test.decodeIDComponents() == nil)
   }
-#endif
 }
+#endif

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -993,7 +993,7 @@ extension AttachmentTests {
 #endif
   }
 
-#if !SWT_NO_CODABLE
+#if !SWT_NO_ABI_JSON_SCHEMA
 #if !SWT_NO_FILE_IO
   @Test("Decoding an encoded attachment with path")
   func decodingAnEncodedAttachmentWithPath() throws {

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -113,6 +113,7 @@ struct ClockTests {
   }
 #endif
 
+#if !SWT_NO_ABI_JSON_SCHEMA
   @Test("Round trip Test.Clock.Instant <-> ABI.EncodedInstant")
   func roundTrip() async throws {
     let now = Test.Clock.Instant()
@@ -125,4 +126,5 @@ struct ClockTests {
     #expect(abs((now.durationSince1970 - decoded.durationSince1970) / .seconds(1)) < 0.001)
 #endif
   }
+#endif
 }

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -586,6 +586,7 @@ struct EventRecorderTests {
     #expect(actualComments.starts(with: expectedComments))
   }
 
+#if !SWT_NO_ABI_JSON_SCHEMA
   @Test("HumanReadableOutputRecorder with encoded events")
   func encodedEvents() async throws {
     let test = Test(name: "Test Name") {}
@@ -629,6 +630,7 @@ struct EventRecorderTests {
       #expect(message.stringValue.contains(expectedMessage))
     }
   }
+#endif
 }
 
 // MARK: - Fixtures

--- a/Tests/TestingTests/SkipInfoTests.swift
+++ b/Tests/TestingTests/SkipInfoTests.swift
@@ -29,7 +29,7 @@ struct SkipInfoTests {
     #expect(skipInfo.sourceLocation == sourceLocation2)
   }
 
-#if !SWT_NO_CODABLE
+#if !SWT_NO_ABI_JSON_SCHEMA
   @Test(
     "Decode from event",
     arguments: [

--- a/Tests/TestingTests/SourceLocationTests.swift
+++ b/Tests/TestingTests/SourceLocationTests.swift
@@ -65,7 +65,7 @@ struct SourceLocationTests {
     #expect(sourceLocation.fileName == "D.swift")
   }
 
-#if !SWT_NO_CODABLE
+#if !SWT_NO_ABI_JSON_SCHEMA
   @Test("SourceLocation.fileID property is synthesized if not decoded")
   func sourceLocationFileIDSynthesizedWhenNeeded() throws {
 #if os(Windows)

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -16,7 +16,7 @@ private func configurationForEntryPoint(withArguments args: [String]) throws -> 
   return try configurationForEntryPoint(from: args)
 }
 
-#if !SWT_NO_CODABLE
+#if !SWT_NO_ABI_JSON_SCHEMA
 /// Reads event stream output from the provided file matching event stream
 /// version `V`.
 private func decodedEventStreamRecords<V: ABI.Version>(fromPath filePath: String) throws -> [ABI.Record<V>] {
@@ -347,7 +347,7 @@ struct SwiftPMTests {
   }
 #endif
 
-#if !SWT_NO_CODABLE
+#if !SWT_NO_ABI_JSON_SCHEMA
   @Test("Severity and isFailure fields included in version 6.3")
   func validateEventStreamContents() async throws {
     let tempDirPath = try temporaryDirectory()


### PR DESCRIPTION
This PR fixes some build failures that occur if `SWT_NO_ABI_JSON_SCHEMA` is set. This is necessary to ensure we can build in e.g. embedded environments where JSON encoding/decoding won't be available.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
