### PR TITLE
[DNM] Remove thunk over `objc_copyImageHeaders()`.

### DIFF
--- a/Sources/_TestDiscovery/SectionBounds.swift
+++ b/Sources/_TestDiscovery/SectionBounds.swift
@@ -104,13 +104,12 @@ private func _sectionBounds(_ kind: SectionBounds.Kind) -> [SectionBounds] {
 #if _runtime(_ObjC)
   if #available(_objcCopyImageHeadersAPI, *) {
     var imageCount = UInt32(0)
-    if let imageHeaders = swt_objc_copyImageHeaders(&imageCount) {
-      defer {
-        free(imageHeaders)
-      }
-      return UnsafeBufferPointer(start: imageHeaders, count: Int(clamping: imageCount))
-        .compactMap { _findSectionBounds(kind, in: $0) }
+    let imageHeaders = objc_copyImageHeaders(&imageCount)
+    defer {
+      free(imageHeaders)
     }
+    return UnsafeBufferPointer(start: imageHeaders, count: Int(clamping: imageCount))
+      .compactMap { _findSectionBounds(kind, in: $0) }
   }
 
   var imageCount = UInt32(0)

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -85,23 +85,6 @@ static mach_port_t swt_mach_task_self(void) {
 #endif
 
 #if defined(__APPLE__) && defined(__OBJC2__) && !SWT_NO_DYNAMIC_LINKING
-/// Get an array of Mach headers that are loaded into the current process and
-/// contain Objective-C or Swift code.
-///
-/// This function is provided because the testing library still needs to
-/// build with older Apple SDKs that do not contain a declaration of the runtime
-/// `objc_copyImageHeaders()` function.
-///
-/// - Bug: This declaration should be removed once Apple has shipped an updated
-///   SDK that includes `objc_copyImageHeaders()`.
-static struct mach_header const *_Nonnull *_Nullable swt_objc_copyImageHeaders(unsigned int *_Nullable outCount) {
-  __auto_type objc_copyImageHeaders = (__typeof__(&swt_objc_copyImageHeaders))dlsym(RTLD_DEFAULT, "objc_copyImageHeaders");
-  if (objc_copyImageHeaders) {
-    return (* objc_copyImageHeaders)(outCount);
-  }
-  return 0;
-}
-
 /// Get an array of the names of Mach images that are loaded into the current
 /// process and contain Objective-C or Swift code.
 ///


### PR DESCRIPTION
Our CI is now on an Xcode 27 beta, so it can directly invoke `objc_copyImageHeaders()`. No need for the `dlsym()`-calling thunk anymore.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
