### PR TITLE
[linux] better construction of `setrlimit`’s first parameter

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -232,7 +232,7 @@ extension ExitTest {
     // a pipe instead of a regular file; that gets us our performance back.
     // SEE: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/coredump.c#n610
     var rl = rlimit(rlim_cur: 1, rlim_max: 1)
-    _ = setrlimit(CInt(RLIMIT_CORE.rawValue), &rl)
+    _ = setrlimit(__rlimit_resource_t(RLIMIT_CORE.rawValue), &rl)
 #elseif os(FreeBSD) || os(OpenBSD)
     // As with Linux, disable the generation core files. The BSDs do not, as far
     // as I can tell, special-case RLIMIT_CORE=1.

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -232,7 +232,7 @@ extension ExitTest {
     // a pipe instead of a regular file; that gets us our performance back.
     // SEE: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/fs/coredump.c#n610
     var rl = rlimit(rlim_cur: 1, rlim_max: 1)
-    _ = setrlimit(__rlimit_resource_t(RLIMIT_CORE.rawValue), &rl)
+    _ = setrlimit(.init(RLIMIT_CORE.rawValue), &rl)
 #elseif os(FreeBSD) || os(OpenBSD)
     // As with Linux, disable the generation core files. The BSDs do not, as far
     // as I can tell, special-case RLIMIT_CORE=1.


### PR DESCRIPTION
For Linux, construct `setrlimit`'s first parameter using its inferred type rather than explicitly using `CInt`.

### Motivation:

Glibc declares the typedef as 'int' normally, but as an enumeration under '_GNU_SOURCE’. Spelling the conversion using the typedef’s name allows this call to compile either way.

### Modifications:

Construct the parameter using an unlabeled initializer, using type inference.
The unlabeled initializer lets the compiler infer the correct type.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [n/a] If public symbols are renamed or modified, DocC references should be updated.
