### PR TITLE
Add more Linux distros to our CI workflows.

### DIFF
--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-main"]'
-      linux_os_versions: '["jammy"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "fedora41"]'
       linux_static_sdk_versions: '["nightly-main"]'
       windows_swift_versions: '["nightly-main"]'
       enable_macos_checks: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-6.4.x"]'
-      linux_os_versions: '["jammy"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "fedora41"]'
       linux_static_sdk_versions: '["nightly-6.4.x"]'
       windows_swift_versions: '["nightly-6.4.x"]'
       enable_macos_checks: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
-      linux_os_versions: '["jammy"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "fedora41"]'
       linux_static_sdk_versions: '["nightly-main", "nightly-6.4.x"]'
       windows_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       enable_macos_checks: true


### PR DESCRIPTION
This PR adds Amazon Linux 2023 and Fedora 41 to our automated CI workflows alongside Ubuntu 22.04 (Jammy). The selection here is more or less arbitrary; I don't want to run against _every_ possible distro for time/perf reasons, unless the other codeowners think it wise.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
