### PR TITLE
Ensure `ABI.decodeEvent(fromRecordJSON:)` sets the `iteration` property.

### DIFF
--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -132,9 +132,10 @@ extension ABI {
   ///   - context: A context value that tracks decoded tests and events.
   ///
   /// - Returns: A tuple containing the decoded event and an associated event
-  ///   context. The event context's ``Event/Context/test`` property is set if
-  ///   the event has a corresponding test. The caller is responsible for
-  ///   setting the context value's other properties if needed. If `recordJSON`
+  ///   context. The event context's ``Event/Context/test`` and
+  ///   ``Event/Context/iteration`` properties are set if the encoded event has
+  ///   its corresponding properties set. The caller is responsible for setting
+  ///   any other properties of the context value that it needs. If `recordJSON`
   ///   was invalid or could not be decoded, this function returns `nil`.
   ///
   /// Records of kind `"test"` are decoded as events of kind `testDiscovered`.
@@ -158,9 +159,10 @@ extension ABI.Version {
   ///   - context: A context value that tracks decoded tests and events.
   ///
   /// - Returns: A tuple containing the decoded event and an associated event
-  ///   context. The event context's ``Event/Context/test`` property is set if
-  ///   the event has a corresponding test. The caller is responsible for
-  ///   setting the context value's other properties if needed. If `recordJSON`
+  ///   context. The event context's ``Event/Context/test`` and
+  ///   ``Event/Context/iteration`` properties are set if the encoded event has
+  ///   its corresponding properties set. The caller is responsible for setting
+  ///   any other properties of the context value that it needs. If `recordJSON`
   ///   was invalid or could not be decoded, this function returns `nil`.
   ///
   /// Records of kind `"test"` are decoded as events of kind `testDiscovered`.
@@ -190,7 +192,7 @@ extension ABI.Version {
       let test = encodedEvent.testID.flatMap(context.test(identifiedBy:))
       result = (
         event,
-        Event.Context(test: test, testCase: nil, iteration: nil, configuration: nil)
+        Event.Context(test: test, testCase: nil, iteration: encodedEvent.iteration, configuration: nil)
       )
     }
 

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -327,7 +327,8 @@
         "kind": "testStarted",
         "instant": {"absolute": 123, "since1970": 456},
         "messages": [],
-        "testID": "SomeValidTestID/testFunc()/Foo.swift:123:456"
+        "testID": "SomeValidTestID/testFunc()/Foo.swift:123:456",
+        "iteration": 987
       }
     }
     """
@@ -342,6 +343,7 @@
       }
       let test = try #require(eventContext.test)
       #expect(test.name == "testFunc()")
+      #expect(eventContext.iteration == 987)
     }
   }
 


### PR DESCRIPTION
Forgot to set this in #1816.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
