### PR TITLE
Fix a test that fails only when the target triple is known.

### DIFF
--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -618,11 +618,10 @@ struct EventRecorderTests {
 
     // Generate the messages to compare against.
     let recorder = Event.HumanReadableOutputRecorder()
-    let messages = encodedEvents.flatMap { recorder.record($0, in: &context) }
+    let messages = encodedEvents.compactMap { recorder.record($0, in: &context).first }
 
     let expectedMessages = [
       "Test run started.",
-      "Testing Library Version:",
       #"Test "Test Name" started."#,
       "Issue recorded",
       #"Test "Test Name" failed"#,


### PR DESCRIPTION
Fix a test that is sensitive to whether or not `SWT_TARGET_TRIPLE` is set.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
