### PR TITLE
Allow decoding a JSON schema version number directly from a C string.

### DIFF
--- a/Sources/Testing/ABI/ABI.VersionNumber.swift
+++ b/Sources/Testing/ABI/ABI.VersionNumber.swift
@@ -50,10 +50,71 @@ extension ABI.VersionNumber {
 // MARK: - CustomStringConvertible
 
 extension ABI.VersionNumber: CustomStringConvertible {
+  /// A cache of previously-parsed version numbers.
+  private static let _versionNumberCache = Mutex<[String: Self?]>()
+
+  /// Parse an instance of this type from the given string.
+  ///
+  /// - Parameters:
+  ///   - string: The string to parse, such as `"0"` or `"6.3.0"`.
+  ///
+  /// - Returns: An instance of this type, or `nil` if one could not be parsed
+  ///   from `string`.
+  ///
+  /// - Bug: We are not able to reuse the logic from swift-syntax's
+  ///   `VersionTupleSyntax` type here because we cannot link to swift-syntax
+  ///   in this target.
+  private static func _parse(_ string: String) -> Self? {
+    // Check if we've previously encountered this version number.
+    let cachedValue = Self._versionNumberCache.withLock { versionNumberCache in
+      versionNumberCache[string]
+    }
+    if case let .some(cachedValue) = cachedValue {
+      return cachedValue
+    }
+
+    var result: Self?
+    do {
+      // Split the string on "." (assuming it is of the form "1", "1.2", or
+      // "1.2.3") and parse the individual components as integers.
+      let components = string.split(separator: ".", omittingEmptySubsequences: false)
+      func componentValue(_ index: Int) -> Component? {
+        components.count > index ? Component(components[index]) : 0
+      }
+      if let majorComponent = componentValue(0),
+         let minorComponent = componentValue(1),
+         let patchComponent = componentValue(2) {
+        result = Self(majorComponent: majorComponent, minorComponent: minorComponent, patchComponent: patchComponent)
+      }
+    }
+
+    Self._versionNumberCache.withLock { versionNumberCache in
+      versionNumberCache[string] = result
+    }
+
+    return result
+  }
+
   /// Initialize an instance of this type by parsing the given string.
   ///
   /// - Parameters:
   ///   - string: The string to parse, such as `"0"` or `"6.3.0"`.
+  ///
+  /// If `string` contains fewer than 3 numeric components, the missing
+  /// components are inferred to be `0` (for example, `"1.2"` is equivalent to
+  /// `"1.2.0"`.) If `string` contains more than 3 numeric components, the
+  /// additional components are ignored.
+  public init?(_ string: String) {
+    guard let result = Self._parse(string) else {
+      return nil
+    }
+    self = result
+  }
+
+  /// Initialize an instance of this type by parsing the given string.
+  ///
+  /// - Parameters:
+  ///   - string: The C string to parse, such as `"0"` or `"6.3.0"`.
   ///
   /// @Comment {
   ///   - Bug: We are not able to reuse the logic from swift-syntax's
@@ -65,20 +126,11 @@ extension ABI.VersionNumber: CustomStringConvertible {
   /// components are inferred to be `0` (for example, `"1.2"` is equivalent to
   /// `"1.2.0"`.) If `string` contains more than 3 numeric components, the
   /// additional components are ignored.
-  public init?(_ string: String) {
-    // Split the string on "." (assuming it is of the form "1", "1.2", or
-    // "1.2.3") and parse the individual components as integers.
-    let components = string.split(separator: ".", omittingEmptySubsequences: false)
-    func componentValue(_ index: Int) -> Component? {
-      components.count > index ? Component(components[index]) : 0
-    }
-
-    guard let majorComponent = componentValue(0),
-          let minorComponent = componentValue(1),
-          let patchComponent = componentValue(2) else {
+  public init?(validatingCString string: UnsafePointer<CChar>) {
+    guard let result = String(validatingCString: string).flatMap(Self._parse) else {
       return nil
     }
-    self.init(majorComponent: majorComponent, minorComponent: minorComponent, patchComponent: patchComponent)
+    self = result
   }
 
   public var description: String {

--- a/Sources/Testing/ABI/ABI.VersionNumber.swift
+++ b/Sources/Testing/ABI/ABI.VersionNumber.swift
@@ -10,6 +10,10 @@
 
 private import _TestingInternals
 
+#if canImport(Synchronization)
+private import Synchronization
+#endif
+
 extension ABI {
   /// A type describing an ABI version number.
   ///

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -60,6 +60,14 @@ static int swt_errno(void) {
   return errno;
 }
 
+/// Set the current C error.
+///
+/// This function is provided because `errno` is a complex macro on some
+/// platforms and cannot be imported directly into Swift.
+static void swt_set_errno(int errorCode) {
+  errno = errorCode;
+}
+
 #if !SWT_NO_FILE_IO
 #if __has_include(<sys/stat.h>) && defined(S_ISFIFO)
 /// Check if a given `mode_t` value indicates that a file is a pipe (FIFO.)

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -60,14 +60,6 @@ static int swt_errno(void) {
   return errno;
 }
 
-/// Set the current C error.
-///
-/// This function is provided because `errno` is a complex macro on some
-/// platforms and cannot be imported directly into Swift.
-static void swt_set_errno(int errorCode) {
-  errno = errorCode;
-}
-
 #if !SWT_NO_FILE_IO
 #if __has_include(<sys/stat.h>) && defined(S_ISFIFO)
 /// Check if a given `mode_t` value indicates that a file is a pipe (FIFO.)

--- a/Tests/TestingTests/ABIEntryPointTests.swift
+++ b/Tests/TestingTests/ABIEntryPointTests.swift
@@ -197,6 +197,16 @@ struct ABIEntryPointTests {
     #expect(version == nil)
   }
 
+  @Test func overflowingABIVersionString() {
+    let version = VersionNumber("\(CUnsignedLongLong.max).\(CUnsignedLongLong.max)")
+    #expect(version == nil)
+  }
+
+  @Test func abiVersionStringWithInvalidCharacters() {
+    let version = VersionNumber("123qqq.0")
+    #expect(version == nil)
+  }
+
   @Test func abiVersionComparisons() throws {
     var versions = [VersionNumber]()
     for major in 0 ..< 10 {


### PR DESCRIPTION
This PR adds an `init` to `ABI.VersionNumber` to allow decoding them directly from C strings without needing to first allocate a Swift string. I toyed with having the existing `String`-based initializer call `withCString` and have the logic all against C strings (to avoid having to allocate a `String` for each C string) but the code was significantly more complex _and_ relied on a system API call to `strtol()` because it wasn't worth writing my own integer parser. The time cost of allocating a temporary `String` shouldn't be any worse than it is today without the new initializer.

This PR also adds a cache for `ABI.VersionNumber.init(String)` which makes that initializer about 10x faster for repeatedly-used version numbers. We can't cache C strings (by address) the same way because we don't know if the C string pointers are immortal, but since we create `String` instances for C strings, we'll still be able to use the cache to avoid _parsing_ them repeatedly.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
