### PR TITLE
Avoid using members of extensions are unavailable when image attachments are unsupported

### DIFF
--- a/Sources/Testing/Attachments/Images/Attachment+AttachableAsImage.swift
+++ b/Sources/Testing/Attachments/Images/Attachment+AttachableAsImage.swift
@@ -82,8 +82,10 @@ extension Attachment {
     as imageFormat: AttachableImageFormat? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
   ) where AttachableValue: _AttachableImageWrapper<T> & AttachableWrapper {
+#if !SWT_NO_IMAGE_ATTACHMENTS
     let attachment = Self(image, named: preferredName, as: imageFormat, sourceLocation: sourceLocation)
     Self.record(attachment, sourceLocation: sourceLocation)
+#endif
   }
 }
 

--- a/Sources/Testing/ExitTests/ExitStatus.swift
+++ b/Sources/Testing/ExitTests/ExitStatus.swift
@@ -167,14 +167,18 @@ extension ExitStatus: CustomStringConvertible {
   public var description: String {
     switch self {
     case let .exitCode(exitCode):
+#if !SWT_NO_PROCESS_SPAWNING
       if let name {
         return ".exitCode(\(name))"
       }
+#endif
       return ".exitCode(\(exitCode))"
     case let .signal(signal):
+#if !SWT_NO_PROCESS_SPAWNING
       if let name {
         return ".signal(\(name))"
       }
+#endif
       return ".signal(\(signal))"
     }
   }


### PR DESCRIPTION
On certain platforms, code must be compiled out code when it uses declarations marked `@available(*, unavailable)` because it is unsupported on those platforms.

### Motivation:

The intended behavior of the Swift compiler is that non-type declarations marked `@available(*, unavailable)` are always diagnosed as unavailable, even when used in contexts that are also unavailable. However, there was a regression which caused the compiler to fail to diagnose these declarations when they are members of an extension that is marked unavailable, rather than being marked unavailable directly.

Swift Testing has source code that was inadvertently taking advantage of this regression which needs to change in order to unblock the compiler fix (https://github.com/swiftlang/swift/pull/90588).

### Modifications:

Compile out some code that would access members of universally unavailable extensions.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
