### PR TITLE
Use Debian 12 in CI instead of Fedora 41.

### DIFF
--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-main"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "debian12", "ubi10"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "debian12"]'
       linux_static_sdk_versions: '["nightly-main"]'
       windows_swift_versions: '["nightly-main"]'
       enable_macos_checks: true

--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-main"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "fedora39"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "debian12", "ubi10"]'
       linux_static_sdk_versions: '["nightly-main"]'
       windows_swift_versions: '["nightly-main"]'
       enable_macos_checks: true

--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-main"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "fedora41"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "fedora39"]'
       linux_static_sdk_versions: '["nightly-main"]'
       windows_swift_versions: '["nightly-main"]'
       enable_macos_checks: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-6.4.x"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "debian12", "ubi10"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "debian12"]'
       linux_static_sdk_versions: '["nightly-6.4.x"]'
       windows_swift_versions: '["nightly-6.4.x"]'
       enable_macos_checks: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-6.4.x"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "fedora39"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "debian12", "ubi10"]'
       linux_static_sdk_versions: '["nightly-6.4.x"]'
       windows_swift_versions: '["nightly-6.4.x"]'
       enable_macos_checks: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-6.4.x"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "fedora41"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "fedora39"]'
       linux_static_sdk_versions: '["nightly-6.4.x"]'
       windows_swift_versions: '["nightly-6.4.x"]'
       enable_macos_checks: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "fedora41"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "fedora39"]'
       linux_static_sdk_versions: '["nightly-main", "nightly-6.4.x"]'
       windows_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       enable_macos_checks: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "fedora39"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "debian12", "ubi10"]'
       linux_static_sdk_versions: '["nightly-main", "nightly-6.4.x"]'
       windows_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       enable_macos_checks: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "debian12", "ubi10"]'
+      linux_os_versions: '["jammy", "amazonlinux2023", "debian12"]'
       linux_static_sdk_versions: '["nightly-main", "nightly-6.4.x"]'
       windows_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       enable_macos_checks: true


### PR DESCRIPTION
We aren't building Swift 6.4 toolchains for Fedora 41 at this time, which is causing one of the Wasm jobs to fail. We don't have a separate host OS matrix for Wasm jobs, so just ~~downgrade to Fedora 39~~ switch to Debian 12.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
