### PR TITLE
Avoid creating multiple Mirror instances for the same value.

### DIFF
--- a/Sources/Testing/SourceAttribution/Expression.swift
+++ b/Sources/Testing/SourceAttribution/Expression.swift
@@ -113,14 +113,36 @@ public struct __Expression: Sendable {
     /// the value it represents contains substructural values.
     public var children: [Self]?
 
+    /// Forms textual representations and type information for the specified
+    /// subject.
+    ///
+    /// - Parameters:
+    ///   - subject: The subject to describe.
+    /// - Returns: A tuple containing the subject's description, debug
+    ///   description, and type information.
+    private static func _describingProperties(
+      of subject: Any
+    ) -> (
+      description: String,
+      debugDescription: String,
+      typeInfo: TypeInfo
+    ) {
+      (
+        String(describingForTest: subject),
+        String(reflecting: subject),
+        TypeInfo(describingTypeOf: subject)
+      )
+    }
+
     /// Initialize an instance of this type describing the specified subject.
     ///
     /// - Parameters:
     ///   - subject: The subject this instance should describe.
     init(describing subject: Any) {
-      description = String(describingForTest: subject)
-      debugDescription = String(reflecting: subject)
-      typeInfo = TypeInfo(describingTypeOf: subject)
+      let properties = Self._describingProperties(of: subject)
+      description = properties.description
+      debugDescription = properties.debugDescription
+      typeInfo = properties.typeInfo
 
 #if !hasFeature(Embedded)
       let mirror = Mirror(reflectingForTest: subject)
@@ -208,11 +230,15 @@ public struct __Expression: Sendable {
         return
       }
 
-      self.init(describing: subject)
+      let properties = Self._describingProperties(of: subject)
+      description = properties.description
+      debugDescription = properties.debugDescription
+      typeInfo = properties.typeInfo
       self.label = label
 
 #if !hasFeature(Embedded)
       let mirror = Mirror(reflectingForTest: subject)
+      isCollection = mirror.displayStyle?.isCollection ?? false
 
       // If the subject being reflected is an instance of a reference type (e.g.
       // a class), keep track of whether it has been seen previously. Later
@@ -268,6 +294,8 @@ public struct __Expression: Sendable {
         }
         self.children = children
       }
+#else
+      isCollection = false
 #endif
     }
   }


### PR DESCRIPTION
Avoid creating multiple `Mirror` instances for the same value.

### Motivation:

Initializing `__Expression.Value` currently creates an unnecessary `Mirror` instance. This does not increase the algorithmic complexity, but the initializer call chain makes it difficult to identify where the extra initialization occurs.

Specifically, the internal `init(reflecting:)` calls the private `init(_reflecting:label:seenObjects:depth:options:)`, which in turn calls the internal `init(describing:)`.

Within this call chain, `init(describing:)` creates a `Mirror`. However, the private `init(_reflecting:label:seenObjects:depth:options:)` cannot reuse it and creates another `Mirror` for the same subject.

The root cause appears to be that `init(describing:)` is also used to initialize specific properties, making it tempting to call it from the private `init(_reflecting:label:seenObjects:depth:options:)`.

### Modifications:

Changed the private `init(_reflecting:label:seenObjects:depth:options:)` to initialize `description`, `debugDescription`, and `typeInfo` without calling the internal `init(describing:)`. The private initializer now creates only one `Mirror` instance for the subject.

Added `_describingProperties(of:)` to avoid repeating the expressions used to initialize these properties in both initializers.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
