### PR TITLE
Fix incorrectly exposed overload of `#require(processExitsWith:)`.

### DIFF
--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -1017,6 +1017,7 @@ public macro require(
 ///   @Available(Xcode, introduced: 26.0)
 /// }
 @freestanding(expression)
+@_documentation(visibility: private)
 @discardableResult
 #if SWT_NO_EXIT_TESTS
 @_unavailableInEmbedded


### PR DESCRIPTION
There's a hidden overload of `#require(processExitsWith:)` that takes a synchronous body closure (so as to help the type checker handle them). It is supposed to be hidden from documentation. Oops.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
