### PR TITLE
Add support for statically linking on Linux

### DIFF
--- a/Sources/Overlays/_Testing_Foundation/CMakeLists.txt
+++ b/Sources/Overlays/_Testing_Foundation/CMakeLists.txt
@@ -33,6 +33,10 @@ if(NOT APPLE)
   target_link_libraries(_Testing_Foundation PUBLIC
     Foundation)
 endif()
+if(NOT BUILD_SHARED_LIBS)
+  target_compile_options(_Testing_Foundation PRIVATE
+    "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestingInternals")
+endif()
 
 # Note: This does not enable Library Evolution, despite emitting a module
 # interface, because Foundation does not have Library Evolution enabled for all

--- a/Sources/_TestDiscovery/CMakeLists.txt
+++ b/Sources/_TestDiscovery/CMakeLists.txt
@@ -25,6 +25,9 @@ set(CMAKE_STATIC_LIBRARY_PREFIX_Swift "lib")
 _swift_testing_install_target(_TestDiscovery)
 
 if(NOT BUILD_SHARED_LIBS)
+  target_compile_options(_TestDiscovery PRIVATE
+    "SHELL:-Xfrontend -public-autolink-library -Xfrontend _TestingInternals")
+
   # When building a static library, install the internal library archive
   # alongside the main library. In shared library builds, the internal library
   # is linked into the main library and does not need to be installed separately.

--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -60,11 +60,6 @@ if(SWT_TESTING_LIBRARY_VERSION)
   add_compile_definitions("$<$<COMPILE_LANGUAGE:CXX>:SWT_TESTING_LIBRARY_VERSION=\"${SWT_TESTING_LIBRARY_VERSION}\">")
 endif()
 
-if((NOT BUILD_SHARED_LIBS) AND (NOT CMAKE_SYSTEM_NAME STREQUAL "WASI"))
-  # When building a static library, Interop is not supported at this time
-  add_compile_definitions("SWT_NO_INTEROP")
-endif()
-
 set(SWT_NO_HARNESS_LIST "iOS" "watchOS" "tvOS" "visionOS" "WASI" "Android")
 if(CMAKE_SYSTEM_NAME IN_LIST SWT_NO_HARNESS_LIST)
   add_compile_definitions("SWT_NO_HARNESS")


### PR DESCRIPTION
Manually adding the autolinks is required when linking these statically.
It also requires we remove the SWT_NO_INTEROP define

This is work towards supporting `-static-stdlib` with test targets on Linux

Work towards https://github.com/swiftlang/swift-package-manager/issues/5590