### PR TITLE
Revert "Add more Linux distros to our CI workflows."

### DIFF
--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-main"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "fedora41"]'
+      linux_os_versions: '["jammy"]'
       linux_static_sdk_versions: '["nightly-main"]'
       windows_swift_versions: '["nightly-main"]'
       enable_macos_checks: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-6.4.x"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "fedora41"]'
+      linux_os_versions: '["jammy"]'
       linux_static_sdk_versions: '["nightly-6.4.x"]'
       windows_swift_versions: '["nightly-6.4.x"]'
       enable_macos_checks: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.13
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.4.x"]'
-      linux_os_versions: '["jammy", "amazonlinux2023", "fedora41"]'
+      linux_os_versions: '["jammy"]'
       linux_static_sdk_versions: '["nightly-main", "nightly-6.4.x"]'
       windows_swift_versions: '["nightly-main", "nightly-6.4.x"]'
       enable_macos_checks: true


### PR DESCRIPTION
Reverts swiftlang/swift-testing#1795

Reverting temporarily as it's interfering with our Wasm builds and the Linux toolchains (other than Ubuntu) are still failing right now.