### PR TITLE
Make the fields of a JSON-encoded event optional.

### DIFF
--- a/Sources/Overlays/_Testing_Foundation/Events/Clock+Date.swift
+++ b/Sources/Overlays/_Testing_Foundation/Events/Clock+Date.swift
@@ -38,7 +38,10 @@ extension Date {
   /// `instant`. For precise date/time calculations, convert instances of
   /// ``ABI/EncodedInstant`` to `SuspendingClock.Instant` instead of `Date`.
   public init?<V>(decoding instant: ABI.EncodedInstant<V>) {
-    self.init(timeIntervalSince1970: instant.since1970)
+    guard let instant = Test.Clock.Instant(decoding: instant) else {
+      return nil
+    }
+    self.init(instant)
   }
 #endif
 }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
@@ -20,10 +20,10 @@ extension ABI {
     /// The number of seconds since the system-defined suspending epoch.
     ///
     /// For more information, see [`SuspendingClock`](https://developer.apple.com/documentation/swift/suspendingclock).
-    var absolute: Double
+    var absolute: Double?
 
     /// The number of seconds since the UNIX epoch (1970-01-01 00:00:00 UT).
-    package var since1970: Double
+    package var since1970: Double?
   }
 }
 
@@ -37,17 +37,72 @@ extension ABI.EncodedInstant {
   public init(encoding instant: borrowing Test.Clock.Instant) {
 #if !SWT_NO_SUSPENDING_CLOCK
     absolute = instant.suspending.rawValue / .seconds(1)
-#else
-    absolute = 0
 #endif
 #if !SWT_NO_UTC_CLOCK
     since1970 = instant.wall.rawValue / .seconds(1)
-#else
-    since1970 = 0
 #endif
   }
 }
 
+#if !SWT_NO_ABI_JSON_SCHEMA
+@_spi(ForToolsIntegrationOnly)
+extension Test.Clock.Instant {
+  /// Initialize this instant to be exactly equal to an instant from the testing
+  /// library's event stream.
+  ///
+  /// - Parameters:
+  ///   - instant: The encoded instant to initialize this instant from.
+  ///
+  /// @Comment {
+  ///   If `instant` omits either the suspending-clock value or the wall-clock
+  ///   value, that value is synthesized from the current system's clock.
+  /// }
+  ///
+  /// - Note: When the original instant is encoded to the event stream,
+  ///   it loses some precision.
+  public init?<V>(decoding instant: ABI.EncodedInstant<V>) {
+    // It's not really an experimental "field", but only synthesize absolute or
+    // since1970 if they're enabled as the current schema requires both values.
+    if !V.includesExperimentalFields, instant.absolute == nil || instant.since1970 == nil {
+      return nil
+    }
+
+    switch (instant.absolute, instant.since1970) {
+    case let (.some(absolute), .some(since1970)):
+      let suspending = TimeValue(rawValue: .seconds(absolute))
+      let wall = TimeValue(rawValue: .seconds(since1970))
+#if !SWT_NO_SUSPENDING_CLOCK && !SWT_NO_UTC_CLOCK
+      self.init(suspending: suspending, wall: wall)
+#elseif !SWT_NO_SUSPENDING_CLOCK
+      self.init(suspending: suspending)
+#elseif !SWT_NO_UTC_CLOCK
+      self.init(wall: wall)
+#else
+      self.init()
+#endif
+#if !SWT_NO_SUSPENDING_CLOCK
+    case let (.some(absolute), _):
+      let effectiveEpoch = Test.Clock().systemEpoch
+      let offset = .seconds(absolute) - effectiveEpoch.suspending.rawValue
+      self = effectiveEpoch.advanced(by: offset)
+#endif
+#if !SWT_NO_UTC_CLOCK
+    case let (_, .some(since1970)):
+      let effectiveEpoch = Test.Clock().systemEpoch
+      let offset = .seconds(since1970) - effectiveEpoch.wall.rawValue
+      self = effectiveEpoch.advanced(by: offset)
+#endif
+    default:
+      // Neither value was encoded (or the sole encoded value isn't supported on
+      // this system). Assume the timestamp is 1:1 with the current system's
+      // clock (i.e. events are delivered, encoded, and decoded with zero latency).
+      self = .now
+    }
+  }
+}
+#endif
+
+#if !SWT_NO_SUSPENDING_CLOCK
 @_spi(ForToolsIntegrationOnly)
 extension SuspendingClock.Instant {
   /// Initialize this instant to equal an instant from the testing library's
@@ -59,9 +114,13 @@ extension SuspendingClock.Instant {
   /// The resulting instance is equivalent to the suspending-clock time
   /// represented by `instant`.
   public init?<V>(decoding instant: ABI.EncodedInstant<V>) {
-    self = SuspendingClock().systemEpoch + .seconds(instant.absolute)
+    guard let instant = Test.Clock.Instant(decoding: instant) else {
+      return nil
+    }
+    self.init(instant)
   }
 }
+#endif
 
 // Date.init(decoding:) is in the Foundation overlay.
 

--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -22,12 +22,12 @@ extension Test {
     public struct Instant: Sendable {
 #if !SWT_NO_SUSPENDING_CLOCK
       /// The suspending-clock time corresponding to this instant.
-      fileprivate(set) var suspending = TimeValue(rawValue: SuspendingClock().systemEpoch.duration(to: .now))
+      var suspending = TimeValue(rawValue: SuspendingClock().systemEpoch.duration(to: .now))
 #endif
 
 #if !SWT_NO_UTC_CLOCK
       /// The wall-clock time since 1970 corresponding to this instant.
-      fileprivate(set) var wall: TimeValue = {
+      var wall: TimeValue = {
 #if !SWT_NO_TIMESPEC
         var wall = timespec()
 #if os(Android)
@@ -63,6 +63,34 @@ extension Test {
       }
     }
 
+    /// Storage for ``systemEpoch``.
+    private static let _systemEpoch = Instant.now
+
+    /// Sets the system epoch for the test clock if it hasn't already been set
+    /// in the current process.
+    ///
+    /// ``Runner/run()`` calls this function before starting tests. Reading the
+    /// value of ``systemEpoch`` will also set the system epoch if it hasn't
+    /// been set yet.
+    static func establishSystemEpochIfNeeded() {
+      _ = _systemEpoch
+    }
+
+    /// An instant of this type that can be used as an epoch.
+    ///
+    /// This instant is semantically equal to the point in time when the current
+    /// process started running tests. As such, it is an arbitrary point in time
+    /// and is not equal to "zero" on the test clock, suspending clock, or wall
+    /// clock. You can use it to compute future and past instants, with the
+    /// caveat that computed instants ignore any wall clock adjustments that may
+    /// occur.
+    ///
+    /// Where possible, prefer ``now`` to get the current instant rather than
+    /// trying to compute it using this property.
+    public var systemEpoch: Instant {
+      Self._systemEpoch
+    }
+
     public init() {}
   }
 }
@@ -79,28 +107,6 @@ extension SuspendingClock.Instant {
   ///   - testClockInstant: The equivalent instant on ``Test/Clock``.
   public init(_ testClockInstant: Test.Clock.Instant) {
     self = SuspendingClock().systemEpoch + testClockInstant.suspending.rawValue
-  }
-}
-#endif
-
-#if !SWT_NO_ABI_JSON_SCHEMA
-@_spi(ForToolsIntegrationOnly)
-extension Test.Clock.Instant {
-  /// Initialize this instant to be exactly equal to an instant from the testing
-  /// library's event stream.
-  ///
-  /// - Note: When the original instant is encoded to the event stream,
-  /// it loses some precision.
-  ///
-  /// - Parameters:
-  ///   - instant: The encoded instant to initialize this instant from.
-  public init?<V>(decoding instant: ABI.EncodedInstant<V>) {
-#if !SWT_NO_SUSPENDING_CLOCK
-    suspending = TimeValue(rawValue: .seconds(instant.absolute))
-#endif
-#if !SWT_NO_UTC_CLOCK
-    wall = TimeValue(rawValue: .seconds(instant.since1970))
-#endif
   }
 }
 #endif

--- a/Sources/Testing/Events/Recorder/Event.AdvancedConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.AdvancedConsoleOutputRecorder.swift
@@ -555,7 +555,7 @@ extension Event.AdvancedConsoleOutputRecorder {
     // Calculate total run duration
     var totalDuration = ""
     if let startTime = context.runStartTime, let endTime = context.runEndTime {
-      totalDuration = _formatDuration(endTime.absolute - startTime.absolute)
+      totalDuration = _formatDuration((endTime.absolute ?? 0.0) - (startTime.absolute ?? 0.0))
     }
     
     // Format: [total] tests completed in [duration] ([pass symbol] pass: [number], [failed symbol] fail: [number], ...)
@@ -710,7 +710,7 @@ extension Event.AdvancedConsoleOutputRecorder {
       var duration = ""
       if let startTime = context.testData[node.testID]?.startTime,
          let endTime = context.testData[node.testID]?.endTime {
-        duration = _formatDuration(endTime.absolute - startTime.absolute)
+        duration = _formatDuration((endTime.absolute ?? 0.0) - (startTime.absolute ?? 0.0))
       }
       
       // Format with right-aligned duration

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -515,6 +515,7 @@ extension Runner {
     runner.configureAttachmentHandling()
 #endif
     _ = Event.installFallbackEventHandler()
+    Test.Clock.establishSystemEpochIfNeeded()
 
     // Context to pass into the test run. We intentionally don't pass the Runner
     // itself (implicitly as `self` nor as an argument) because we don't want to

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -15,13 +15,18 @@
   /// Creates an EncodedEvent from a JSON string.
   ///
   /// - Throws: If the JSON doesn't represent a valid EncodedEvent.
-  private func encodedEvent(
-    _ json: String,
-  ) throws -> ABI.EncodedEvent<ABI.CurrentVersion> {
+  private func encodedEvent<V>(_ version: V.Type, _ json: String) throws -> ABI.EncodedEvent<V> {
     var json = json
     return try json.withUTF8 { json in
-      try JSON.decode(ABI.EncodedEvent<ABI.CurrentVersion>.self, from: UnsafeRawBufferPointer(json))
+      try JSON.decode(ABI.EncodedEvent<V>.self, from: UnsafeRawBufferPointer(json))
     }
+  }
+
+  /// Creates an EncodedEvent from a JSON string.
+  ///
+  /// - Throws: If the JSON doesn't represent a valid EncodedEvent.
+  private func encodedEvent(_ json: String) throws -> ABI.EncodedEvent<ABI.CurrentVersion> {
+    try encodedEvent(ABI.CurrentVersion.self, json)
   }
 
   @Test func `Decoded event always has nil testID and testCaseID`() throws {
@@ -184,6 +189,102 @@
     }
     let test = Test() {}
     await test.run(configuration: configuration)
+  }
+
+  @Test func `Encoded instant in event is decodable`() throws {
+    let event = try encodedEvent(
+      """
+      {
+        "kind": "testStarted",
+        "instant": {"absolute": 123, "since1970": 456},
+        "messages": [],
+        "testID": "SomeValidTestID/testFunc()"
+      }
+      """)
+    let decoded = try #require(Event(decoding: event))
+
+#if !SWT_NO_SUSPENDING_CLOCK
+    #expect(decoded.instant.suspending.rawValue == .seconds(123))
+#endif
+#if !SWT_NO_UTC_CLOCK
+    #expect(decoded.instant.wall.rawValue == .seconds(456))
+#endif
+  }
+
+  @Test func `Encoded event with suspending clock instant only is decodable`() throws {
+    let event = try encodedEvent(
+      ABI.ExperimentalVersion.self,
+      """
+      {
+        "kind": "testStarted",
+        "instant": {"absolute": 123},
+        "messages": [],
+        "testID": "SomeValidTestID/testFunc()"
+      }
+      """)
+    let decoded = try #require(Event(decoding: event))
+
+#if !SWT_NO_SUSPENDING_CLOCK
+    #expect(decoded.instant.suspending.rawValue == .seconds(123))
+#endif
+#if !SWT_NO_UTC_CLOCK
+    #expect(decoded.instant.wall.rawValue > .seconds(123))
+#endif
+  }
+
+  @Test func `Encoded event with wall clock instant only is decodable`() throws {
+    let event = try encodedEvent(
+      ABI.ExperimentalVersion.self,
+      """
+      {
+        "kind": "testStarted",
+        "instant": {"since1970": 123},
+        "messages": [],
+        "testID": "SomeValidTestID/testFunc()"
+      }
+      """)
+    let decoded = try #require(Event(decoding: event))
+
+#if !SWT_NO_SUSPENDING_CLOCK
+    // The system will have booted well after the UNIX epoch + 123s
+    #expect(decoded.instant.suspending.rawValue < .zero)
+#endif
+#if !SWT_NO_UTC_CLOCK
+    #expect(decoded.instant.wall.rawValue == .seconds(123))
+#endif
+  }
+
+  @Test func `Encoded event with empty instant is decodable`() throws {
+    let event = try encodedEvent(
+      ABI.ExperimentalVersion.self,
+      """
+      {
+        "kind": "testStarted",
+        "instant": {},
+        "messages": [],
+        "testID": "SomeValidTestID/testFunc()"
+      }
+      """)
+    let before = Test.Clock().now
+    let decoded = try #require(Event(decoding: event))
+    let after = Test.Clock().now
+
+    #expect(decoded.instant > before)
+    #expect(decoded.instant < after)
+  }
+
+  @Test func `Encoded event with wall clock instant only fails to decode for older schema version`() throws {
+    let event = try encodedEvent(
+      ABI.v6_3.self,
+      """
+      {
+        "kind": "testStarted",
+        "instant": {"since1970": 123},
+        "messages": [],
+        "testID": "SomeValidTestID/testFunc()"
+      }
+      """)
+    #expect(Event(decoding: event) == nil)
   }
 }
 #endif


### PR DESCRIPTION
This PR makes the `absolute` and `since1970` fields of `ABI.EncodedInstant` optional when using the experimental version of the JSON schema. If either is missing, we synthesize them by mapping against the current system's clocks. If both are missing, we use the current time on the current system and cross our fingers.

This logic may be incorrect if events are decoded on a different system or different session from where they were encoded. The expectation in those cases is that if a field is missing, it will be _consistently_ missing from all events and so the offsets we compute will still be correct relative to each other even if they are not strictly accurate in the originating device's reference frame. (We do not attempt to handle relativistic time dilation.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
