### PR TITLE
Update swift-syntax package dependency 605 prerelease

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -116,7 +116,7 @@ let package = Package(
     // manager to use the lexicographically highest-sorted tag with the
     // specified semantic version, meaning the most recent "prerelease" tag will
     // always be used.
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "604.0.0-latest"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "605.0.0-latest"),
 
     // Add a dependency on Swift Argument Parser. Note that the rest of the
     // toolchain (as of this writing) uses 1.5.x, so we match that; if the

--- a/Sources/TestingMacros/CMakeLists.txt
+++ b/Sources/TestingMacros/CMakeLists.txt
@@ -33,7 +33,7 @@ if(SwiftTesting_BuildMacrosAsExecutables)
   set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/_d)
   FetchContent_Declare(SwiftSyntax
     GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
-    GIT_TAG 65b02a90ad2cc213e09309faeb7f6909e0a8577a) # 604.0.0-prerelease-2026-01-20
+    GIT_TAG a8b1c535647243d603b6772e7e8306c993a0c188) # 605.0.0-prerelease-2026-06-26
   FetchContent_MakeAvailable(SwiftSyntax)
 endif()
 


### PR DESCRIPTION
Update the swift-syntax package dependency to be from the 605.0.0 series, of which the current latest is [605.0.0-prerelease-2026-06-26](https://github.com/swiftlang/swift-syntax/releases/tag/605.0.0-prerelease-2026-06-26).

I confirmed a local CMake build succeeds

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
