### PR TITLE
Fix missing docs text for some unsupported confirmation() overloads

### DIFF
--- a/Sources/Testing/Issues/Confirmation.swift
+++ b/Sources/Testing/Issues/Confirmation.swift
@@ -215,7 +215,8 @@ public func confirmation<R>(
 /// that handles the partial-range-through operator (`...n`).
 ///
 /// This overload is necessary because the lower bound of `PartialRangeThrough`
-/// is ambiguous: does it start at `0` or `1`? Test authors should specify a
+/// is ambiguous: does it start at `0` or `1`? Test authors should specify an
+/// explicit lower bound.
 @available(*, unavailable, message: "Range expression '...n' is ambiguous without an explicit lower bound")
 public func confirmation<R>(
   _ comment: Comment? = nil,
@@ -231,7 +232,8 @@ public func confirmation<R>(
 /// that handles the partial-range-up-to operator (`..<n`).
 ///
 /// This overload is necessary because the lower bound of `PartialRangeUpTo` is
-/// ambiguous: does it start at `0` or `1`? Test authors should specify a
+/// ambiguous: does it start at `0` or `1`? Test authors should specify an
+/// explicit lower bound.
 @available(*, unavailable, message: "Range expression '..<n' is ambiguous without an explicit lower bound")
 public func confirmation<R>(
   _ comment: Comment? = nil,


### PR DESCRIPTION
### Motivation:

Docs for some overloads are missing a few words, so fill them in here.

### Modifications:

Update docs for confirmation() overloads.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
