### PR TITLE
Add support for Nerd Fonts glyphs in console output

### DIFF
--- a/Documentation/EnvironmentVariables.md
+++ b/Documentation/EnvironmentVariables.md
@@ -28,6 +28,7 @@ names prefixed with `SWT_`.
 | `COLORTERM`\* | `String` | Used to determine if the current terminal supports 24-bit color. Common across UNIX-like platforms. |
 | `NO_COLOR`[\*](https://no-color.org) | `Any?` | If set to any value, disables color output regardless of terminal capabilities. |
 | `SWT_ENABLE_EXPERIMENTAL_CONSOLE_OUTPUT` | `Bool` | Used to enable or disable experimental console output. |
+| `SWT_NERD_FONTS_ENABLED` | `Bool` | Used to explicitly enable or disable [Nerd&nbsp;Fonts](https://www.nerdfonts.com) support. |
 | `SWT_SF_SYMBOLS_ENABLED` | `Bool` | Used to explicitly enable or disable SF&nbsp;Symbols support on macOS. |
 | `TERM`[\*](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html) | `String` | Used to determine if the current terminal supports 4- or 8-bit color. Common across UNIX-like platforms. |
 

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -780,6 +780,13 @@ extension Event.ConsoleOutputRecorder.Options {
     }
 #endif
 
+    // There is no standard cross-platform way to detect what font (if any) the
+    // current terminal is using, so Nerd Fonts glyphs are only used when
+    // explicitly requested with an environment variable.
+    if let environmentVariable = Environment.flag(named: "SWT_NERD_FONTS_ENABLED") {
+      result.useNerdFonts = environmentVariable
+    }
+
     // If color output is enabled, load tag colors from user/package preferences
     // on disk.
     if result.useANSIEscapeCodes && result.ansiColorBitDepth > 1 {

--- a/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.ConsoleOutputRecorder.swift
@@ -61,6 +61,22 @@ extension Event {
       public var useSFSymbols: Bool = false
 #endif
 
+      /// Whether or not to use [Nerd Fonts](https://www.nerdfonts.com) glyphs
+      /// in the output.
+      ///
+      /// When the value of this property is `true`, Nerd Fonts glyphs are
+      /// assumed to be present in the font used for rendering within the
+      /// Unicode Private Use Areas. When using Swift Testing from the command
+      /// line with `swift test`, set the `SWT_NERD_FONTS_ENABLED` environment
+      /// variable to enable them.
+      ///
+      /// If a Nerd Font is not used for rendering where the output is being
+      /// displayed, the effect of setting the value of this property to `true`
+      /// is unspecified. On Apple platforms, if the value of this property and
+      /// the value of ``useSFSymbols`` are both `true`, Nerd Fonts glyphs are
+      /// used.
+      public var useNerdFonts: Bool = false
+
       /// Storage for ``tagColors``.
       private var _tagColors = Tag.Color.predefined
 
@@ -137,6 +153,9 @@ extension Event.Symbol {
   /// - Returns: A string representation of "no symbol" appropriate for writing
   ///   to a stream.
   fileprivate static func placeholderStringValue(options: Event.ConsoleOutputRecorder.Options) -> String {
+    if options.useNerdFonts {
+      return "  "
+    }
 #if os(macOS) || (os(iOS) && targetEnvironment(macCatalyst))
     if options.useSFSymbols {
       return "  "
@@ -168,6 +187,17 @@ extension Event.Symbol {
       }
     }
 #endif
+    if options.useNerdFonts {
+      // Unlike SF Symbols, Nerd Fonts glyphs are only ever explicitly enabled,
+      // so they take precedence over SF Symbols if both are enabled.
+      symbolCharacter = String(nerdFontCharacter)
+      if options.useANSIEscapeCodes {
+        // Nerd Fonts glyphs are frequently drawn edge-to-edge within their
+        // bounding boxes. As with SF Symbols above, add an extra trailing space
+        // to ensure the glyph has enough room for rendering.
+        symbolCharacter = "\(symbolCharacter) "
+      }
+    }
 
     if useColorANSIEscapeCodes {
       switch self {

--- a/Sources/Testing/Events/Recorder/Event.Symbol.swift
+++ b/Sources/Testing/Events/Recorder/Event.Symbol.swift
@@ -101,6 +101,53 @@ extension Event.Symbol {
 }
 #endif
 
+// MARK: - Nerd Fonts
+
+extension Event.Symbol {
+  /// The [Nerd Fonts](https://www.nerdfonts.com) character corresponding to
+  /// this instance.
+  ///
+  /// Each instance of this type has a corresponding Nerd Fonts glyph, encoded
+  /// in a Unicode Private Use Area, that can be used to represent it in
+  /// text-based output. The value of this property is only rendered correctly
+  /// when the font used by the terminal is a Nerd Font.
+  ///
+  /// This property is not part of the public interface of the testing library.
+  var nerdFontCharacter: Character {
+    switch self {
+    case .default:
+      // Nerd Fonts: nf-md-rhombus_outline
+      "\u{F070C}"
+    case .skip:
+      // Nerd Fonts: nf-fa-arrow_circle_right
+      "\u{F0A9}"
+    case let .pass(knownIssueCount):
+      if knownIssueCount > 0 {
+        // Nerd Fonts: nf-fa-minus
+        "\u{F068}"
+      } else {
+        // Nerd Fonts: nf-fa-check
+        "\u{F00C}"
+      }
+    case .fail:
+      // Nerd Fonts: nf-fa-times
+      "\u{F00D}"
+    case .difference:
+      // Nerd Fonts: nf-md-plus_minus
+      "\u{F0992}"
+    case .warning:
+      // Nerd Fonts: nf-fa-exclamation_triangle
+      "\u{F071}"
+    case .details:
+      // Nerd Fonts: nf-md-subdirectory_arrow_right
+      "\u{F060D}"
+    case .attachment:
+      // Nerd Fonts: nf-fa-paperclip
+      "\u{F0C6}"
+    }
+  }
+}
+
 // MARK: - Unicode
 
 extension Event.Symbol {

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -37,26 +37,29 @@ struct EventRecorderTests {
     }
   }
 
-  private static var optionCombinations: [(useSFSymbols: Bool, ansiColorBitDepth: Int8?)] {
-    var result: [(useSFSymbols: Bool, ansiColorBitDepth: Int8?)] = [
-      (false, nil), (false, 1), (false, 4), (false, 8), (false, 24),
+  private static var optionCombinations: [(useSFSymbols: Bool, useNerdFonts: Bool, ansiColorBitDepth: Int8?)] {
+    var result: [(useSFSymbols: Bool, useNerdFonts: Bool, ansiColorBitDepth: Int8?)] = [
+      (false, false, nil), (false, false, 1), (false, false, 4), (false, false, 8), (false, false, 24),
+      (false, true, nil), (false, true, 1), (false, true, 4), (false, true, 8), (false, true, 24),
     ]
 #if os(macOS)
     result += [
-      (true, nil), (true, 1), (true, 4), (true, 8), (true, 24),
+      (true, false, nil), (true, false, 1), (true, false, 4), (true, false, 8), (true, false, 24),
+      (true, true, nil), (true, true, 1), (true, true, 4), (true, true, 8), (true, true, 24),
     ]
 #endif
     return result
   }
 
   @Test("Writing events", arguments: optionCombinations)
-  func writingToStream(useSFSymbols: Bool, ansiColorBitDepth: Int8?) async throws {
+  func writingToStream(useSFSymbols: Bool, useNerdFonts: Bool, ansiColorBitDepth: Int8?) async throws {
     let stream = Stream()
 
     var options = Event.ConsoleOutputRecorder.Options()
 #if os(macOS)
     options.useSFSymbols = useSFSymbols
 #endif
+    options.useNerdFonts = useNerdFonts
     if let ansiColorBitDepth {
       options.useANSIEscapeCodes = true
       options.ansiColorBitDepth = ansiColorBitDepth
@@ -88,6 +91,23 @@ struct EventRecorderTests {
     } else {
       #expect(!buffer.contains("\u{001B}["))
       #expect(!buffer.contains("●"))
+    }
+
+    if useNerdFonts {
+      // The Nerd Fonts glyphs for passing and failing tests (nf-fa-check and
+      // nf-fa-times) should be used instead of the Unicode or SF Symbols
+      // characters.
+      #expect(buffer.contains("\u{F00C}"))
+      #expect(buffer.contains("\u{F00D}"))
+      #expect(!buffer.contains(Event.Symbol.pass(knownIssueCount: 0).unicodeCharacter))
+      #expect(!buffer.contains(Event.Symbol.fail.unicodeCharacter))
+#if os(macOS)
+      #expect(!buffer.contains(Event.Symbol.pass(knownIssueCount: 0).sfSymbolCharacter))
+      #expect(!buffer.contains(Event.Symbol.fail.sfSymbolCharacter))
+#endif
+    } else {
+      #expect(!buffer.contains("\u{F00C}"))
+      #expect(!buffer.contains("\u{F00D}"))
     }
 
 #if SWT_COLLECTION_DIFFING_ENABLED


### PR DESCRIPTION
Adds opt-in support for rendering [Nerd Fonts](https://www.nerdfonts.com) glyphs in console output via the `SWT_NERD_FONTS_ENABLED` environment variable.

### Motivation:

The console output recorder represents events with Unicode pictographs, or with SF Symbols on macOS when available. Terminals configured with a Nerd Font can render richer, more legible glyphs instead.

Since there is no standard cross-platform way to detect which font (if any) the current terminal is using, this follows the fallback approach suggested in #702: an explicit opt-in via an environment variable, mirroring the existing `SWT_SF_SYMBOLS_ENABLED` pattern.

Resolves #702.

### Modifications:

- Added `Event.Symbol.nerdFontCharacter` mapping each symbol to a Nerd Fonts glyph (codepoints verified against the official Nerd Fonts `glyphnames.json` registry):

  | Symbol | Codepoint | Glyph name |
  |-|-|-|
  | `.default` | U+F070C | `nf-md-rhombus_outline` |
  | `.skip` | U+F0A9 | `nf-fa-arrow_circle_right` |
  | `.pass` | U+F00C | `nf-fa-check` |
  | `.pass` (with known issues) | U+F068 | `nf-fa-minus` |
  | `.fail` | U+F00D | `nf-fa-times` |
  | `.difference` | U+F0992 | `nf-md-plus_minus` |
  | `.warning` | U+F071 | `nf-fa-exclamation_triangle` |
  | `.details` | U+F060D | `nf-md-subdirectory_arrow_right` |
  | `.attachment` | U+F0C6 | `nf-fa-paperclip` |

- Added `useNerdFonts` to `Event.ConsoleOutputRecorder.Options`. Unlike `useSFSymbols`, it is available on all platforms. Since Nerd Fonts glyphs are only ever enabled explicitly, they take precedence over SF Symbols if both options are enabled. As with SF Symbols, an extra trailing space is added after the glyph when ANSI escape codes are in use.
- The entry point (e.g. `swift test`) now reads the `SWT_NERD_FONTS_ENABLED` environment variable to enable the option. There is no automatic detection.
- Documented the new environment variable in `Documentation/EnvironmentVariables.md`.
- Extended the "Writing events" test matrix in `EventRecorderTests` with a `useNerdFonts` dimension, including checks that Nerd Fonts glyphs replace the Unicode (and SF Symbols) characters when enabled.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
