### PR TITLE
[6.4.x] Enable Android emulator testing with the 6.4 snapshot toolchain employing swift-build in SwiftPM

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   create_merge_pr:
     name: Create PR to merge main into release branch
-    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@0.0.15
     with:
       head_branch: main
       base_branch: release/6.4.x

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
             ls -ld /Applications/*Xcode*
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.15
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.3"]'
       linux_os_versions: '["jammy"]'
@@ -35,13 +35,15 @@ jobs:
       wasm_sdk_versions: '["6.3", "nightly-main", "nightly-6.3"]'
       enable_android_sdk_build: true
       android_ndk_versions: '["r28c", "r29"]'
+      android_sdk_versions: '["nightly-6.4.x"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'
+      enable_android_sdk_checks: true
       enable_freebsd_checks: true
       freebsd_swift_versions: '["nightly-main"]'
       freebsd_os_versions: '["14.3"]'
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.11
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.15
     with:
       license_header_check_project_name: "Swift"
       docs_check_enabled: false


### PR DESCRIPTION
- **Explanation**: Add Android testing and update CI workflow version
  
- **Scope**: Only minor CI changes

- **Issues**: None

- **Original PRs**: Cut down and updated version of #1745

- **Risk**: None from code, as no changes there; very low from these CI changes, as all the same workflows are passing

- **Testing**: Passing on trunk for the last month and a half

- **Reviewers**: @grynspan