### PR TITLE
[6.4.x] Avoid using members of extensions are unavailable when image attachments are unsupported

### DIFF
--- a/Sources/Testing/Attachments/Images/Attachment+AttachableAsImage.swift
+++ b/Sources/Testing/Attachments/Images/Attachment+AttachableAsImage.swift
@@ -82,8 +82,10 @@ extension Attachment {
     as imageFormat: AttachableImageFormat? = nil,
     sourceLocation: SourceLocation = #_sourceLocation
   ) where AttachableValue: _AttachableImageWrapper<T> & AttachableWrapper {
+#if !SWT_NO_IMAGE_ATTACHMENTS
     let attachment = Self(image, named: preferredName, as: imageFormat, sourceLocation: sourceLocation)
     Self.record(attachment, sourceLocation: sourceLocation)
+#endif
   }
 }
 

--- a/Sources/Testing/ExitTests/ExitStatus.swift
+++ b/Sources/Testing/ExitTests/ExitStatus.swift
@@ -167,14 +167,18 @@ extension ExitStatus: CustomStringConvertible {
   public var description: String {
     switch self {
     case let .exitCode(exitCode):
+#if !SWT_NO_PROCESS_SPAWNING
       if let name {
         return ".exitCode(\(name))"
       }
+#endif
       return ".exitCode(\(exitCode))"
     case let .signal(signal):
+#if !SWT_NO_PROCESS_SPAWNING
       if let name {
         return ".signal(\(name))"
       }
+#endif
       return ".signal(\(signal))"
     }
   }


### PR DESCRIPTION
- **Explanation**: Compile out some code that would access members of universally unavailable extensions.
- **Scope**: Affects code related to attachments and exit tests.
- **Issues**: rdar://182756795
- **Original PRs**: https://github.com/swiftlang/swift-testing/pull/1785
- **Risk**: Low, adds some `#if` guards which should've been there all along
- **Testing**: Has been validated to work in `main` against an accompanying compiler change (https://github.com/swiftlang/swift/pull/90588)
- **Reviewers**: @tshortli, @grynspan 
