### PR TITLE
Make the `"messages"` field in the JSON event stream optional.

### DIFF
--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -27,15 +27,21 @@ extension ABI.Version {
     precondition(self != ABI.Xcode16.self, "Attempted to create an ABI.Record-generating event handler for the Xcode 16 compatibility path.")
 #endif
 
-    let humanReadableOutputRecorder = Event.HumanReadableOutputRecorder()
-    return { event, context in
+    var humanReadableOutputRecorder: Event.HumanReadableOutputRecorder?
+    if alwaysEncodeMessagesField {
+      humanReadableOutputRecorder = Event.HumanReadableOutputRecorder()
+    }
+    return { [humanReadableOutputRecorder] event, context in
       if case .testDiscovered = event.kind, let test = context.test {
         let testRecord = ABI.Record<Self>(encoding: test)
         recordHandler(testRecord)
       } else {
-        var configuration = Configuration()
-        configuration.verbosity = 0
-        let messages = humanReadableOutputRecorder.record(event, in: context, configuration: configuration)
+        var messages: [Event.HumanReadableOutputRecorder.Message] = []
+        if let humanReadableOutputRecorder {
+          var configuration = Configuration()
+          configuration.verbosity = 0
+          messages = humanReadableOutputRecorder.record(event, in: context, configuration: configuration)
+        }
         if let eventRecord = ABI.Record<Self>(encoding: event, in: context, messages: messages) {
           recordHandler(eventRecord)
         }

--- a/Sources/Testing/ABI/ABI.Record.swift
+++ b/Sources/Testing/ABI/ABI.Record.swift
@@ -51,7 +51,7 @@ extension ABI.Record {
     self.init(encoding: test)
   }
 
-  init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message]) {
+  init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message] = []) {
     guard let event = ABI.EncodedEvent<V>(encoding: event, in: eventContext, messages: messages) else {
       return nil
     }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -182,7 +182,7 @@ extension ABI {
     @_spi(Experimental)
     public var _sourceLocation: EncodedSourceLocation<V>?
 
-    init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message]) {
+    init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message] = []) {
       guard let encodedKind = Kind(encoding: event.kind, in: eventContext) else {
         return nil
       }
@@ -233,7 +233,55 @@ extension ABI {
 
 // MARK: - Codable
 
-extension ABI.EncodedEvent: Codable {}
+extension ABI.EncodedEvent: Codable {
+  /// The keys used to encode ``ABI/EncodedEvent``.
+  private enum _CodingKeys: String, CodingKey {
+    case kind
+    case instant
+    case issue
+    case attachment
+    case messages
+    case testID
+    case iteration
+    case testCase = "_testCase"
+    case comments = "_comments"
+    case sourceLocation = "_sourceLocation"
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: _CodingKeys.self)
+    try container.encode(kind, forKey: .kind)
+    try container.encode(instant, forKey: .instant)
+    try container.encodeIfPresent(issue, forKey: .issue)
+    try container.encodeIfPresent(attachment, forKey: .attachment)
+    if V.alwaysEncodeMessagesField || !messages.isEmpty {
+      try container.encode(messages, forKey: .messages)
+    }
+    try container.encodeIfPresent(testID, forKey: .testID)
+    try container.encodeIfPresent(iteration, forKey: .iteration)
+    try container.encodeIfPresent(_testCase, forKey: .testCase)
+    try container.encodeIfPresent(_comments, forKey: .comments)
+    try container.encodeIfPresent(_sourceLocation, forKey: .sourceLocation)
+  }
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: _CodingKeys.self)
+    kind = try container.decode(Kind.self, forKey: .kind)
+    instant = try container.decode(ABI.EncodedInstant<V>.self, forKey: .instant)
+    issue = try container.decodeIfPresent(ABI.EncodedIssue<V>.self, forKey: .issue)
+    attachment = try container.decodeIfPresent(ABI.EncodedAttachment<V>.self, forKey: .attachment)
+    if V.alwaysDecodeMessagesField {
+      messages = try container.decode([ABI.EncodedMessage<V>].self, forKey: .messages)
+    } else {
+      messages = try container.decodeIfPresent([ABI.EncodedMessage<V>].self, forKey: .messages) ?? []
+    }
+    testID = try container.decodeIfPresent(ABI.EncodedTest<V>.ID.self, forKey: .testID)
+    iteration = try container.decodeIfPresent(Int.self, forKey: .iteration)
+    _testCase = try container.decodeIfPresent(ABI.EncodedTestCase<V>.self, forKey: .testCase)
+    _comments = try container.decodeIfPresent([String].self, forKey: .comments)
+    _sourceLocation = try container.decodeIfPresent(ABI.EncodedSourceLocation<V>.self, forKey: .sourceLocation)
+  }
+}
 extension ABI.EncodedEvent.Kind: Codable {}
 
 // MARK: - Conversion to/from library types
@@ -317,6 +365,40 @@ extension Event {
       }
       self.testID = testID
     }
+  }
+}
+
+// MARK: - Automatic inclusion of messages
+
+/// Whether or not to always include the `"messages"` field in encoded events
+/// even when it is an empty array.
+#if DEBUG
+private var _alwaysIncludeMessagesField: Bool? {
+  Environment.flag(named: "SWT_EXPERIMENTAL_EVENT_STREAM_MESSAGES_FIELD_ENABLED")
+}
+#else
+private let _alwaysIncludeMessagesField = Environment.flag(named: "SWT_EXPERIMENTAL_EVENT_STREAM_MESSAGES_FIELD_ENABLED")
+#endif
+
+extension ABI.Version {
+  /// Whether or not to always include the `"messages"` field when encoding
+  /// events even when it is an empty array.
+  static var alwaysEncodeMessagesField: Bool {
+    // If the environment variable above is set to `true`, then even newer
+    // schema versions should encode the "messages" field.
+
+    // TODO: fix speculative version number check
+    _alwaysIncludeMessagesField == true || versionNumber < ABI.ExperimentalVersion.versionNumber
+  }
+
+  /// Whether or not to require the presence of the `"messages"` field in
+  /// _decoded_ events.
+  static var alwaysDecodeMessagesField: Bool {
+    // Whether or not the field is required during decoding is solely dependent
+    // on the schema version, not on the environment variable.
+
+    // TODO: fix speculative version number check
+    versionNumber < ABI.ExperimentalVersion.versionNumber
   }
 }
 #endif

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -130,7 +130,7 @@
     let test = Test {}
     let event = Event(.testCaseStarted, testID: .init(["SomeValidTestID", "testFunc()"]), testCaseID: nil)
     let context = Event.Context(test: test, testCase: nil, iteration: 2, configuration: nil)
-    let encoded = try #require(ABI.EncodedEvent<ABI.v6_4>(encoding: event, in: context, messages: []))
+    let encoded = try #require(ABI.EncodedEvent<ABI.v6_4>(encoding: event, in: context))
 
     #expect(encoded.iteration == 2)
 
@@ -139,7 +139,7 @@
       #expect(str.contains(#""iteration":2"#))
     }
 
-    let encoded6_3 = try #require(ABI.EncodedEvent<ABI.v6_3>(encoding: event, in: context, messages: []))
+    let encoded6_3 = try #require(ABI.EncodedEvent<ABI.v6_3>(encoding: event, in: context))
     #expect(encoded6_3.iteration == nil)
     try JSON.withEncoding(of: encoded6_3) { buf in
       let str = String(decoding: buf, as: UTF8.self)
@@ -175,7 +175,7 @@
   @Test func `Encoded event for non-parameterized test doesn't add testCase`() async {
     var configuration = Configuration()
     configuration.eventHandler = { event, context in
-      guard let encoded = ABI.EncodedEvent<ABI.CurrentVersion>(encoding: event, in: context, messages: []) else {
+      guard let encoded = ABI.EncodedEvent<ABI.CurrentVersion>(encoding: event, in: context) else {
         return
       }
       switch encoded.kind {
@@ -218,7 +218,6 @@
       {
         "kind": "testStarted",
         "instant": {"absolute": 123},
-        "messages": [],
         "testID": "SomeValidTestID/testFunc()"
       }
       """)
@@ -239,7 +238,6 @@
       {
         "kind": "testStarted",
         "instant": {"since1970": 123},
-        "messages": [],
         "testID": "SomeValidTestID/testFunc()"
       }
       """)
@@ -261,7 +259,6 @@
       {
         "kind": "testStarted",
         "instant": {},
-        "messages": [],
         "testID": "SomeValidTestID/testFunc()"
       }
       """)
@@ -372,6 +369,68 @@
       var context = ABI.Context()
       #expect(ABI.decodeEvent(fromRecordJSON: badRecordJSON, in: &context) == nil)
     }
+  }
+
+  @Test func `Fails to decode v6.3 record with missing 'messages' field`() throws {
+    #expect(throws: DecodingError.self) {
+      _ = try encodedEvent(
+        ABI.v6_3.self,
+        """
+        {
+          "kind": "testStarted",
+          "instant": {"absolute": 123, "since1970": 456},
+          "testID": "SomeValidTestID/testFunc()"
+        }
+        """
+      )
+    }
+
+    #expect(throws: Never.self) {
+      _ = try encodedEvent(
+        ABI.ExperimentalVersion.self,
+        """
+        {
+          "kind": "testStarted",
+          "instant": {"absolute": 123, "since1970": 456},
+          "testID": "SomeValidTestID/testFunc()"
+        }
+        """
+      )
+    }
+  }
+
+  @Test(.serialized(for: \Environment.self))
+  func `Includes messages when SWT_EXPERIMENTAL_EVENT_STREAM_MESSAGES_FIELD_ENABLED is set`() throws {
+    let oldEnvvar = Environment.variable(named: "SWT_EXPERIMENTAL_EVENT_STREAM_MESSAGES_FIELD_ENABLED")
+    Environment.setVariable(nil, named: "SWT_EXPERIMENTAL_EVENT_STREAM_MESSAGES_FIELD_ENABLED")
+    defer {
+      Environment.setVariable(oldEnvvar, named: "SWT_EXPERIMENTAL_EVENT_STREAM_MESSAGES_FIELD_ENABLED")
+    }
+
+    #expect(ABI.v6_3.alwaysEncodeMessagesField)
+    #expect(ABI.v6_3.alwaysDecodeMessagesField)
+
+    #expect(!ABI.ExperimentalVersion.alwaysEncodeMessagesField)
+    #expect(!ABI.ExperimentalVersion.alwaysDecodeMessagesField)
+
+    Environment.setVariable("true", named: "SWT_EXPERIMENTAL_EVENT_STREAM_MESSAGES_FIELD_ENABLED")
+
+    #expect(ABI.ExperimentalVersion.alwaysEncodeMessagesField)
+    #expect(!ABI.ExperimentalVersion.alwaysDecodeMessagesField)
+
+    let eventHandler = ABI.ExperimentalVersion.eventHandler(encodeAsJSONLines: false) { recordJSON in
+      #expect(throws: Never.self) {
+        let decodedRecord = try JSON.decode(ABI.Record<ABI.ExperimentalVersion>.self, from: recordJSON)
+        guard case let .event(decodedEvent) = decodedRecord.kind else {
+          Issue.record("Got the wrong kind '\(decodedRecord.kind)' of record back when encoding an event.")
+          return
+        }
+        #expect(!decodedEvent.messages.isEmpty)
+      }
+    }
+    let event = Event(.runStarted, testID: nil, testCaseID: nil)
+    let eventContext = Event.Context(test: nil, testCase: nil, iteration: nil, configuration: nil)
+    eventHandler(event, eventContext)
   }
 }
 #endif

--- a/Tests/TestingTests/ABI.EncodedTestTests.swift
+++ b/Tests/TestingTests/ABI.EncodedTestTests.swift
@@ -101,7 +101,7 @@
     let test = Test(traits: [], sourceLocation: .__here(), containingTypeInfo: TypeInfo(describing: Int.self))
     let event = Event(.testStarted, testID: test.id, testCaseID: nil)
     let eventContext = Event.Context(test: test, testCase: nil, iteration: 1, configuration: nil)
-    let encodedEvent = ABI.EncodedEvent<ABI.CurrentVersion>(encoding: event, in: eventContext, messages: [])
+    let encodedEvent = ABI.EncodedEvent<ABI.CurrentVersion>(encoding: event, in: eventContext)
     #expect(encodedEvent != nil)
   }
 }

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -1070,7 +1070,6 @@ extension AttachmentTests {
       {
         "kind": "valueAttached",
         "instant": { "since1970": 0, "absolute": 0 },
-        "messages": [],
         "_sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
         "attachment": { "_bytes": "YWJjMTIz" }
       }

--- a/Tests/TestingTests/TestCaseIterationTests.swift
+++ b/Tests/TestingTests/TestCaseIterationTests.swift
@@ -126,7 +126,7 @@ struct TestCaseIterationTests {
     let events = Mutex<[ABI.EncodedEvent<ABI.CurrentVersion>]>([])
     var configuration = Configuration()
     configuration.eventHandler = { event, context in
-      guard let encoded = ABI.EncodedEvent<ABI.CurrentVersion>(encoding: event, in: context, messages: []) else {
+      guard let encoded = ABI.EncodedEvent<ABI.CurrentVersion>(encoding: event, in: context) else {
         return
       }
       events.withLock {


### PR DESCRIPTION
There's significant overhead to generating, encoding, and decoding the `"messages"` field in our JSON schema. This PR makes it optional and, when using the experimental schema version, no longer includes it by default.

There is a corresponding environment variable calling processes can set, `"SWT_EXPERIMENTAL_EVENT_STREAM_MESSAGES_FIELD_ENABLED"`, that forces output of the `"messages"` field even in the newer schema. This allows clients that actually use the field (e.g. the Swift VS Code plugin) to continue doing so.

The team will be pitching this change as a formal change to the JSON schema at some point in the nearish future.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
