### PR TITLE
Show "Libraries" eyebrow on the Testing documentation landing page

### DIFF
--- a/Sources/Testing/Testing.docc/Documentation.md
+++ b/Sources/Testing/Testing.docc/Documentation.md
@@ -14,6 +14,10 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 Create and run tests for your Swift packages and Xcode projects.
 
+@Metadata {
+    @TitleHeading("Libraries")
+}
+
 ## Overview
 
 With Swift Testing you leverage powerful and expressive capabilities of

--- a/Sources/Testing/Testing.docc/Documentation.md
+++ b/Sources/Testing/Testing.docc/Documentation.md
@@ -15,7 +15,7 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 Create and run tests for your Swift packages and Xcode projects.
 
 @Metadata {
-    @TitleHeading("Libraries")
+  @TitleHeading("Libraries")
 }
 
 ## Overview


### PR DESCRIPTION
## Summary
- The `Testing` DocC catalog belongs to the "Libraries" nav group in the combined swift.org docs, but its title heading was unset, so no eyebrow was shown on the landing page.
- Adds a `@Metadata` block with `@TitleHeading("Libraries")` to `Documentation.md` to match its nav group.

## Test plan
- [ ] Preview the DocC catalog and confirm the "Libraries" eyebrow appears above the title on the landing page.