### PR TITLE
Expose as tools SPI an `ABI.Version.eventHandler()` variant that produces JSON.

### DIFF
--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -10,23 +10,9 @@
 
 #if !SWT_NO_ABI_JSON_SCHEMA
 extension ABI.Version {
-  /// Create an event handler that encodes instances of ``Event`` as instances
-  /// of ``ABI/Record`` and forwards them to a handler function.
-  ///
-  /// - Parameters:
-  ///   - recordHandler: The record handler to forward events to.
-  ///
-  /// - Returns: An event handler.
-  ///
-  /// You can use this event handler with ``Configuration/eventHandler`` to
-  /// automatically transform instances of ``Event`` to ``ABI/Record``.
   public static func eventHandler(
     forwardingTo recordHandler: @escaping @Sendable (_ record: ABI.Record<Self>) -> Void
   ) -> Event.Handler {
-#if !SWT_NO_SNAPSHOT_TYPES && DEBUG
-    precondition(self != ABI.Xcode16.self, "Attempted to create an ABI.Record-generating event handler for the Xcode 16 compatibility path.")
-#endif
-
     var humanReadableOutputRecorder: Event.HumanReadableOutputRecorder?
     if alwaysEncodeMessagesField {
       humanReadableOutputRecorder = Event.HumanReadableOutputRecorder()
@@ -49,7 +35,7 @@ extension ABI.Version {
     }
   }
 
-  static func eventHandler(
+  public static func eventHandler(
     encodeAsJSONLines: Bool,
     forwardingTo recordHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
   ) -> Event.Handler {
@@ -71,6 +57,12 @@ extension ABI.Version {
 // MARK: - Xcode 16 compatibility
 
 extension ABI.Xcode16 {
+  static func eventHandler(
+    forwardingTo recordHandler: @escaping @Sendable (_ record: ABI.Record<Self>) -> Void
+  ) -> Event.Handler {
+    preconditionFailure("Attempted to create an ABI.Record-generating event handler for the Xcode 16 compatibility path.")
+  }
+
   static func eventHandler(
     encodeAsJSONLines: Bool,
     forwardingTo recordHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -21,29 +21,47 @@ extension ABI {
   public protocol Version: Sendable {
     /// The numeric representation of this ABI version.
     static var versionNumber: VersionNumber { get }
-  }
 
-  /// A protocol that extends the public ``ABI/Version`` protocol with
-  /// internal-only requirements.
-  protocol _Version: Version {
 #if !SWT_NO_ABI_JSON_SCHEMA
+    /// Create an event handler that encodes instances of ``Event`` as instances
+    /// of ``ABI/Record`` and forwards them to a handler function.
+    ///
+    /// - Parameters:
+    ///   - recordHandler: The record handler to forward events to.
+    ///
+    /// - Returns: An event handler.
+    ///
+    /// You can use this event handler with ``Configuration/eventHandler`` to
+    /// automatically transform instances of ``Event`` to ``ABI/Record``.
+    static func eventHandler(
+      forwardingTo recordHandler: @escaping @Sendable (_ record: ABI.Record<Self>) -> Void
+    ) -> Event.Handler
+
     /// Create an event handler that encodes events as JSON and forwards them to
     /// an ABI-friendly event handler.
     ///
     /// - Parameters:
     ///   - encodeAsJSONLines: Whether or not to ensure JSON passed to
-    ///     `eventHandler` is encoded as JSON Lines (i.e. that it does not
+    ///     `recordHandler` is encoded as JSON Lines (i.e. that it does not
     ///     contain extra newlines.)
-    ///   - eventHandler: The event handler to forward events to.
+    ///   - recordHandler: The event handler to forward events to.
     ///
     /// - Returns: An event handler.
     ///
     /// The resulting event handler outputs data as JSON. For each event handled
     /// by the resulting event handler, a JSON object representing it and its
-    /// associated context is created and is passed to `eventHandler`.
+    /// associated context is created and is passed to `recordHandler`.
+    ///
+    /// If `encodeAsJSONLines` is `true`, the resulting JSON does not include
+    /// any newline characters (not even a trailing newline). If
+    /// `encodeAsJSONLines` is `false`, it is unspecified whether the resulting
+    /// JSON contains newline characters.
+    ///
+    /// You can use this event handler with ``Configuration/eventHandler`` to
+    /// automatically transform instances of ``Event`` to JSON.
     static func eventHandler(
       encodeAsJSONLines: Bool,
-      forwardingTo eventHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
+      forwardingTo recordHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
     ) -> Event.Handler
 #endif
   }
@@ -60,7 +78,7 @@ extension ABI {
   /// - Returns: A type conforming to ``ABI/Version`` that represents the given
   ///   ABI version, or `nil` if no such type exists.
   public static func version(forVersionNumber versionNumber: VersionNumber) -> (any Version.Type)? {
-    _version(forVersionNumber: versionNumber)
+    version(forVersionNumber: versionNumber, givenSwiftCompilerVersion: swiftCompilerVersion)
   }
 
   /// Get the type representing a given ABI version.
@@ -76,10 +94,10 @@ extension ABI {
   ///
   /// - Returns: A type conforming to ``ABI/Version`` that represents the given
   ///   ABI version, or `nil` if no such type exists.
-  static func _version(
+  static func version(
     forVersionNumber versionNumber: VersionNumber,
-    givenSwiftCompilerVersion swiftCompilerVersion: @autoclosure () -> VersionNumber = swiftCompilerVersion
-  ) -> (any _Version.Type)? {
+    givenSwiftCompilerVersion swiftCompilerVersion: @autoclosure () -> VersionNumber
+  ) -> (any Version.Type)? {
     if versionNumber >= ABI.ExperimentalVersion.versionNumber {
       // The experimental ABI version is higher than any real ABI version.
       return ABI.ExperimentalVersion.self
@@ -146,7 +164,7 @@ extension ABI {
   /// `recordJSON`.
   public static func decodeEvent(fromRecordJSON recordJSON: UnsafeRawBufferPointer, in context: inout ABI.Context) -> (event: Event, context: Event.Context)? {
     guard let versionNumber = try? VersionNumber(fromRecordJSON: recordJSON),
-          let abi = _version(forVersionNumber: versionNumber) else {
+          let abi = version(forVersionNumber: versionNumber) else {
       return nil
     }
     return abi.decodeEvent(fromRecordJSON: recordJSON, in: &context)
@@ -245,7 +263,7 @@ extension ABI {
   /// A namespace and version type for Xcode&nbsp;16 compatibility.
   ///
   /// - Warning: This type will be removed in a future update.
-  enum Xcode16: Sendable, Version, _Version {
+  enum Xcode16: Sendable, Version {
     static var versionNumber: VersionNumber {
       VersionNumber(-1, 0)
     }
@@ -253,7 +271,7 @@ extension ABI {
 #endif
 
   /// A namespace and type for ABI version 0 symbols.
-  public enum v0: Sendable, Version, _Version {
+  public enum v0: Sendable, Version {
     public static var versionNumber: VersionNumber {
       VersionNumber(0, 0)
     }
@@ -265,7 +283,7 @@ extension ABI {
   ///   @Available(Swift, introduced: 6.3)
   ///   @Available(Xcode, introduced: 26.4)
   /// }
-  public enum v6_3: Sendable, Version, _Version {
+  public enum v6_3: Sendable, Version {
     public static var versionNumber: VersionNumber {
       VersionNumber(6, 3)
     }
@@ -277,7 +295,7 @@ extension ABI {
   ///   @Available(Swift, introduced: 6.4)
   ///   @Available(Xcode, introduced: 27.0)
   /// }
-  public enum v6_4: Sendable, Version, _Version {
+  public enum v6_4: Sendable, Version {
     public static var versionNumber: VersionNumber {
       VersionNumber(6, 4)
     }
@@ -288,7 +306,7 @@ extension ABI {
   /// @Metadata {
   ///   @Available(Swift, introduced: 6.5)
   /// }
-  public enum v6_5: Sendable, Version, _Version {
+  public enum v6_5: Sendable, Version {
     public static var versionNumber: VersionNumber {
       VersionNumber(6, 5)
     }
@@ -297,7 +315,7 @@ extension ABI {
   /// A namespace and type representing the ABI version whose symbols are
   /// considered experimental.
   @_spi(Experimental)
-  public enum ExperimentalVersion: Sendable, Version, _Version {
+  public enum ExperimentalVersion: Sendable, Version {
     public static var versionNumber: VersionNumber {
       VersionNumber(99, 0)
     }

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -805,7 +805,7 @@ func eventHandlerForStreamingEvents(
   forwardingTo targetEventHandler: @escaping @Sendable (UnsafeRawBufferPointer) -> Void
 ) throws -> Event.Handler {
   let versionNumber = versionNumber ?? ABI.CurrentVersion.versionNumber
-  guard let abi = ABI._version(forVersionNumber: versionNumber) else {
+  guard let abi = ABI.version(forVersionNumber: versionNumber) else {
     throw _EntryPointError.invalidArgument("--event-stream-version", value: "\(versionNumber)")
   }
   return abi.eventHandler(encodeAsJSONLines: encodeAsJSONLines, forwardingTo: targetEventHandler)

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -452,7 +452,7 @@ struct SwiftPMTests {
     let currentVersionNumber = ABI.CurrentVersion.versionNumber
     var newerVersionNumber = currentVersionNumber
     newerVersionNumber.patchComponent += 1
-    let version = try #require(ABI._version(forVersionNumber: newerVersionNumber, givenSwiftCompilerVersion: newerVersionNumber))
+    let version = try #require(ABI.version(forVersionNumber: newerVersionNumber, givenSwiftCompilerVersion: newerVersionNumber))
     #expect(version.versionNumber == currentVersionNumber)
   }
 


### PR DESCRIPTION
This PR adds a convenience function that produces an event stream handler that yields JSON directly. It's the moral equivalent of:

```swift
let eventHandler = ABI.___.eventHandler { record in
  guard let json = try? JSONEncoder().encode(record) else {
    // failed to encode (unexpected)
  }
  // write JSON somewhere
}
```

And has a toggle for JSON Lines output specifically.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
