### PR TITLE
Suppress spurious warning about `TaskLocal.withValue()`.

### DIFF
--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -114,7 +114,9 @@ extension Configuration {
 
     var runtimeState = Runner.RuntimeState.current ?? .init()
     runtimeState.configuration = configuration
-    return try await Runner.RuntimeState.$current.withValue(runtimeState, operation: body)
+    return try await Runner.RuntimeState.$current.withValue(runtimeState) {
+      try await body()
+    }
   }
 
   /// A type containing the mutable state tracked by ``Configuration/_all`` and,


### PR DESCRIPTION
The compiler is currently complaining:

> ⚠️ Runner.RuntimeState.swift:117:51: warning: 'withValue(\_:operation:isolation:file:line:)' is deprecated: Prefer the 'nonisolated(nonsending)' overload with stricter execution on caller context semantics: withValue(\_:operation:file:line:)

Shhhhh. Sleep now, compiler.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
