### PR TITLE
`TypeInfo` needs to handle generic clauses.

### DIFF
--- a/Sources/Testing/Parameterization/TypeInfo.swift
+++ b/Sources/Testing/Parameterization/TypeInfo.swift
@@ -137,24 +137,36 @@ public struct TypeInfo: Sendable {
 func rawIdentifierAwareSplit<S>(_ string: S, separator: Character, maxSplits: Int = .max) -> [S.SubSequence] where S: StringProtocol {
   var result = [S.SubSequence]()
 
+  // Characters with special consideration in this function.
+  let backtick: Character = "`"
+  let openAngleBracket: Character = "<"
+  let closeAngleBracket: Character = ">"
+
   var inRawIdentifier = false
+  var genericClauseDepth = 0
   var componentStartIndex = string.startIndex
   for i in string.indices {
     let c = string[i]
-    if c == "`" {
+    if c == backtick {
       // We are either entering or exiting a raw identifier. While inside a raw
       // identifier, separator characters are ignored.
       inRawIdentifier.toggle()
-    } else if c == separator && !inRawIdentifier {
-      // Add everything up to this separator as the next component, then start
-      // a new component after the separator.
-      result.append(string[componentStartIndex ..< i])
-      componentStartIndex = string.index(after: i)
+    } else if !inRawIdentifier {
+      if c == separator && genericClauseDepth == 0 {
+        // Add everything up to this separator as the next component, then start
+        // a new component after the separator.
+        result.append(string[componentStartIndex ..< i])
+        componentStartIndex = string.index(after: i)
 
-      if result.count == maxSplits {
-        // We don't need to find more separators. We'll add the remainder of the
-        // string outside the loop as the last component, then return.
-        break
+        if result.count == maxSplits {
+          // We don't need to find more separators. We'll add the remainder of
+          // the string outside the loop as the last component, then return.
+          break
+        }
+      } else if c == openAngleBracket {
+        genericClauseDepth += 1
+      } else if c == closeAngleBracket {
+        genericClauseDepth -= 1
       }
     }
   }

--- a/Tests/TestingTests/TypeInfoTests.swift
+++ b/Tests/TestingTests/TypeInfoTests.swift
@@ -51,30 +51,30 @@ struct TypeInfoTests {
   }
 
   @Test("Splitting raw identifiers",
-    arguments: [
-      ("Foo.Bar", ["Foo", "Bar"]),
-      ("`Foo`.Bar", ["`Foo`", "Bar"]),
-      ("`Foo`.`Bar`", ["`Foo`", "`Bar`"]),
-      ("Foo.`Bar`", ["Foo", "`Bar`"]),
-      ("Foo.`Bar`.Quux", ["Foo", "`Bar`", "Quux"]),
-      ("Foo.`B.ar`.Quux", ["Foo", "`B.ar`", "Quux"]),
+        arguments: [
+          ("Foo.Bar", ["Foo", "Bar"]),
+          ("`Foo`.Bar", ["`Foo`", "Bar"]),
+          ("`Foo`.`Bar`", ["`Foo`", "`Bar`"]),
+          ("Foo.`Bar`", ["Foo", "`Bar`"]),
+          ("Foo.`Bar`.Quux", ["Foo", "`Bar`", "Quux"]),
+          ("Foo.`B.ar`.Quux", ["Foo", "`B.ar`", "Quux"]),
 
-      // These have substrings we intentionally strip out.
-      ("Foo.`B.ar`.(unknown context at $0).Quux", ["Foo", "`B.ar`", "Quux"]),
-      ("(extension in Module):Foo.`B.ar`.(unknown context at $0).Quux", ["Foo", "`B.ar`", "Quux"]),
-      ("(extension in `Module`):Foo.`B.ar`.(unknown context at $0).Quux", ["Foo", "`B.ar`", "Quux"]),
-      ("(extension in `Module`):`Foo`.`B.ar`.(unknown context at $0).Quux", ["`Foo`", "`B.ar`", "Quux"]),
-      ("(extension in `Mo:dule`):`Foo`.`B.ar`.(unknown context at $0).Quux", ["`Foo`", "`B.ar`", "Quux"]),
-      ("(extension in `Module`):`F:oo`.`B.ar`.(unknown context at $0).Quux", ["`F:oo`", "`B.ar`", "Quux"]),
-      ("`(extension in Foo):Bar`.Baz", ["`(extension in Foo):Bar`", "Baz"]),
-      ("(extension in `(extension in Foo2):Bar2`):`(extension in Foo):Bar`.Baz", ["`(extension in Foo):Bar`", "Baz"]),
+          // These have substrings we intentionally strip out.
+          ("Foo.`B.ar`.(unknown context at $0).Quux", ["Foo", "`B.ar`", "Quux"]),
+          ("(extension in Module):Foo.`B.ar`.(unknown context at $0).Quux", ["Foo", "`B.ar`", "Quux"]),
+          ("(extension in `Module`):Foo.`B.ar`.(unknown context at $0).Quux", ["Foo", "`B.ar`", "Quux"]),
+          ("(extension in `Module`):`Foo`.`B.ar`.(unknown context at $0).Quux", ["`Foo`", "`B.ar`", "Quux"]),
+          ("(extension in `Mo:dule`):`Foo`.`B.ar`.(unknown context at $0).Quux", ["`Foo`", "`B.ar`", "Quux"]),
+          ("(extension in `Module`):`F:oo`.`B.ar`.(unknown context at $0).Quux", ["`F:oo`", "`B.ar`", "Quux"]),
+          ("`(extension in Foo):Bar`.Baz", ["`(extension in Foo):Bar`", "Baz"]),
+          ("(extension in `(extension in Foo2):Bar2`):`(extension in Foo):Bar`.Baz", ["`(extension in Foo):Bar`", "Baz"]),
 
-      // These aren't syntactically valid, but we should at least not crash.
-      ("Foo.`B.ar`.Quux.`Alpha`..Beta", ["Foo", "`B.ar`", "Quux", "`Alpha`", "", "Beta"]),
-      ("Foo.`B.ar`.Quux.`Alpha", ["Foo", "`B.ar`", "Quux", "`Alpha"]),
-      ("Foo.`B.ar`.Quux.`Alpha``", ["Foo", "`B.ar`", "Quux", "`Alpha``"]),
-      ("Foo.`B.ar`.Quux.`Alpha...", ["Foo", "`B.ar`", "Quux", "`Alpha..."]),
-    ]
+          // These aren't syntactically valid, but we should at least not crash.
+          ("Foo.`B.ar`.Quux.`Alpha`..Beta", ["Foo", "`B.ar`", "Quux", "`Alpha`", "", "Beta"]),
+          ("Foo.`B.ar`.Quux.`Alpha", ["Foo", "`B.ar`", "Quux", "`Alpha"]),
+          ("Foo.`B.ar`.Quux.`Alpha``", ["Foo", "`B.ar`", "Quux", "`Alpha``"]),
+          ("Foo.`B.ar`.Quux.`Alpha...", ["Foo", "`B.ar`", "Quux", "`Alpha..."]),
+        ]
   )
   func rawIdentifiers(fqn: String, expectedComponents: [String]) throws {
     let actualComponents = TypeInfo.fullyQualifiedNameComponents(ofTypeWithName: fqn)
@@ -83,20 +83,20 @@ struct TypeInfoTests {
 
   // As above, but round-tripping through .fullyQualifiedName.
   @Test("Round-tripping raw identifiers",
-    arguments: [
-      ("Foo.Bar", ["Foo", "Bar"]),
-      ("`Foo`.Bar", ["`Foo`", "Bar"]),
-      ("`Foo`.`Bar`", ["`Foo`", "`Bar`"]),
-      ("Foo.`Bar`", ["Foo", "`Bar`"]),
-      ("Foo.`Bar`.Quux", ["Foo", "`Bar`", "Quux"]),
-      ("Foo.`B.ar`.Quux", ["Foo", "`B.ar`", "Quux"]),
+        arguments: [
+          ("Foo.Bar", ["Foo", "Bar"]),
+          ("`Foo`.Bar", ["`Foo`", "Bar"]),
+          ("`Foo`.`Bar`", ["`Foo`", "`Bar`"]),
+          ("Foo.`Bar`", ["Foo", "`Bar`"]),
+          ("Foo.`Bar`.Quux", ["Foo", "`Bar`", "Quux"]),
+          ("Foo.`B.ar`.Quux", ["Foo", "`B.ar`", "Quux"]),
 
-      // These aren't syntactically valid, but we should at least not crash.
-      ("Foo.`B.ar`.Quux.`Alpha`..Beta", ["Foo", "`B.ar`", "Quux", "`Alpha`", "", "Beta"]),
-      ("Foo.`B.ar`.Quux.`Alpha", ["Foo", "`B.ar`", "Quux", "`Alpha"]),
-      ("Foo.`B.ar`.Quux.`Alpha``", ["Foo", "`B.ar`", "Quux", "`Alpha``"]),
-      ("Foo.`B.ar`.Quux.`Alpha...", ["Foo", "`B.ar`", "Quux", "`Alpha..."]),
-    ]
+          // These aren't syntactically valid, but we should at least not crash.
+          ("Foo.`B.ar`.Quux.`Alpha`..Beta", ["Foo", "`B.ar`", "Quux", "`Alpha`", "", "Beta"]),
+          ("Foo.`B.ar`.Quux.`Alpha", ["Foo", "`B.ar`", "Quux", "`Alpha"]),
+          ("Foo.`B.ar`.Quux.`Alpha``", ["Foo", "`B.ar`", "Quux", "`Alpha``"]),
+          ("Foo.`B.ar`.Quux.`Alpha...", ["Foo", "`B.ar`", "Quux", "`Alpha..."]),
+        ]
   )
   func roundTrippedRawIdentifiers(fqn: String, expectedComponents: [String]) throws {
     let typeInfo = TypeInfo(fullyQualifiedName: fqn, unqualifiedName: "", mangledName: "")
@@ -123,6 +123,23 @@ struct TypeInfoTests {
   @Test func typeOfMoveOnlyValueIsInferred() {
     let value = MoveOnlyType()
     #expect(TypeInfo(describingTypeOf: value).unqualifiedName == "MoveOnlyType")
+  }
+
+  @Test func typeNameWithGenericClause() {
+    let type = Array<Int>.self
+    let nameComponents = TypeInfo(describing: type).fullyQualifiedNameComponents
+    #expect(nameComponents == ["Swift", "Array<Swift.Int>"])
+  }
+
+  @Test func typeNameWithNestedGenericClauses() {
+    let type = Array<Array<Int>>.self
+    let nameComponents = TypeInfo(describing: type).fullyQualifiedNameComponents
+    #expect(nameComponents == ["Swift", "Array<Swift.Array<Swift.Int>>"])
+  }
+
+  @Test func typeNameWithGenericClausesAndBackTicks() {
+    let nameComponents = TypeInfo(fullyQualifiedName: "A.`B<C>`<D`>`>.E<`F`.G>", mangledName: nil).fullyQualifiedNameComponents
+    #expect(nameComponents == ["A", "`B<C>`<D`>`>", "E<`F`.G>"])
   }
 }
 


### PR DESCRIPTION
`TypeInfo` can be used with types that have generic clauses. Currently, we can misparse these things. Consider:

```swift
let a = [0, 1, 2]
let b = [1, 2, 3]
```

`a` and `b` are of type `Swift.Array<Swift.Int>`, however the `TypeInfo` value produced for `a` and `b` will report a `fullyQualifiedNameComponents` value of `["Swift", "Array<Swift", "Int>"]` instead of `["Swift", "Array<Swift.Int>"]`.

This PR resolves that issue. We aren't trying to reimplement swift-syntax here, but the new code handles a common case more accurately.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
