### PR TITLE
Remove underscore from `iteration` in JSON record for encoded events

### DIFF
--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -205,6 +205,8 @@ sufficient information to display the event in a human-readable format.
   ["attachment": <attachment>,] ; the attachment (if kind is "valueAttached")
   "messages": <array:message>,
   ["testID": <test-id>,]
+  ["iteration": <number>,] ; the iteration number (if "kind" is
+      ; "testStarted", "testCaseStarted, "testEnded", or "testCaseEnded")
 }
 
 <event-kind> ::= "runStarted" | "testStarted" | "testCaseStarted" |
@@ -249,3 +251,4 @@ sufficient information to display the event in a human-readable format.
 | [ST-0016](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0016-test-cancellation.md#integration-with-supporting-tools) | Added test cancellation. | 6.3 | `"6.3"` |
 | [ST-0019](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0019-include-tags-bugs-and-timeline-in-event-stream.md#json-schema-changes) | Added `tags`, `bugs`, and `timeLimit`. | 6.4 | `"6.4"` |
 | [ST-0020](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0020-sourcelocation-filepath.md#detailed-design) | Added `filePath`. | 6.3 | `"6.3"` |
+| [ST-0024](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0024-per-test-case-repetitions.md)| Added `iteration`. | 6.4 | "6.4" |

--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -205,8 +205,8 @@ sufficient information to display the event in a human-readable format.
   ["attachment": <attachment>,] ; the attachment (if kind is "valueAttached")
   "messages": <array:message>,
   ["testID": <test-id>,]
-  ["iteration": <number>,] ; the iteration number (if "kind" is
-      ; "testStarted", "testCaseStarted, "testEnded", or "testCaseEnded")
+  ["iteration": <number>,] ; the iteration number (if the event is recorded
+                           ; during test execution)
 }
 
 <event-kind> ::= "runStarted" | "testStarted" | "testCaseStarted" |

--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -251,4 +251,4 @@ sufficient information to display the event in a human-readable format.
 | [ST-0016](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0016-test-cancellation.md#integration-with-supporting-tools) | Added test cancellation. | 6.3 | `"6.3"` |
 | [ST-0019](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0019-include-tags-bugs-and-timeline-in-event-stream.md#json-schema-changes) | Added `tags`, `bugs`, and `timeLimit`. | 6.4 | `"6.4"` |
 | [ST-0020](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0020-sourcelocation-filepath.md#detailed-design) | Added `filePath`. | 6.3 | `"6.3"` |
-| [ST-0024](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0024-per-test-case-repetitions.md)| Added `iteration`. | 6.4 | "6.4" |
+| [ST-0024](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0024-per-test-case-repetitions.md)| Added `iteration`. | 6.4 | `"6.4"` |

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -115,7 +115,6 @@ extension ABI {
         kind = .runStarted
       case .testStarted:
         kind = .testStarted
-        iteration = eventContext.iteration
       case .testCaseStarted:
         // For non-parameterized tests, we elide `testCaseStarted` calls because it would be
         // redundant. However, for multiple iterations of a test case within a non-parameterized
@@ -129,7 +128,6 @@ extension ABI {
         } else {
           kind = .testCaseStarted
         }
-        iteration = eventContext.iteration
       case let .issueRecorded(recordedIssue):
         kind = .issueRecorded
         issue = EncodedIssue(encoding: recordedIssue, in: eventContext)
@@ -146,11 +144,9 @@ extension ABI {
         } else {
           kind = .testCaseEnded
         }
-        iteration = eventContext.iteration
       case .testCaseCancelled:
         kind = .testCaseCancelled
       case .testEnded:
-        iteration = eventContext.iteration
         kind = .testEnded
       case .testSkipped:
         kind = .testSkipped
@@ -164,6 +160,17 @@ extension ABI {
       instant = EncodedInstant(encoding: event.instant)
       self.messages = messages.map(EncodedMessage.init)
       testID = event.testID.map(EncodedTest.ID.init)
+
+      // Fields introduced in 6.4
+
+      if V.versionNumber >= ABI.v6_4.versionNumber {
+        switch event.kind {
+        case .testStarted, .testCaseStarted, .testEnded, .testCaseEnded:
+          iteration = eventContext.iteration
+        default:
+          break
+        }
+      }
 
       // Experimental fields
       if V.includesExperimentalFields {

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -165,7 +165,10 @@ extension ABI {
 
       if V.versionNumber >= ABI.v6_4.versionNumber {
         switch event.kind {
-        case .testStarted, .testCaseStarted, .testEnded, .testCaseEnded:
+        case .testStarted, .testCaseStarted,
+            .testEnded, .testCaseEnded,
+            .testCancelled, .testCaseCancelled,
+            .testSkipped:
           iteration = eventContext.iteration
         default:
           break

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -66,6 +66,11 @@ extension ABI {
     /// The ID of the test associated with this event, if any.
     var testID: EncodedTest<V>.ID?
 
+    /// The iteration of the `testID` being executed.
+    ///
+    /// This value is one-indexed; the first iteration is `1`.
+    public var iteration: Int?
+
     /// The ID of the test case associated with this event, if any.
     ///
     /// - Warning: Test cases are not yet part of the JSON schema.
@@ -103,13 +108,6 @@ extension ABI {
     ///   part of said JSON schema.
     @_spi(Experimental)
     public var _sourceLocation: EncodedSourceLocation<V>?
-
-    /// The iteration of the `testID` being executed.
-    ///
-    /// This value is one-indexed; the first iteration is `1`.
-    ///
-    /// - Warning: Iteration indices are not yet part of the JSON schema.
-    var _iteration: Int?
 
     init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message]) {
       switch event.kind {
@@ -172,13 +170,13 @@ extension ABI {
         case let .valueAttached(attachment):
           _sourceLocation = EncodedSourceLocation<V>(encoding: attachment.sourceLocation)
         case .testCaseStarted, .testCaseEnded, .testStarted, .testEnded:
-          _iteration = eventContext.iteration
+          iteration = eventContext.iteration
         case let .testCaseCancelled(skipInfo),
           let .testSkipped(skipInfo),
           let .testCancelled(skipInfo):
           _comments = Array(skipInfo.comment).map(\.rawValue)
           _sourceLocation = skipInfo.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
-          _iteration = eventContext.iteration
+          iteration = eventContext.iteration
         default:
           break
         }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -115,6 +115,7 @@ extension ABI {
         kind = .runStarted
       case .testStarted:
         kind = .testStarted
+        iteration = eventContext.iteration
       case .testCaseStarted:
         // For non-parameterized tests, we elide `testCaseStarted` calls because it would be
         // redundant. However, for multiple iterations of a test case within a non-parameterized
@@ -128,6 +129,7 @@ extension ABI {
         } else {
           kind = .testCaseStarted
         }
+        iteration = eventContext.iteration
       case let .issueRecorded(recordedIssue):
         kind = .issueRecorded
         issue = EncodedIssue(encoding: recordedIssue, in: eventContext)
@@ -144,9 +146,11 @@ extension ABI {
         } else {
           kind = .testCaseEnded
         }
+        iteration = eventContext.iteration
       case .testCaseCancelled:
         kind = .testCaseCancelled
       case .testEnded:
+        iteration = eventContext.iteration
         kind = .testEnded
       case .testSkipped:
         kind = .testSkipped
@@ -169,14 +173,11 @@ extension ABI {
           _sourceLocation = recordedIssue.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
         case let .valueAttached(attachment):
           _sourceLocation = EncodedSourceLocation<V>(encoding: attachment.sourceLocation)
-        case .testCaseStarted, .testCaseEnded, .testStarted, .testEnded:
-          iteration = eventContext.iteration
         case let .testCaseCancelled(skipInfo),
           let .testSkipped(skipInfo),
           let .testCancelled(skipInfo):
           _comments = Array(skipInfo.comment).map(\.rawValue)
           _sourceLocation = skipInfo.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
-          iteration = eventContext.iteration
         default:
           break
         }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -164,15 +164,7 @@ extension ABI {
       // Fields introduced in 6.4
 
       if V.versionNumber >= ABI.v6_4.versionNumber {
-        switch event.kind {
-        case .testStarted, .testCaseStarted,
-            .testEnded, .testCaseEnded,
-            .testCancelled, .testCaseCancelled,
-            .testSkipped:
-          iteration = eventContext.iteration
-        default:
-          break
-        }
+        iteration = eventContext.iteration
       }
 
       // Experimental fields

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -681,7 +681,7 @@ extension Event.HumanReadableOutputRecorder {
       let eventContext = Event.Context(
         test: encodedEvent.testID.flatMap(context.test(identifiedBy:)),
         testCase: nil,
-        iteration: encodedEvent._iteration,
+        iteration: encodedEvent.iteration,
         configuration: nil
       )
       return record(event, in: eventContext, configuration: configuration)

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -119,6 +119,22 @@
     }
   }
 
+  // MARK: Iteration
+
+  @Test func `Encode iteration`() throws {
+    let test = Test {}
+    let event = Event(.testCaseStarted, testID: .init(["SomeValidTestID", "testFunc()"]), testCaseID: nil)
+    let context = Event.Context(test: test, testCase: nil, iteration: 2, configuration: nil)
+    let encoded = try #require(ABI.EncodedEvent<ABI.v6_4>(encoding: event, in: context, messages: []))
+
+    #expect(encoded.iteration == 2)
+
+    try JSON.withEncoding(of: encoded) { buf in
+      let str = String(decoding: buf, as: UTF8.self)
+      #expect(str.contains(#""iteration":2"#))
+    }
+  }
+
   @Test func `Decode iteration`() throws {
     var event = try encodedEvent(
       """

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -133,6 +133,13 @@
       let str = String(decoding: buf, as: UTF8.self)
       #expect(str.contains(#""iteration":2"#))
     }
+
+    let encoded6_3 = try #require(ABI.EncodedEvent<ABI.v6_3>(encoding: event, in: context, messages: []))
+    #expect(encoded6_3.iteration == nil)
+    try JSON.withEncoding(of: encoded6_3) { buf in
+      let str = String(decoding: buf, as: UTF8.self)
+      #expect(!str.contains(#"iteration"#))
+    }
   }
 
   @Test func `Decode iteration`() throws {

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -118,5 +118,30 @@
       return
     }
   }
+
+  @Test func `Decode iteration`() throws {
+    var event = try encodedEvent(
+      """
+      {
+        "kind": "testStarted",
+        "instant": {"absolute": 123, "since1970": 456},
+        "messages": [],
+        "testID": "SomeValidTestID/testFunc()",
+        "iteration": 2
+      }
+      """)
+    #expect(event.iteration == 2)
+
+    event = try encodedEvent(
+      """
+      {
+        "kind": "testStarted",
+        "instant": {"absolute": 123, "since1970": 456},
+        "messages": [],
+        "testID": "SomeValidTestID/testFunc()"
+      }
+      """)
+    #expect(event.iteration == nil)
+  }
 }
 #endif


### PR DESCRIPTION
I missed this in the implementation of ST-0024, `iteration` on the encoded event needs to be non-underscored.

Fixes rdar://182236523

### Motivation:

Implements the ST-0024 spec.

### Modifications:

Just removes the underscore and adds a regression test.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
