### PR TITLE
Stand up the "6.5" JSON schema version.

### DIFF
--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -49,7 +49,7 @@ extension ABI {
   }
 
   /// The current supported ABI version (ignoring any experimental versions.)
-  public typealias CurrentVersion = v6_4
+  public typealias CurrentVersion = v6_5
 
   /// Get the type representing a given ABI version.
   ///
@@ -103,6 +103,8 @@ extension ABI {
     }
 
     return switch versionNumber {
+    case ABI.v6_5.versionNumber...:
+      ABI.v6_5.self
     case ABI.v6_4.versionNumber...:
       ABI.v6_4.self
     case ABI.v6_3.versionNumber...:
@@ -278,6 +280,17 @@ extension ABI {
   public enum v6_4: Sendable, Version, _Version {
     public static var versionNumber: VersionNumber {
       VersionNumber(6, 4)
+    }
+  }
+
+  /// A namespace and type for ABI version 6.4 symbols.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public enum v6_5: Sendable, Version, _Version {
+    public static var versionNumber: VersionNumber {
+      VersionNumber(6, 5)
     }
   }
 

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -389,6 +389,7 @@ struct SwiftPMTests {
           ("--experimental-event-stream-output", "--experimental-event-stream-version", ABI.v6_3.versionNumber),
           ("--experimental-event-stream-output", "--experimental-event-stream-version", ABI.v6_4.versionNumber),
           ("--event-stream-output-path", "--event-stream-version", ABI.v6_4.versionNumber),
+          ("--event-stream-output-path", "--event-stream-version", ABI.v6_5.versionNumber),
         ])
   func eventStreamOutput(outputArgumentName: String, versionArgumentName: String, version: VersionNumber) async throws {
     let version = try #require(ABI.version(forVersionNumber: version))

--- a/Tests/TestingTests/TestCaseIterationTests.swift
+++ b/Tests/TestingTests/TestCaseIterationTests.swift
@@ -120,7 +120,7 @@ struct TestCaseIterationTests {
 
   private func assertEncodedEventKinds(
     _ test: Test,
-    equals expected: [ABI.EncodedEvent<ABI.v6_4>.Kind],
+    equals expected: [ABI.EncodedEvent<ABI.CurrentVersion>.Kind],
     sourceLocation: SourceLocation = #_sourceLocation
   ) async {
     let events = Mutex<[ABI.EncodedEvent<ABI.CurrentVersion>]>([])


### PR DESCRIPTION
This new version doesn't include any new content yet, but we're in 6.5 now, so…

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
