### PR TITLE
[6.4.x] Suppress spurious warning about `TaskLocal.withValue()`.

### DIFF
--- a/Sources/Testing/Running/Runner.RuntimeState.swift
+++ b/Sources/Testing/Running/Runner.RuntimeState.swift
@@ -114,7 +114,9 @@ extension Configuration {
 
     var runtimeState = Runner.RuntimeState.current ?? .init()
     runtimeState.configuration = configuration
-    return try await Runner.RuntimeState.$current.withValue(runtimeState, operation: body)
+    return try await Runner.RuntimeState.$current.withValue(runtimeState) {
+      try await body()
+    }
   }
 
   /// A type containing the mutable state tracked by ``Configuration/_all`` and,


### PR DESCRIPTION
- **Explanation**: Suppresses a deprecation warning from the compiler when building as a package.
- **Scope**: Runner async code.
- **Issues**: N/A
- **Original PRs**: #1811
- **Risk**: Low
- **Testing**: Existing test coverage
- **Reviewers**: @harlanhaskins @stmontgomery