### PR TITLE
Fix `.testStarted` etc. events being suppressed for suites.

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -67,35 +67,38 @@ extension ABI {
         ///   `testStarted`/`testEnded` events, and replace `testCaseStarted`/
         ///   `testCaseEnded` with `testStarted`/`testEnded`.
         /// - For parameterized tests, emit all events.
-        let isNonParameterizedTest = eventContext.test?.isParameterized == false
+        var isNonParameterizedTestFunction = false
+        if let test = eventContext.test, !test.isSuite {
+          isNonParameterizedTestFunction = !test.isParameterized
+        }
 
         switch kind {
         case .runStarted:
           self = .runStarted
         case .testStarted:
-          if isNonParameterizedTest {
+          if isNonParameterizedTestFunction {
             return nil
           }
           self = .testStarted
         case .testCaseStarted:
-          self = isNonParameterizedTest ? .testStarted : .testCaseStarted
+          self = isNonParameterizedTestFunction ? .testStarted : .testCaseStarted
         case .issueRecorded:
           self = .issueRecorded
         case .valueAttached:
           self = .valueAttached
         case .testCaseEnded:
-          self = isNonParameterizedTest ? .testEnded : .testCaseEnded
+          self = isNonParameterizedTestFunction ? .testEnded : .testCaseEnded
         case .testCaseCancelled:
-          self = isNonParameterizedTest ? .testCancelled : .testCaseCancelled
+          self = isNonParameterizedTestFunction ? .testCancelled : .testCaseCancelled
         case .testEnded:
-          if isNonParameterizedTest {
+          if isNonParameterizedTestFunction {
             return nil
           }
           self = .testEnded
         case .testSkipped:
           self = .testSkipped
         case .testCancelled:
-          if isNonParameterizedTest {
+          if isNonParameterizedTestFunction {
             return nil
           }
           self = .testCancelled

--- a/Tests/TestingTests/ABI.EncodedTestTests.swift
+++ b/Tests/TestingTests/ABI.EncodedTestTests.swift
@@ -96,5 +96,13 @@
 
     #expect(test.decodeIDComponents() == nil)
   }
+
+  @Test func `Can encode an event for a test suite`() {
+    let test = Test(traits: [], sourceLocation: .__here(), containingTypeInfo: TypeInfo(describing: Int.self))
+    let event = Event(.testStarted, testID: test.id, testCaseID: nil)
+    let eventContext = Event.Context(test: test, testCase: nil, iteration: 1, configuration: nil)
+    let encodedEvent = ABI.EncodedEvent<ABI.CurrentVersion>(encoding: event, in: eventContext, messages: [])
+    #expect(encodedEvent != nil)
+  }
 }
 #endif


### PR DESCRIPTION
This fixes events in the JSON event stream not being emitted for test suites. The logic for detecting non-parameterized test (function)s is incorrect and does not account for them.

Caused by #1793.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
