### PR TITLE
Add SPI to decode record JSON blobs in a one-liner.

### DIFF
--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -121,6 +121,82 @@ extension ABI {
   }
 }
 
+// MARK: - Decoding record JSON
+
+extension ABI {
+  /// Decode an event from the given record JSON.
+  ///
+  /// - Parameters:
+  ///   - recordJSON: The record JSON to decode.
+  ///   - context: A context value that tracks decoded tests and events.
+  ///
+  /// - Returns: A tuple containing the decoded event and an associated event
+  ///   context. The event context's ``Event/Context/test`` property is set if
+  ///   the event has a corresponding test. The caller is responsible for
+  ///   setting the context value's other properties if needed. If `recordJSON`
+  ///   was invalid or could not be decoded, this function returns `nil`.
+  ///
+  /// Records of kind `"test"` are decoded as events of kind `testDiscovered`.
+  ///
+  /// This function infers the ABI version to use from the contents of
+  /// `recordJSON`.
+  public static func decodeEvent(fromRecordJSON recordJSON: UnsafeRawBufferPointer, in context: inout ABI.Context) -> (event: Event, context: Event.Context)? {
+    guard let versionNumber = try? VersionNumber(fromRecordJSON: recordJSON),
+          let abi = _version(forVersionNumber: versionNumber) else {
+      return nil
+    }
+    return abi.decodeEvent(fromRecordJSON: recordJSON, in: &context)
+  }
+}
+
+extension ABI.Version {
+  /// Decode an event from the given record JSON.
+  ///
+  /// - Parameters:
+  ///   - recordJSON: The record JSON to decode.
+  ///   - context: A context value that tracks decoded tests and events.
+  ///
+  /// - Returns: A tuple containing the decoded event and an associated event
+  ///   context. The event context's ``Event/Context/test`` property is set if
+  ///   the event has a corresponding test. The caller is responsible for
+  ///   setting the context value's other properties if needed. If `recordJSON`
+  ///   was invalid or could not be decoded, this function returns `nil`.
+  ///
+  /// Records of kind `"test"` are decoded as events of kind `testDiscovered`.
+  ///
+  /// If `recordJSON` was encoded with an incompatible ABI version, this
+  /// function returns `nil`.
+  public static func decodeEvent(fromRecordJSON recordJSON: UnsafeRawBufferPointer, in context: inout ABI.Context) -> (event: Event, context: Event.Context)? {
+    var result: (event: Event, context: Event.Context)?
+
+    guard let record = try? JSON.decode(ABI.Record<Self>.self, from: recordJSON) else {
+      return nil
+    }
+
+    switch record.kind {
+    case let .test(encodedTest):
+      guard let test = Test(decoding: encodedTest, in: &context) else {
+        return nil
+      }
+      result = (
+        Event(.testDiscovered, testID: test.id, testCaseID: nil),
+        Event.Context(test: test, testCase: nil, iteration: nil, configuration: nil)
+      )
+    case let .event(encodedEvent):
+      guard let event = Event(decoding: encodedEvent, in: &context) else {
+        return nil
+      }
+      let test = encodedEvent.testID.flatMap(context.test(identifiedBy:))
+      result = (
+        event,
+        Event.Context(test: test, testCase: nil, iteration: nil, configuration: nil)
+      )
+    }
+
+    return result
+  }
+}
+
 // MARK: - Experimental fields
 
 /// The value of the environment variable flag which enables experimental event

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -121,6 +121,7 @@ extension ABI {
   }
 }
 
+#if !SWT_NO_ABI_JSON_SCHEMA
 // MARK: - Decoding record JSON
 
 extension ABI {
@@ -196,6 +197,7 @@ extension ABI.Version {
     return result
   }
 }
+#endif
 
 // MARK: - Experimental fields
 

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -286,5 +286,93 @@
       """)
     #expect(Event(decoding: event) == nil)
   }
+
+  @Test func `ABI.decodeJSON() helper function`() throws {
+    var context = ABI.Context()
+
+    let testJSON = """
+    {
+      "version": "6.3",
+      "kind": "test",
+      "payload": {
+        "kind": "function",
+        "name": "testFunc()",
+        "sourceLocation": {
+          "filePath": "some_directory/Foo.swift",
+          "line": 123,
+          "column": 456
+        },
+        "id": "SomeValidTestID/testFunc()/Foo.swift:123:456"
+      }
+    }
+    """
+
+    do {
+      let testDiscoveredEventAndContext = try Array(testJSON.utf8).withUnsafeBytes { testJSON in
+        try #require(ABI.decodeEvent(fromRecordJSON: testJSON, in: &context))
+      }
+      let (event, eventContext) = testDiscoveredEventAndContext
+      if case .testDiscovered = event.kind {} else {
+        Issue.record("Expected .testDiscovered event, got \(event.kind) instead")
+      }
+      let test = try #require(eventContext.test)
+      #expect(test.name == "testFunc()")
+    }
+
+    let eventJSON = """
+    {
+      "version": "6.3",
+      "kind": "event",
+      "payload": {
+        "kind": "testStarted",
+        "instant": {"absolute": 123, "since1970": 456},
+        "messages": [],
+        "testID": "SomeValidTestID/testFunc()/Foo.swift:123:456"
+      }
+    }
+    """
+
+    do {
+      let testStartedEventAndContext = try Array(eventJSON.utf8).withUnsafeBytes { eventJSON in
+        try #require(ABI.decodeEvent(fromRecordJSON: eventJSON, in: &context))
+      }
+      let (event, eventContext) = testStartedEventAndContext
+      if case .testStarted = event.kind {} else {
+        Issue.record("Expected .testStarted event, got \(event.kind) instead")
+      }
+      let test = try #require(eventContext.test)
+      #expect(test.name == "testFunc()")
+    }
+  }
+
+  static let badJSONs: [String] = [
+
+  ]
+  @Test(
+    arguments: [
+      """
+      {}
+      """,
+      """
+      {
+        "version": "6.3",
+        "kind": "test",
+        "payload": {}
+      }
+      """,
+      """
+      {
+        "version": "6.3",
+        "kind": "event",
+        "payload": {}
+      }
+      """,
+    ]
+  ) func `ABI.decodeJSON() rejects bad JSON`(badRecordJSON: String) throws {
+    Array(badRecordJSON.utf8).withUnsafeBytes { badRecordJSON in
+      var context = ABI.Context()
+      #expect(ABI.decodeEvent(fromRecordJSON: badRecordJSON, in: &context) == nil)
+    }
+  }
 }
 #endif


### PR DESCRIPTION
This PR introduces SPI to handle all the decoding nitty-gritty for the JSON event stream.

Resolves rdar://183746212.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
