### PR TITLE
Support non-finite floats in exit test captures

### DIFF
--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -1118,7 +1118,7 @@ extension ExitTest {
           try JSON.decode(
             type,
             from: capturedValueJSON,
-            allowNonFiniteFloatingPointValues: true
+            userInfo: [._allowNonFiniteFloatingPointValuesUserInfoKey: true]
           )
         }
       }
@@ -1147,7 +1147,7 @@ extension ExitTest {
     for capturedValue in capturedValues {
       try JSON.withEncoding(
         of: capturedValue.wrappedValue!,
-        allowNonFiniteFloatingPointValues: true
+        userInfo: [._allowNonFiniteFloatingPointValuesUserInfoKey: true]
       ) { capturedValueJSON in
         try JSON.asJSONLine(capturedValueJSON, body)
       }

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -1118,7 +1118,7 @@ extension ExitTest {
           try JSON.decode(
             type,
             from: capturedValueJSON,
-            userInfo: [._allowNonFiniteFloatingPointValuesUserInfoKey: true]
+            userInfo: [.allowNonFiniteFloatingPointValuesUserInfoKey: true]
           )
         }
       }
@@ -1147,7 +1147,7 @@ extension ExitTest {
     for capturedValue in capturedValues {
       try JSON.withEncoding(
         of: capturedValue.wrappedValue!,
-        userInfo: [._allowNonFiniteFloatingPointValuesUserInfoKey: true]
+        userInfo: [.allowNonFiniteFloatingPointValuesUserInfoKey: true]
       ) { capturedValueJSON in
         try JSON.asJSONLine(capturedValueJSON, body)
       }

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -1115,7 +1115,11 @@ extension ExitTest {
 
       func open<T>(_ type: T.Type) throws -> T where T: Codable & Sendable {
         return try capturedValueJSON.withUnsafeBytes { capturedValueJSON in
-          try JSON.decode(type, from: capturedValueJSON)
+          try JSON.decode(
+            type,
+            from: capturedValueJSON,
+            allowNonFiniteFloatingPointValues: true
+          )
         }
       }
       capturedValue.wrappedValue = try open(capturedValue.typeOfWrappedValue)
@@ -1141,7 +1145,10 @@ extension ExitTest {
   /// configurations is undefined.
   private borrowing func _withEncodedCapturedValuesForEntryPoint(_ body: (UnsafeRawBufferPointer) throws -> Void) throws -> Void {
     for capturedValue in capturedValues {
-      try JSON.withEncoding(of: capturedValue.wrappedValue!) { capturedValueJSON in
+      try JSON.withEncoding(
+        of: capturedValue.wrappedValue!,
+        allowNonFiniteFloatingPointValues: true
+      ) { capturedValueJSON in
         try JSON.asJSONLine(capturedValueJSON, body)
       }
     }

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -25,8 +25,8 @@ enum JSON {
   private static let _prettyPrintingEnabled = Environment.flag(named: "SWT_PRETTY_PRINT_JSON") == true
 
   /// String representations of non-finite floating-point values.
-  private static let _positiveInfinityString = "INF"
-  private static let _negativeInfinityString = "-INF"
+  private static let _positiveInfinityString = "Infinity"
+  private static let _negativeInfinityString = "-Infinity"
   private static let _nanString = "NaN"
 
   /// Encode a value as JSON.
@@ -34,8 +34,6 @@ enum JSON {
   /// - Parameters:
   ///   - value: The value to encode.
   ///   - userInfo: Any user info to pass into the encoder during encoding.
-  ///   - allowNonFiniteFloatingPointValues: Whether or not non-finite
-  ///     floating-point values can be encoded.
   ///   - body: A function to call.
   ///
   /// - Returns: Whatever is returned by `body`.
@@ -44,12 +42,14 @@ enum JSON {
   static func withEncoding<R>(
     of value: some Encodable,
     userInfo: [CodingUserInfoKey: any Sendable] = [:],
-    allowNonFiniteFloatingPointValues: Bool = false,
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) throws -> R {
     let encoder = JSONEncoder()
 
-    if allowNonFiniteFloatingPointValues {
+    // Set user info keys that clients want to use during encoding.
+    encoder.userInfo.merge(userInfo, uniquingKeysWith: { _, rhs in rhs })
+
+    if encoder.userInfo[._allowNonFiniteFloatingPointValuesUserInfoKey] as? Bool == true {
       encoder.nonConformingFloatEncodingStrategy = .convertToString(
         positiveInfinity: _positiveInfinityString,
         negativeInfinity: _negativeInfinityString,
@@ -63,9 +63,6 @@ enum JSON {
       encoder.outputFormatting.insert(.prettyPrinted)
       encoder.outputFormatting.insert(.withoutEscapingSlashes)
     }
-
-    // Set user info keys that clients want to use during encoding.
-    encoder.userInfo.merge(userInfo, uniquingKeysWith: { _, rhs in rhs})
 
     let data = try encoder.encode(value)
     return try data.withUnsafeBytes(body)
@@ -102,8 +99,7 @@ enum JSON {
   /// - Parameters:
   ///   - type: The type of value to decode.
   ///   - jsonRepresentation: The JSON encoding of the value to decode.
-  ///   - allowNonFiniteFloatingPointValues: Whether or not non-finite
-  ///     floating-point values can be decoded.
+  ///   - userInfo: Any user info to pass into the decoder during decoding.
   ///
   /// - Returns: An instance of `T` decoded from `jsonRepresentation`.
   ///
@@ -111,7 +107,7 @@ enum JSON {
   static func decode<T>(
     _ type: T.Type,
     from jsonRepresentation: UnsafeRawBufferPointer,
-    allowNonFiniteFloatingPointValues: Bool = false
+    userInfo: [CodingUserInfoKey: any Sendable] = [:]
   ) throws -> T where T: Decodable {
     try withExtendedLifetime(jsonRepresentation) {
       let byteCount = jsonRepresentation.count
@@ -125,7 +121,11 @@ enum JSON {
         Data()
       }
       let decoder = JSONDecoder()
-      if allowNonFiniteFloatingPointValues {
+
+      // Set user info keys that clients want to use during decoding.
+      decoder.userInfo.merge(userInfo, uniquingKeysWith: { _, rhs in rhs })
+
+      if decoder.userInfo[._allowNonFiniteFloatingPointValuesUserInfoKey] as? Bool == true {
         decoder.nonConformingFloatDecodingStrategy = .convertFromString(
           positiveInfinity: _positiveInfinityString,
           negativeInfinity: _negativeInfinityString,
@@ -137,3 +137,13 @@ enum JSON {
   }
 #endif
 }
+
+#if !SWT_NO_CODABLE
+extension CodingUserInfoKey {
+  /// A coding user info key whose value is a `Bool` indicating whether or not
+  /// non-finite floating-point values are allowed.
+  static var _allowNonFiniteFloatingPointValuesUserInfoKey: Self {
+    Self(rawValue: "org.swift.testing.coding-user-info-key.allow-non-finite-floating-point-values")!
+  }
+}
+#endif

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -49,7 +49,7 @@ enum JSON {
     // Set user info keys that clients want to use during encoding.
     encoder.userInfo.merge(userInfo, uniquingKeysWith: { _, rhs in rhs })
 
-    if encoder.userInfo[._allowNonFiniteFloatingPointValuesUserInfoKey] as? Bool == true {
+    if encoder.userInfo[.allowNonFiniteFloatingPointValuesUserInfoKey] as? Bool == true {
       encoder.nonConformingFloatEncodingStrategy = .convertToString(
         positiveInfinity: _positiveInfinityString,
         negativeInfinity: _negativeInfinityString,
@@ -125,7 +125,7 @@ enum JSON {
       // Set user info keys that clients want to use during decoding.
       decoder.userInfo.merge(userInfo, uniquingKeysWith: { _, rhs in rhs })
 
-      if decoder.userInfo[._allowNonFiniteFloatingPointValuesUserInfoKey] as? Bool == true {
+      if decoder.userInfo[.allowNonFiniteFloatingPointValuesUserInfoKey] as? Bool == true {
         decoder.nonConformingFloatDecodingStrategy = .convertFromString(
           positiveInfinity: _positiveInfinityString,
           negativeInfinity: _negativeInfinityString,
@@ -142,7 +142,7 @@ enum JSON {
 extension CodingUserInfoKey {
   /// A coding user info key whose value is a `Bool` indicating whether or not
   /// non-finite floating-point values are allowed.
-  static var _allowNonFiniteFloatingPointValuesUserInfoKey: Self {
+  static var allowNonFiniteFloatingPointValuesUserInfoKey: Self {
     Self(rawValue: "org.swift.testing.coding-user-info-key.allow-non-finite-floating-point-values")!
   }
 }

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -24,18 +24,38 @@ enum JSON {
   /// testing library to improve the readability of JSON output.
   private static let _prettyPrintingEnabled = Environment.flag(named: "SWT_PRETTY_PRINT_JSON") == true
 
+  /// String representations of non-finite floating-point values.
+  private static let _positiveInfinityString = "INF"
+  private static let _negativeInfinityString = "-INF"
+  private static let _nanString = "NaN"
+
   /// Encode a value as JSON.
   ///
   /// - Parameters:
   ///   - value: The value to encode.
   ///   - userInfo: Any user info to pass into the encoder during encoding.
+  ///   - allowNonFiniteFloatingPointValues: Whether or not non-finite
+  ///     floating-point values can be encoded.
   ///   - body: A function to call.
   ///
   /// - Returns: Whatever is returned by `body`.
   ///
   /// - Throws: Whatever is thrown by `body` or by the encoding process.
-  static func withEncoding<R>(of value: some Encodable, userInfo: [CodingUserInfoKey: any Sendable] = [:], _ body: (UnsafeRawBufferPointer) throws -> R) throws -> R {
+  static func withEncoding<R>(
+    of value: some Encodable,
+    userInfo: [CodingUserInfoKey: any Sendable] = [:],
+    allowNonFiniteFloatingPointValues: Bool = false,
+    _ body: (UnsafeRawBufferPointer) throws -> R
+  ) throws -> R {
     let encoder = JSONEncoder()
+
+    if allowNonFiniteFloatingPointValues {
+      encoder.nonConformingFloatEncodingStrategy = .convertToString(
+        positiveInfinity: _positiveInfinityString,
+        negativeInfinity: _negativeInfinityString,
+        nan: _nanString
+      )
+    }
 
     // Keys must be sorted to ensure deterministic matching of encoded data.
     encoder.outputFormatting.insert(.sortedKeys)
@@ -82,11 +102,17 @@ enum JSON {
   /// - Parameters:
   ///   - type: The type of value to decode.
   ///   - jsonRepresentation: The JSON encoding of the value to decode.
+  ///   - allowNonFiniteFloatingPointValues: Whether or not non-finite
+  ///     floating-point values can be decoded.
   ///
   /// - Returns: An instance of `T` decoded from `jsonRepresentation`.
   ///
   /// - Throws: Whatever is thrown by the decoding process.
-  static func decode<T>(_ type: T.Type, from jsonRepresentation: UnsafeRawBufferPointer) throws -> T where T: Decodable {
+  static func decode<T>(
+    _ type: T.Type,
+    from jsonRepresentation: UnsafeRawBufferPointer,
+    allowNonFiniteFloatingPointValues: Bool = false
+  ) throws -> T where T: Decodable {
     try withExtendedLifetime(jsonRepresentation) {
       let byteCount = jsonRepresentation.count
       let data = if byteCount > 0 {
@@ -98,7 +124,15 @@ enum JSON {
       } else {
         Data()
       }
-      return try JSONDecoder().decode(type, from: data)
+      let decoder = JSONDecoder()
+      if allowNonFiniteFloatingPointValues {
+        decoder.nonConformingFloatDecodingStrategy = .convertFromString(
+          positiveInfinity: _positiveInfinityString,
+          negativeInfinity: _negativeInfinityString,
+          nan: _nanString
+        )
+      }
+      return try decoder.decode(type, from: data)
     }
   }
 #endif

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -569,6 +569,20 @@ private import _TestingInternals
     }
   }
 
+  @Test("Capture list (non-finite floating-point values)")
+  func captureListWithNonFiniteFloatingPointValues() async {
+    await #expect(processExitsWith: .success) {
+      [
+        positiveInfinity = Double.infinity as Double,
+        negativeInfinity = -Double.infinity as Double,
+        nan = Double.nan as Double,
+      ] in
+      #expect(positiveInfinity == Double.infinity)
+      #expect(negativeInfinity == -Double.infinity)
+      #expect(nan.isNaN)
+    }
+  }
+
   @Test("Capture list (very long encoded form)")
   func longCaptureList() async {
     let count = 1 * 1024 * 1024

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -569,17 +569,24 @@ private import _TestingInternals
     }
   }
 
-  @Test("Capture list (non-finite floating-point values)")
-  func captureListWithNonFiniteFloatingPointValues() async {
+  @Test(
+    "Capture list (non-finite floating-point values)",
+    arguments: [Double.infinity, -Double.infinity, Double.nan]
+  )
+  func captureListWithNonFiniteFloatingPointValues(_ value: Double) async {
+    let expectedIsNaN = value.isNaN
+    let expectedIsNegative = value.sign == .minus
     await #expect(processExitsWith: .success) {
       [
-        positiveInfinity = Double.infinity as Double,
-        negativeInfinity = -Double.infinity as Double,
-        nan = Double.nan as Double,
+        value,
+        expectedIsNaN = expectedIsNaN as Bool,
+        expectedIsNegative = expectedIsNegative as Bool,
       ] in
-      #expect(positiveInfinity == Double.infinity)
-      #expect(negativeInfinity == -Double.infinity)
-      #expect(nan.isNaN)
+      #expect(value.isNaN == expectedIsNaN)
+      if !expectedIsNaN {
+        #expect(value.isInfinite)
+        #expect((value.sign == .minus) == expectedIsNegative)
+      }
     }
   }
 


### PR DESCRIPTION
Allow exit test capture lists to round-trip NaN and positive and negative infinity.

### Motivation:

Exit-test value capturing became available in Swift 6.3. Captured values are JSON-encoded in the parent process and decoded in the subprocess. The default JSON coding strategies reject non-finite floating-point values even though `Float` and `Double` satisfy the `Codable` and `Sendable` requirements for captured values.

Fixes #1836.

### Modifications:

Configure matching non-conforming floating-point encoding and decoding strategies specifically for the exit-test captured-value transport, using an internal coding user-info key so other JSON call sites retain their default behavior.

Use `"NaN"`, `"Infinity"`, and `"-Infinity"` as the JSON string representations, following conventions used by other JSON encoders.

Add a parameterized regression test covering positive infinity, negative infinity, and NaN, including validation that their classification and sign survive the round trip.

### AI Disclosure:

Codex was used to help investigate the exit-test capture path, research JSON prior art, and draft and refine the implementation, tests, and PR text. I reviewed the resulting changes and verified the regression test locally.

### Checklist:

- [x] Code and documentation follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] No public symbols are renamed or modified, so no DocC references need updating.

### Future discussion

I suggest this should also be cherry-picked into release/6.4 and release/6.3.