### PR TITLE
Add overload of `#expect(processExitsWith:)` to help the type checker.

### DIFF
--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -888,6 +888,52 @@ public macro expect(
   performing expression: @escaping @Sendable () async throws -> Void
 ) -> ExitTest.Result? = #externalMacro(module: "TestingMacros", type: "ExitTestExpectMacro")
 
+/// Check that an expression causes the process to terminate in a given fashion.
+///
+/// - Parameters:
+///   - expectedExitCondition: The expected exit condition.
+///   - observedValues: An array of key paths representing results from within
+///     the exit test that should be observed and returned by this macro. The
+///     ``ExitTest/Result/exitStatus`` property is always returned.
+///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
+///   - expression: The expression to be evaluated.
+///
+/// - Returns: If the exit test passes, an instance of ``ExitTest/Result``
+///   describing the state of the exit test when it exited. If the exit test
+///   fails, the result is `nil`.
+///
+/// Use this overload of `#expect()` when an expression will cause the current
+/// process to terminate and the nature of that termination will determine if
+/// the test passes or fails. For example, to test that calling `fatalError()`
+/// causes a process to terminate:
+///
+/// ```swift
+/// await #expect(processExitsWith: .failure) {
+///   fatalError()
+/// }
+/// ```
+///
+/// @Metadata {
+///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
+/// }
+@freestanding(expression)
+@_documentation(visibility: private)
+@discardableResult
+#if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
+@available(*, unavailable, message: "Exit tests are not available on this platform.")
+#endif
+public macro expect(
+  processExitsWith expectedExitCondition: ExitTest.Condition,
+  observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
+  _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = #_sourceLocation,
+  performing expression: @escaping @Sendable () throws -> Void
+) -> ExitTest.Result? = #externalMacro(module: "TestingMacros", type: "ExitTestExpectMacro")
+
 /// Check that an expression causes the process to terminate in a given fashion
 /// and throw an error if it did not.
 ///
@@ -934,6 +980,54 @@ public macro require(
   _ comment: @autoclosure () -> Comment? = nil,
   sourceLocation: SourceLocation = #_sourceLocation,
   performing expression: @escaping @Sendable () async throws -> Void
+) -> ExitTest.Result = #externalMacro(module: "TestingMacros", type: "ExitTestRequireMacro")
+
+/// Check that an expression causes the process to terminate in a given fashion
+/// and throw an error if it did not.
+///
+/// - Parameters:
+///   - expectedExitCondition: The expected exit condition.
+///   - observedValues: An array of key paths representing results from within
+///     the exit test that should be observed and returned by this macro. The
+///     ``ExitTest/Result/exitStatus`` property is always returned.
+///   - comment: A comment describing the expectation.
+///   - sourceLocation: The source location to which recorded expectations and
+///     issues should be attributed.
+///   - expression: The expression to be evaluated.
+///
+/// - Returns: An instance of ``ExitTest/Result`` describing the state of the
+///   exit test when it exited.
+///
+/// - Throws: An instance of ``ExpectationFailedError`` if the exit condition of
+///   the child process does not equal `expectedExitCondition`.
+///
+/// Use this overload of `#require()` when an expression will cause the current
+/// process to terminate and the nature of that termination will determine if
+/// the test passes or fails. For example, to test that calling `fatalError()`
+/// causes a process to terminate:
+///
+/// ```swift
+/// try await #require(processExitsWith: .failure) {
+///   fatalError()
+/// }
+/// ```
+///
+/// @Metadata {
+///   @Available(Swift, introduced: 6.2)
+///   @Available(Xcode, introduced: 26.0)
+/// }
+@freestanding(expression)
+@discardableResult
+#if SWT_NO_EXIT_TESTS
+@_unavailableInEmbedded
+@available(*, unavailable, message: "Exit tests are not available on this platform.")
+#endif
+public macro require(
+  processExitsWith expectedExitCondition: ExitTest.Condition,
+  observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
+  _ comment: @autoclosure () -> Comment? = nil,
+  sourceLocation: SourceLocation = #_sourceLocation,
+  performing expression: @escaping @Sendable () throws -> Void
 ) -> ExitTest.Result = #externalMacro(module: "TestingMacros", type: "ExitTestRequireMacro")
 
 #if !SWT_NO_CODABLE

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -743,6 +743,17 @@ private import _TestingInternals
     await #expect(processExitsWith: .success) {}
   }
 #endif
+
+  @Test("noasync function callable from synchronous exit test body")
+  func noasyncCallable() async throws {
+    await #expect(processExitsWith: .success) {
+      some_noasync_function()
+    }
+
+    await #expect(processExitsWith: .success) { @MainActor in
+      some_noasync_function()
+    }
+  }
 }
 
 // MARK: - Fixtures
@@ -784,4 +795,7 @@ func sellIceCreamCones(count: Int) async throws {
   }
 }
 #endif
+
+@available(*, noasync)
+fileprivate func some_noasync_function() { /* ... */ }
 #endif


### PR DESCRIPTION
This PR adds overloads of `#expect(processExitsWith:)` and `#require(processExitsWith:)` that take _synchronous_ body closures. These overloads behave identically to the existing ones, but keep the type checker from promoting the closures to `async`. This then allows exit test bodies that are not explicitly `async` to call functions marked `@available(*, noasync)` without diagnosing.

> [!NOTE]
> Whether or not `noasync` functions are safe to call from a particular synchronous context is not known at our layer, and may be undecidable in the general case anyway. However, the language currently permits you to call such a function on any task so long as the immediate caller is not `async`, and we're just preserving that behaviour, not adding new behaviour.

Resolves #1786.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
