### PR TITLE
Defer allocating `__Expression` instances until we actually need them.

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -469,7 +469,7 @@ func callExitTest(
   encodingCapturedValues capturedValues: [ExitTest.CapturedValue],
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable],
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
@@ -528,7 +528,7 @@ func callExitTest(
 
   // Plumb the exit test's result through the general expectation machinery.
   func expressionWithCapturedRuntimeValues() -> __Expression {
-    var expression = expression.capturingRuntimeValues(result.exitStatus)
+    var expression = expression().capturingRuntimeValues(result.exitStatus)
 
     expression.subexpressions = [expectedExitCondition.exitStatus, result.exitStatus]
       .compactMap { exitStatus in
@@ -545,7 +545,7 @@ func callExitTest(
   }
   return __checkValue(
     expectedExitCondition.isApproximatelyEqual(to: result.exitStatus),
-    expression: expression,
+    expression: expression(),
     expressionWithCapturedRuntimeValues: expressionWithCapturedRuntimeValues(),
     mismatchedExitConditionDescription: #"expected exit status "\#(expectedExitCondition)", but "\#(result.exitStatus)" was reported instead"#,
     comments: comments(),

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -1108,7 +1108,7 @@ public func __checkClosureCall<R>(
     mismatchExplanationValue = explanation
   } catch {
     caughtError = error
-    expression = { expression().capturingRuntimeValues(error) }
+    expression = { [expression] in expression().capturingRuntimeValues(error) }
     let secondError = Issue.withErrorRecording(at: sourceLocation) {
       errorMatches = try errorMatcher(error)
     }
@@ -1159,7 +1159,7 @@ public func __checkClosureCall<R>(
     mismatchExplanationValue = explanation
   } catch {
     caughtError = error
-    expression = { expression().capturingRuntimeValues(error) }
+    expression = { [expression] in expression().capturingRuntimeValues(error) }
     let secondError = await Issue.withErrorRecording(at: sourceLocation) {
       errorMatches = try await errorMatcher(error)
     }

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -91,18 +91,22 @@ public func __checkValue(
   // Post an event for the expectation regardless of whether or not it passed.
   // If the current event handler is not configured to handle events of this
   // kind, this event is discarded.
-  lazy var expectation = Expectation(evaluatedExpression: expression, isPassing: condition, isRequired: isRequired, sourceLocation: sourceLocation)
-  if Configuration.deliverExpectationCheckedEvents {
+  func makeExpectation() -> Expectation {
+    Expectation(evaluatedExpression: expression, isPassing: condition, isRequired: isRequired, sourceLocation: sourceLocation)
+  }
+  if _slowPath(Configuration.deliverExpectationCheckedEvents) {
+    let expectation = makeExpectation()
     Event.post(.expectationChecked(expectation))
   }
 
   // Early exit if the expectation passed.
-  if condition {
+  if _fastPath(condition) {
     return .success(())
   }
 
   // Since this expectation failed, populate its optional fields which are
   // only evaluated and included lazily upon failure.
+  var expectation = makeExpectation()
   expectation.mismatchedErrorDescription = mismatchedErrorDescription()
   expectation.differenceDescription = difference()
   expectation.mismatchedExitConditionDescription = mismatchedExitConditionDescription()

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -60,7 +60,8 @@
 ///   `#require()` macros. Do not call it directly.
 public func __checkValue(
   _ condition: Bool,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   expressionWithCapturedRuntimeValues: @autoclosure () -> __Expression? = nil,
   mismatchedErrorDescription: @autoclosure () -> String? = nil,
   difference: @autoclosure () -> String? = nil,
@@ -69,22 +70,17 @@ public func __checkValue(
   isRequired: Bool,
   sourceLocation: SourceLocation
 ) -> Result<Void, any Error> {
+  lazy var expression = expression()
+
   // If the expression being evaluated is a negation (!x instead of x), flip
-  // the condition here so that we evaluate it in the correct sense. We loop
-  // in case of multiple prefix operators (!!(a == b), for example.)
+  // the condition here so that we evaluate it in the correct sense.
   var condition = condition
-  do {
-    var expression: __Expression? = expression
-    while expression?.isNegated == true {
-      defer {
-        expression = expression?.subexpressions.first
-      }
-      condition = !condition
-    }
+  let isNegated = (negationCount + 1).isMultiple(of: 2)
+  if isNegated {
+    condition = !condition
   }
 
   // Capture the correct expression in the expectation.
-  var expression = expression
   if !condition, let expressionWithCapturedRuntimeValues = expressionWithCapturedRuntimeValues() {
     expression = expressionWithCapturedRuntimeValues
     if expression.runtimeValue == nil, expression.isNegated {
@@ -169,7 +165,8 @@ private func _callBinaryOperator<T, U, R>(
 ///   `#require()` macros. Do not call it directly.
 @_disfavoredOverload public func __checkBinaryOperation<T, U>(
   _ lhs: T, _ op: (T, () -> U) -> Bool, _ rhs: @autoclosure () -> U,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -177,8 +174,9 @@ private func _callBinaryOperator<T, U, R>(
   let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, rhs),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, rhs),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -201,7 +199,8 @@ private func _callBinaryOperator<T, U, R>(
 @_disfavoredOverload
 public func __checkFunctionCall<T, each U>(
   _ lhs: T, calling functionCall: (T, repeat each U) throws -> Bool, _ arguments: repeat each U,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -209,8 +208,9 @@ public func __checkFunctionCall<T, each U>(
   let condition = try functionCall(lhs, repeat each arguments)
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, repeat each arguments),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, repeat each arguments),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -229,7 +229,8 @@ public func __checkFunctionCall<T, each U>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0>(
   _ lhs: T, calling functionCall: (T, Arg0) throws -> Bool, _ argument0: Arg0,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -237,8 +238,9 @@ public func __checkFunctionCall<T, Arg0>(
   let condition = try functionCall(lhs, argument0)
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, argument0),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, argument0),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -256,7 +258,8 @@ public func __checkFunctionCall<T, Arg0>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1) throws -> Bool, _ argument0: Arg0, _ argument1: Arg1,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -264,8 +267,9 @@ public func __checkFunctionCall<T, Arg0, Arg1>(
   let condition = try functionCall(lhs, argument0, argument1)
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, argument0, argument1),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, argument0, argument1),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -283,7 +287,8 @@ public func __checkFunctionCall<T, Arg0, Arg1>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1, Arg2>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2) throws -> Bool, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -291,8 +296,9 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2>(
   let condition = try functionCall(lhs, argument0, argument1, argument2)
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, argument0, argument1, argument2),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, argument0, argument1, argument2),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -310,7 +316,8 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2, Arg3) throws -> Bool, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2, _ argument3: Arg3,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -318,8 +325,9 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3>(
   let condition = try functionCall(lhs, argument0, argument1, argument2, argument3)
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, argument0, argument1, argument2, argument3),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, argument0, argument1, argument2, argument3),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -340,7 +348,8 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkInoutFunctionCall<T, /*each*/ U>(
   _ lhs: T, calling functionCall: (T, inout /*repeat each*/ U) throws -> Bool, _ arguments: inout /*repeat each*/ U,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -348,8 +357,9 @@ public func __checkInoutFunctionCall<T, /*each*/ U>(
   let condition = try functionCall(lhs, /*repeat each*/ &arguments)
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, /*repeat each*/ arguments),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, /*repeat each*/ arguments),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -371,7 +381,8 @@ public func __checkInoutFunctionCall<T, /*each*/ U>(
 @_disfavoredOverload
 public func __checkFunctionCall<T, each U, R>(
   _ lhs: T, calling functionCall: (T, repeat each U) throws -> R?, _ arguments: repeat each U,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -379,8 +390,9 @@ public func __checkFunctionCall<T, each U, R>(
   let optionalValue = try functionCall(lhs, repeat each arguments)
   return __checkValue(
     optionalValue,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(optionalValue, lhs, repeat each arguments),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(optionalValue, lhs, repeat each arguments),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -399,7 +411,8 @@ public func __checkFunctionCall<T, each U, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, R>(
   _ lhs: T, calling functionCall: (T, Arg0) throws -> R?, _ argument0: Arg0,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -407,8 +420,9 @@ public func __checkFunctionCall<T, Arg0, R>(
   let optionalValue = try functionCall(lhs, argument0)
   return __checkValue(
     optionalValue,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(optionalValue, lhs, argument0),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(optionalValue, lhs, argument0),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -426,7 +440,8 @@ public func __checkFunctionCall<T, Arg0, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1, R>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1) throws -> R?, _ argument0: Arg0, _ argument1: Arg1,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -434,8 +449,9 @@ public func __checkFunctionCall<T, Arg0, Arg1, R>(
   let optionalValue = try functionCall(lhs, argument0, argument1)
   return __checkValue(
     optionalValue,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(optionalValue, lhs, argument0, argument1),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(optionalValue, lhs, argument0, argument1),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -453,7 +469,8 @@ public func __checkFunctionCall<T, Arg0, Arg1, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1, Arg2, R>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2) throws -> R?, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -461,8 +478,9 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2, R>(
   let optionalValue = try functionCall(lhs, argument0, argument1, argument2)
   return __checkValue(
     optionalValue,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(optionalValue, lhs, argument0, argument1, argument2),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(optionalValue, lhs, argument0, argument1, argument2),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -480,7 +498,8 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3, R>(
   _ lhs: T, calling functionCall: (T, Arg0, Arg1, Arg2, Arg3) throws -> R?, _ argument0: Arg0, _ argument1: Arg1, _ argument2: Arg2, _ argument3: Arg3,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -488,8 +507,9 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3, R>(
   let optionalValue = try functionCall(lhs, argument0, argument1, argument2, argument3)
   return __checkValue(
     optionalValue,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(optionalValue, lhs, argument0, argument1, argument2, argument3),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(optionalValue, lhs, argument0, argument1, argument2, argument3),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -511,7 +531,8 @@ public func __checkFunctionCall<T, Arg0, Arg1, Arg2, Arg3, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkInoutFunctionCall<T, /*each*/ U, R>(
   _ lhs: T, calling functionCall: (T, inout /*repeat each*/ U) throws -> R?, _ arguments: inout /*repeat each*/ U,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -519,8 +540,9 @@ public func __checkInoutFunctionCall<T, /*each*/ U, R>(
   let optionalValue = try functionCall(lhs, /*repeat each*/ &arguments)
   return __checkValue(
     optionalValue,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(optionalValue, lhs, /*repeat each*/ arguments),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(optionalValue, lhs, /*repeat each*/ arguments),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -542,7 +564,8 @@ public func __checkInoutFunctionCall<T, /*each*/ U, R>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkPropertyAccess<T>(
   _ lhs: T, getting memberAccess: (T) -> Bool,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -550,8 +573,9 @@ public func __checkPropertyAccess<T>(
   let condition = memberAccess(lhs)
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, condition),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, condition),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -572,7 +596,8 @@ public func __checkPropertyAccess<T>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkPropertyAccess<T, U>(
   _ lhs: T, getting memberAccess: (T) -> U?,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -580,8 +605,9 @@ public func __checkPropertyAccess<T, U>(
   let optionalValue = memberAccess(lhs)
   return __checkValue(
     optionalValue,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(optionalValue, lhs, optionalValue as U??),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(optionalValue, lhs, optionalValue as U??),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -600,7 +626,8 @@ public func __checkPropertyAccess<T, U>(
 ///   `#require()` macros. Do not call it directly.
 @_disfavoredOverload public func __checkBinaryOperation<T>(
   _ lhs: T, _ op: (T, () -> T) -> Bool, _ rhs: @autoclosure () -> T,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -631,8 +658,9 @@ public func __checkPropertyAccess<T, U>(
 
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, rhs),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, rhs),
     difference: difference(),
     comments: comments(),
     isRequired: isRequired,
@@ -651,7 +679,8 @@ public func __checkPropertyAccess<T, U>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkBinaryOperation(
   _ lhs: String, _ op: (String, () -> String) -> Bool, _ rhs: @autoclosure () -> String,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -659,8 +688,9 @@ public func __checkBinaryOperation(
   let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, rhs),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, rhs),
     difference: nil,
     comments: comments(),
     isRequired: isRequired,
@@ -679,7 +709,8 @@ public func __checkBinaryOperation(
 ///   `#require()` macros. Do not call it directly.
 public func __checkBinaryOperation<T, U>(
   _ lhs: T, _ op: (T, () -> U) -> Bool, _ rhs: @autoclosure () -> U,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -687,8 +718,9 @@ public func __checkBinaryOperation<T, U>(
   let (condition, rhs) = _callBinaryOperator(lhs, op, rhs)
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, lhs, rhs),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, lhs, rhs),
     difference: nil,
     comments: comments(),
     isRequired: isRequired,
@@ -706,7 +738,8 @@ public func __checkBinaryOperation<T, U>(
 public func __checkCast<V, T>(
   _ value: V,
   is _: T.Type,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -714,8 +747,9 @@ public func __checkCast<V, T>(
   let condition = value is T
   return __checkValue(
     condition,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(condition, value, type(of: value as Any)),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(condition, value, type(of: value as Any)),
     difference: nil,
     comments: comments(),
     isRequired: isRequired,
@@ -739,7 +773,8 @@ public func __checkCast<V, T>(
 ///   `#require()` macros. Do not call it directly.
 public func __checkValue<T>(
   _ optionalValue: T?,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   expressionWithCapturedRuntimeValues: @autoclosure () -> __Expression? = nil,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
@@ -753,8 +788,9 @@ public func __checkValue<T>(
   // (`nil`) that will be captured.
   __checkValue(
     optionalValue != nil,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: (expressionWithCapturedRuntimeValues() ?? expression).capturingRuntimeValues(optionalValue as T??),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: (expressionWithCapturedRuntimeValues() ?? expression()).capturingRuntimeValues(optionalValue as T??),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -779,7 +815,8 @@ public func __checkValue<T>(
 ///   `#require()` macros. Do not call it directly.
 @_disfavoredOverload public func __checkBinaryOperation<T>(
   _ lhs: T?, _ op: (T?, () -> T?) -> T?, _ rhs: @autoclosure () -> T?,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -787,8 +824,9 @@ public func __checkValue<T>(
   let (optionalValue, rhs) = _callBinaryOperator(lhs, op, rhs)
   return __checkValue(
     optionalValue,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(optionalValue, lhs as T??, rhs as T??),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(optionalValue, lhs as T??, rhs as T??),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -805,7 +843,8 @@ public func __checkValue<T>(
 public func __checkCast<V, T>(
   _ value: V,
   as _: T.Type,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
+  negationCount: Int = 0,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -816,8 +855,9 @@ public func __checkCast<V, T>(
   let optionalValue = value as? T
   return __checkValue(
     optionalValue != nil,
-    expression: expression,
-    expressionWithCapturedRuntimeValues: expression.capturingRuntimeValues(optionalValue, value, type(of: value as Any)),
+    expression: expression(),
+    negationCount: negationCount,
+    expressionWithCapturedRuntimeValues: expression().capturingRuntimeValues(optionalValue, value, type(of: value as Any)),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -839,7 +879,7 @@ public func __checkCast<V, T>(
 public func __checkClosureCall<E>(
   throws errorType: E.Type,
   performing body: () throws -> some Any,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -848,7 +888,7 @@ public func __checkClosureCall<E>(
     __checkClosureCall(
       throws: Never.self,
       performing: body,
-      expression: expression,
+      expression: expression(),
       comments: comments(),
       isRequired: isRequired,
       sourceLocation: sourceLocation
@@ -858,7 +898,7 @@ public func __checkClosureCall<E>(
       performing: body,
       throws: { $0 is E },
       mismatchExplanation: { "expected error of type \(errorType), but \(_description(of: $0)) was thrown instead" },
-      expression: expression,
+      expression: expression(),
       comments: comments(),
       isRequired: isRequired,
       sourceLocation: sourceLocation
@@ -877,7 +917,7 @@ public func __checkClosureCall<E>(
 public func __checkClosureCall<E>(
   throws errorType: E.Type,
   performing body: () async throws -> sending some Any,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
@@ -887,7 +927,7 @@ public func __checkClosureCall<E>(
     await __checkClosureCall(
       throws: Never.self,
       performing: body,
-      expression: expression,
+      expression: expression(),
       comments: comments(),
       isRequired: isRequired,
       isolation: isolation,
@@ -898,7 +938,7 @@ public func __checkClosureCall<E>(
       performing: body,
       throws: { $0 is E },
       mismatchExplanation: { "expected error of type \(errorType), but \(_description(of: $0)) was thrown instead" },
-      expression: expression,
+      expression: expression(),
       comments: comments(),
       isRequired: isRequired,
       isolation: isolation,
@@ -920,7 +960,7 @@ public func __checkClosureCall<E>(
 public func __checkClosureCall(
   throws _: Never.Type,
   performing body: () throws -> some Any,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -936,7 +976,7 @@ public func __checkClosureCall(
 
   return __checkValue(
     success,
-    expression: expression,
+    expression: expression(),
     mismatchedErrorDescription: mismatchExplanationValue,
     comments: comments(),
     isRequired: isRequired,
@@ -956,7 +996,7 @@ public func __checkClosureCall(
 public func __checkClosureCall(
   throws _: Never.Type,
   performing body: () async throws -> sending some Any,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
@@ -973,7 +1013,7 @@ public func __checkClosureCall(
 
   return __checkValue(
     success,
-    expression: expression,
+    expression: expression(),
     mismatchedErrorDescription: mismatchExplanationValue,
     comments: comments(),
     isRequired: isRequired,
@@ -993,7 +1033,7 @@ public func __checkClosureCall(
 public func __checkClosureCall<E>(
   throws error: E,
   performing body: () throws -> some Any,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -1002,7 +1042,7 @@ public func __checkClosureCall<E>(
     performing: body,
     throws: { true == (($0 as? E) == error) },
     mismatchExplanation: { "expected error \(_description(of: error)), but \(_description(of: $0)) was thrown instead" },
-    expression: expression,
+    expression: expression(),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -1019,7 +1059,7 @@ public func __checkClosureCall<E>(
 public func __checkClosureCall<E>(
   throws error: E,
   performing body: () async throws -> sending some Any,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
@@ -1029,7 +1069,7 @@ public func __checkClosureCall<E>(
     performing: body,
     throws: { true == (($0 as? E) == error) },
     mismatchExplanation: { "expected error \(_description(of: error)), but \(_description(of: $0)) was thrown instead" },
-    expression: expression,
+    expression: expression(),
     comments: comments(),
     isRequired: isRequired,
     isolation: isolation,
@@ -1049,7 +1089,7 @@ public func __checkClosureCall<R>(
   performing body: () throws -> R,
   throws errorMatcher: (any Error) throws -> Bool,
   mismatchExplanation: ((any Error) -> String)? = nil,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   sourceLocation: SourceLocation
@@ -1068,7 +1108,7 @@ public func __checkClosureCall<R>(
     mismatchExplanationValue = explanation
   } catch {
     caughtError = error
-    expression = expression.capturingRuntimeValues(error)
+    expression = { expression().capturingRuntimeValues(error) }
     let secondError = Issue.withErrorRecording(at: sourceLocation) {
       errorMatches = try errorMatcher(error)
     }
@@ -1081,7 +1121,7 @@ public func __checkClosureCall<R>(
 
   return __checkValue(
     errorMatches,
-    expression: expression,
+    expression: expression(),
     mismatchedErrorDescription: mismatchExplanationValue,
     comments: comments(),
     isRequired: isRequired,
@@ -1099,7 +1139,7 @@ public func __checkClosureCall<R>(
   performing body: () async throws -> sending R,
   throws errorMatcher: (any Error) async throws -> Bool,
   mismatchExplanation: ((any Error) -> String)? = nil,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
@@ -1119,7 +1159,7 @@ public func __checkClosureCall<R>(
     mismatchExplanationValue = explanation
   } catch {
     caughtError = error
-    expression = expression.capturingRuntimeValues(error)
+    expression = { expression().capturingRuntimeValues(error) }
     let secondError = await Issue.withErrorRecording(at: sourceLocation) {
       errorMatches = try await errorMatcher(error)
     }
@@ -1132,7 +1172,7 @@ public func __checkClosureCall<R>(
 
   return __checkValue(
     errorMatches,
-    expression: expression,
+    expression: expression(),
     mismatchedErrorDescription: mismatchExplanationValue,
     comments: comments(),
     isRequired: isRequired,
@@ -1156,7 +1196,7 @@ public func __checkClosureCall(
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
   performing _: @convention(c) () -> Void,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
@@ -1167,7 +1207,7 @@ public func __checkClosureCall(
     encodingCapturedValues: [],
     processExitsWith: expectedExitCondition,
     observing: observedValues,
-    expression: expression,
+    expression: expression(),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation
@@ -1188,7 +1228,7 @@ public func __checkClosureCall<each T>(
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
   performing _: @convention(c) () -> Void,
-  expression: __Expression,
+  expression: @autoclosure () -> __Expression,
   comments: @autoclosure () -> [Comment],
   isRequired: Bool,
   isolation: isolated (any Actor)? = #isolation,
@@ -1199,7 +1239,7 @@ public func __checkClosureCall<each T>(
     encodingCapturedValues: Array(repeat each capturedValues),
     processExitsWith: expectedExitCondition,
     observing: observedValues,
-    expression: expression,
+    expression: expression(),
     comments: comments(),
     isRequired: isRequired,
     sourceLocation: sourceLocation

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -151,6 +151,9 @@ extension ConditionMacro {
         }
 
         expandedFunctionName = conditionArgument.expandedFunctionName
+        if conditionArgument.negationCount > 0 {
+          checkArguments.append(Argument(label: "negationCount", expression: IntegerLiteralExprSyntax(conditionArgument.negationCount)))
+        }
       }
 
       // Capture any comments as well -- either in source, preceding the

--- a/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
+++ b/Sources/TestingMacros/Support/ConditionArgumentParsing.swift
@@ -27,6 +27,9 @@ struct Condition {
   /// the testing library's `__Expression` type.
   var expression: ExprSyntax
 
+  /// How many negation operators were applied to the overall expression.
+  var negationCount = 0
+
   init(_ expandedFunctionName: String, arguments: [Argument], expression: ExprSyntax) {
     self.expandedFunctionName = .identifier(expandedFunctionName)
     self.arguments = arguments
@@ -455,6 +458,7 @@ private func _parseCondition(from expr: MemberAccessExprSyntax, for macro: some 
 private func _parseCondition(negating expr: ExprSyntax, isParenthetical: Bool, for macro: some FreestandingMacroExpansionSyntax, in context: some MacroExpansionContext) -> Condition {
   var result = _parseCondition(from: expr, for: macro, in: context)
   result.expression = createExpressionExprForNegation(of: result.expression, isParenthetical: isParenthetical)
+  result.negationCount += 1
   return result
 }
 

--- a/Tests/TestingMacrosTests/ConditionMacroTests.swift
+++ b/Tests/TestingMacrosTests/ConditionMacroTests.swift
@@ -37,7 +37,7 @@ struct ConditionMacroTests {
       ##"#expect("a" == "b")"##:
         ##"Testing.__checkBinaryOperation("a", { $0 == $1() }, "b", expression: .__fromBinaryOperation(.__fromStringLiteral(#""a""#, "a"), "==", .__fromStringLiteral(#""b""#, "b")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()"##,
       ##"#expect(!Bool.random())"##:
-        ##"Testing.__checkFunctionCall(Bool.self, calling: { $0.random() }, expression: .__fromNegation(.__fromFunctionCall(.__fromSyntaxNode("Bool"), "random"), false), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()"##,
+        ##"Testing.__checkFunctionCall(Bool.self, calling: { $0.random() }, expression: .__fromNegation(.__fromFunctionCall(.__fromSyntaxNode("Bool"), "random"), false), negationCount: 1, comments: [], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()"##,
       ##"#expect((true && false))"##:
         ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, false, expression: .__fromBinaryOperation(.__fromSyntaxNode("true"), "&&", .__fromSyntaxNode("false")), comments: [], isRequired: false, sourceLocation: Testing.SourceLocation.__here()).__expected()"##,
       ##"#expect(try x())"##:
@@ -117,7 +117,7 @@ struct ConditionMacroTests {
       ##"#require("a" == "b")"##:
         ##"Testing.__checkBinaryOperation("a", { $0 == $1() }, "b", expression: .__fromBinaryOperation(.__fromStringLiteral(#""a""#, "a"), "==", .__fromStringLiteral(#""b""#, "b")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation.__here()).__required()"##,
       ##"#require(!Bool.random())"##:
-        ##"Testing.__checkFunctionCall(Bool.self, calling: { $0.random() }, expression: .__fromNegation(.__fromFunctionCall(.__fromSyntaxNode("Bool"), "random"), false), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation.__here()).__required()"##,
+        ##"Testing.__checkFunctionCall(Bool.self, calling: { $0.random() }, expression: .__fromNegation(.__fromFunctionCall(.__fromSyntaxNode("Bool"), "random"), false), negationCount: 1, comments: [], isRequired: true, sourceLocation: Testing.SourceLocation.__here()).__required()"##,
       ##"#require((true && false))"##:
         ##"Testing.__checkBinaryOperation(true, { $0 && $1() }, false, expression: .__fromBinaryOperation(.__fromSyntaxNode("true"), "&&", .__fromSyntaxNode("false")), comments: [], isRequired: true, sourceLocation: Testing.SourceLocation.__here()).__required()"##,
       ##"#require(try x())"##:


### PR DESCRIPTION
This PR makes the `expression` argument of the internal `__check()` function family an autoclosure that we only evaluate on expectation failure. This saves us the cost of allocating these values. For tests that heavily rely on `#expect()` (in the hundreds of thousands of invocations!), this has a measurable impact on test time.

The remaining time spent in a successful call to `#expect()` outside the test code itself is dominated by unspecialized generics overhead, which we can't realistically eliminate at our layer. The compiler team will need to look into that separately.

### Metrics

Tested on an Ubuntu 24.04 VM with the latest Swift nightly toolchain (Swift 1f6442f1d1fcbb7 + Swift Testing 2171d0caab16414) and with a toolchain containing this PR built via CI command (Swift 202b1eab5ef91b2 + Swift Testing a4c97b3e3d4d796).

Built and ran the tests in the attached Swift package using `swift test`. The target tests were built without optimizations. 📎 [testing-perf-demo.tgz](https://github.com/user-attachments/files/31043475/testing-perf-demo.tgz)

| | Main Branch | With Patch | Difference |
|-|-:|-:|-|
| Control Group (`fast()`) | 0.097s | 0.097s | None[^really] |
| Run 1 | 0.779s | 0.348s | |
| Run 2 | 0.767s | 0.345s | |
| Run 3 | 0.769s | 0.357s | |
| Average of runs | 0.772s | 0.350s | 2.2x as fast |

[^really]: Yes, I really got the same result.

The remaining time appears to be dominated by Swift generics code in the runtime. At our layer, we cannot realistically optimize these calls away.

Resolves rdar://184618689.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
