### PR TITLE
Don't call `write()` in new tag-filtering code without file I/O enabled.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -670,7 +670,9 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
       if string.contains(backtickRegex) {
         let originalString = string
         string = String(string.dropFirst().dropLast())
+#if !SWT_NO_FILE_IO
         try? FileHandle.stderr.write("Backticks aren't a valid part of a Swift symbol. Replacing '\(originalString)' with '\(string)'.\n")
+#endif
       }
     }
 


### PR DESCRIPTION
Embedded Swift targets may not have access to file I/O, so we need to conditionalize this one line.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
