### PR TITLE
Add a `SWT_NO_ENVIRONMENT_VARIABLES` check before calling `getenv()` in C.

### DIFF
--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -118,10 +118,12 @@ static const char *_Nonnull *_Nullable swt_objc_copyImageNames(unsigned int *_Nu
     return 0;
   }
 
+#if !SWT_NO_ENVIRONMENT_VARIABLES
   if (getenv("XCODE_RUNNING_FOR_PLAYGROUNDS") != 0) {
     // XOJIT appears to be enabled.
     return 0;
   }
+#endif
 
   return objc_copyImageNames(outCount);
 }


### PR DESCRIPTION
This fixes configs that don't/shouldn't/can't touch the environment block.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
