### PR TITLE
Update Issue JSON schema

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -217,7 +217,7 @@ extension ABI.EncodedAttachment: FileClonable {
     }
     return attachment.attachableValue.clone(toFileAtPath: filePath)
   }
-  
+
 }
 #endif
 
@@ -265,7 +265,7 @@ extension Attachment where AttachableValue == AnyAttachable {
       return nil
     }
     self.init(decoding: attachment)
-    if let sourceLocation = event._sourceLocation.flatMap(SourceLocation.init(decoding:)) {
+    if let sourceLocation = event.sourceLocation.flatMap(SourceLocation.init(decoding:)) {
       self.sourceLocation = sourceLocation
     }
   }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedConfirmationMiscount.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedConfirmationMiscount.swift
@@ -1,0 +1,87 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if !SWT_NO_ABI_JSON_SCHEMA
+extension ABI {
+  /// A type implementing the JSON encoding of the actual and expected
+  /// confirmation counts for a miscounted confirmation for the ABI entry point
+  /// and event stream output.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  struct EncodedConfirmationMiscount<V>: Sendable where V: ABI.Version {
+    /// The actual number of confirmations that occurred.
+    var actual: Int
+
+    /// The number of confirmations that were expected.
+    var expected: ExpectedCount
+
+    /// An enumeration describing the number of confirmations that were
+    /// expected, which may be a single value or a range of values.
+    enum ExpectedCount {
+      /// The expected count was a single value.
+      case single(Int)
+
+      /// The expected count was a range of values.
+      case range(ABI.EncodedRange<V>)
+    }
+  }
+}
+
+// MARK: - Conversion to/from library types
+
+extension ABI.EncodedConfirmationMiscount {
+  /// Encodes a miscount based on the actual and expected count.
+  /// - Parameter value: A tuple containing actual and expected number of confirmations.
+  ///    If the expected count is a single value, provide it as a single value
+  ///    range, e.g. `5...5`.
+  init?(encoding value: (actual: Int, expected: any RangeExpression)) {
+    guard let range = ABI.EncodedRange<V>(expectedRange: value.expected) else { return nil }
+
+    actual = value.actual
+    if let min = range.min, let max = range.max, min == max {
+      expected = .single(min)
+    } else {
+      expected = .range(range)
+    }
+  }
+}
+
+// MARK: - Codable
+
+extension ABI.EncodedConfirmationMiscount: Codable {
+  private enum _CodingKeys: String, CodingKey {
+    case actual
+    case expected
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: _CodingKeys.self)
+    try container.encode(actual, forKey: .actual)
+    switch expected {
+    case .single(let count):
+      try container.encode(count, forKey: .expected)
+    case .range(let range):
+      try container.encode(range, forKey: .expected)
+    }
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: _CodingKeys.self)
+    actual = try container.decode(Int.self, forKey: .actual)
+    if let count = try? container.decode(Int.self, forKey: .expected) {
+      expected = .single(count)
+    } else {
+      expected = .range(try container.decode(ABI.EncodedRange<V>.self, forKey: .expected))
+    }
+  }
+}
+#endif

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
@@ -18,9 +18,6 @@ extension ABI {
   /// This type is not part of the public interface of the testing library. It
   /// assists in converting values to JSON; clients that consume this JSON are
   /// expected to write their own decoders.
-  ///
-  /// - Warning: Errors are not yet part of the JSON schema.
-  @_spi(Experimental)
   public struct EncodedError<V>: Sendable where V: ABI.Version {
     /// The error's description.
     ///
@@ -37,7 +34,10 @@ extension ABI {
     var domain: String?
 
     /// The code of the error.
-    var code: Int
+    var code: Int?
+
+    /// The type info for the error.
+    var typeInfo: EncodedTypeInfo<V>?
 
     // TODO: userInfo (partial) encoding
   }
@@ -56,7 +56,7 @@ extension ABI.EncodedError: Error {
   }
 
   public var _code: Int {
-    code
+    code ?? -1
   }
 
   public var _userInfo: AnyObject? {
@@ -67,7 +67,14 @@ extension ABI.EncodedError: Error {
 
 // MARK: - Codable
 
-extension ABI.EncodedError: Codable {}
+extension ABI.EncodedError: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case code
+    case domain
+    case description
+    case typeInfo = "type"
+  }
+}
 
 // MARK: - CustomTestStringConvertible
 
@@ -76,9 +83,9 @@ extension ABI.EncodedError: CustomTestStringConvertible {
     if let description {
       return description
     } else if let domain {
-      return "\(domain) error \(code)"
+      return "\(domain) error \(_code)"
     }
-    return "error \(code)"
+    return "error \(_code)"
   }
 }
 
@@ -95,6 +102,7 @@ extension ABI.EncodedError {
       self.domain = domain
     }
     code = error._code
+    typeInfo = ABI.EncodedTypeInfo<V>(encoding: TypeInfo(describingTypeOf: error))
   }
 }
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -160,9 +160,7 @@ extension ABI {
     /// issue matcher, and either can be `nil`. In such cases, the secondary
     /// comment(s) are represented via a distinct property depending on the kind
     /// of that event.
-    ///
-    /// - Warning: Comments at this level are not yet part of the JSON schema.
-    var _comments: [String]?
+    var comments: [String]?
 
     /// A source location associated with this event, if any.
     ///
@@ -206,18 +204,30 @@ extension ABI {
         iteration = eventContext.iteration
       }
 
+      // Fields introduced in 6.5
+      if V.versionNumber >= ABI.v6_5.versionNumber {
+        switch event.kind {
+        case let .issueRecorded(recordedIssue):
+          comments = recordedIssue.comments.map(\.rawValue)
+        case let .testCaseCancelled(skipInfo),
+          let .testSkipped(skipInfo),
+          let .testCancelled(skipInfo):
+          comments = Array(skipInfo.comment).map(\.rawValue)
+        default:
+          break
+        }
+      }
+
       // Experimental fields
       if V.includesExperimentalFields {
         switch event.kind {
         case let .issueRecorded(recordedIssue):
-          _comments = recordedIssue.comments.map(\.rawValue)
           _sourceLocation = recordedIssue.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
         case let .valueAttached(attachment):
           _sourceLocation = EncodedSourceLocation<V>(encoding: attachment.sourceLocation)
         case let .testCaseCancelled(skipInfo),
           let .testSkipped(skipInfo),
           let .testCancelled(skipInfo):
-          _comments = Array(skipInfo.comment).map(\.rawValue)
           _sourceLocation = skipInfo.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
         default:
           break
@@ -244,7 +254,7 @@ extension ABI.EncodedEvent: Codable {
     case testID
     case iteration
     case testCase = "_testCase"
-    case comments = "_comments"
+    case comments
     case sourceLocation = "_sourceLocation"
   }
 
@@ -260,7 +270,7 @@ extension ABI.EncodedEvent: Codable {
     try container.encodeIfPresent(testID, forKey: .testID)
     try container.encodeIfPresent(iteration, forKey: .iteration)
     try container.encodeIfPresent(_testCase, forKey: .testCase)
-    try container.encodeIfPresent(_comments, forKey: .comments)
+    try container.encodeIfPresent(comments, forKey: .comments)
     try container.encodeIfPresent(_sourceLocation, forKey: .sourceLocation)
   }
 
@@ -278,7 +288,7 @@ extension ABI.EncodedEvent: Codable {
     testID = try container.decodeIfPresent(ABI.EncodedTest<V>.ID.self, forKey: .testID)
     iteration = try container.decodeIfPresent(Int.self, forKey: .iteration)
     _testCase = try container.decodeIfPresent(ABI.EncodedTestCase<V>.self, forKey: .testCase)
-    _comments = try container.decodeIfPresent([String].self, forKey: .comments)
+    comments = try container.decodeIfPresent([String].self, forKey: .comments)
     _sourceLocation = try container.decodeIfPresent(ABI.EncodedSourceLocation<V>.self, forKey: .sourceLocation)
   }
 }
@@ -387,8 +397,7 @@ extension ABI.Version {
     // If the environment variable above is set to `true`, then even newer
     // schema versions should encode the "messages" field.
 
-    // TODO: fix speculative version number check
-    _alwaysIncludeMessagesField == true || versionNumber < ABI.ExperimentalVersion.versionNumber
+    _alwaysIncludeMessagesField == true || versionNumber < ABI.v6_5.versionNumber
   }
 
   /// Whether or not to require the presence of the `"messages"` field in
@@ -397,8 +406,7 @@ extension ABI.Version {
     // Whether or not the field is required during decoding is solely dependent
     // on the schema version, not on the environment variable.
 
-    // TODO: fix speculative version number check
-    versionNumber < ABI.ExperimentalVersion.versionNumber
+    versionNumber < ABI.v6_5.versionNumber
   }
 }
 #endif

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -174,11 +174,7 @@ extension ABI {
     /// the known issue matcher. In such cases, the secondary source location(s)
     /// are represented via a distinct property depending on the kind of that
     /// event.
-    ///
-    /// - Warning: Source locations at this level of the JSON schema are not yet
-    ///   part of said JSON schema.
-    @_spi(Experimental)
-    public var _sourceLocation: EncodedSourceLocation<V>?
+    public var sourceLocation: EncodedSourceLocation<V>?
 
     init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message] = []) {
       guard let encodedKind = Kind(encoding: event.kind, in: eventContext) else {
@@ -208,10 +204,14 @@ extension ABI {
         switch event.kind {
         case let .issueRecorded(recordedIssue):
           comments = recordedIssue.comments.map(\.rawValue)
+          sourceLocation = recordedIssue.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
+        case let .valueAttached(attachment):
+          sourceLocation = EncodedSourceLocation<V>(encoding: attachment.sourceLocation)
         case let .testCaseCancelled(skipInfo),
           let .testSkipped(skipInfo),
           let .testCancelled(skipInfo):
           comments = Array(skipInfo.comment).map(\.rawValue)
+          sourceLocation = skipInfo.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
         default:
           break
         }
@@ -219,19 +219,6 @@ extension ABI {
 
       // Experimental fields
       if V.includesExperimentalFields {
-        switch event.kind {
-        case let .issueRecorded(recordedIssue):
-          _sourceLocation = recordedIssue.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
-        case let .valueAttached(attachment):
-          _sourceLocation = EncodedSourceLocation<V>(encoding: attachment.sourceLocation)
-        case let .testCaseCancelled(skipInfo),
-          let .testSkipped(skipInfo),
-          let .testCancelled(skipInfo):
-          _sourceLocation = skipInfo.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
-        default:
-          break
-        }
-
         if eventContext.test?.isParameterized == true {
           _testCase = eventContext.testCase.map(EncodedTestCase.init)
         }
@@ -254,7 +241,7 @@ extension ABI.EncodedEvent: Codable {
     case iteration
     case testCase = "_testCase"
     case comments
-    case sourceLocation = "_sourceLocation"
+    case sourceLocation
   }
 
   public func encode(to encoder: any Encoder) throws {
@@ -270,7 +257,7 @@ extension ABI.EncodedEvent: Codable {
     try container.encodeIfPresent(iteration, forKey: .iteration)
     try container.encodeIfPresent(_testCase, forKey: .testCase)
     try container.encodeIfPresent(comments, forKey: .comments)
-    try container.encodeIfPresent(_sourceLocation, forKey: .sourceLocation)
+    try container.encodeIfPresent(sourceLocation, forKey: .sourceLocation)
   }
 
   public init(from decoder: any Decoder) throws {
@@ -288,7 +275,7 @@ extension ABI.EncodedEvent: Codable {
     iteration = try container.decodeIfPresent(Int.self, forKey: .iteration)
     _testCase = try container.decodeIfPresent(ABI.EncodedTestCase<V>.self, forKey: .testCase)
     comments = try container.decodeIfPresent([String].self, forKey: .comments)
-    _sourceLocation = try container.decodeIfPresent(ABI.EncodedSourceLocation<V>.self, forKey: .sourceLocation)
+    sourceLocation = try container.decodeIfPresent(ABI.EncodedSourceLocation<V>.self, forKey: .sourceLocation)
   }
 }
 extension ABI.EncodedEvent.Kind: Codable {}

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -199,7 +199,6 @@ extension ABI {
       testID = event.testID.map(EncodedTest.ID.init)
 
       // Fields introduced in 6.4
-
       if V.versionNumber >= ABI.v6_4.versionNumber {
         iteration = eventContext.iteration
       }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedExpression.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedExpression.swift
@@ -16,9 +16,6 @@ extension ABI {
   /// This type is not part of the public interface of the testing library. It
   /// assists in converting values to JSON; clients that consume this JSON are
   /// expected to write their own decoders.
-  ///
-  /// - Warning: Expressions are not yet part of the JSON schema.
-  @_spi(Experimental)
   public struct EncodedExpression<V>: Sendable where V: ABI.Version {
     /// The source code of the original captured expression.
     var sourceCode: String
@@ -31,7 +28,13 @@ extension ABI {
 
     /// The fully-qualified name of the type of value represented by
     /// `runtimeValue`, or `nil` if that value has not been captured.
-    var runtimeTypeName: String?
+    var runtimeTypeName: String? {
+      _typeInfo?.fullyQualifiedName
+    }
+
+    /// The full type info for the value represented by `runtimeValue`, or `nil`
+    /// if that value has not been captured.
+    fileprivate var _typeInfo: EncodedTypeInfo<V>?
 
     /// Any child expressions within this expression.
     var children: [EncodedExpression]?
@@ -40,7 +43,14 @@ extension ABI {
 
 // MARK: - Codable
 
-extension ABI.EncodedExpression: Codable {}
+extension ABI.EncodedExpression: Codable {
+  private enum CodingKeys: String, CodingKey {
+    case sourceCode
+    case runtimeValue = "value"
+    case _typeInfo = "type"
+    case children
+  }
+}
 
 // MARK: - Conversion to/from library types
 
@@ -52,7 +62,7 @@ extension ABI.EncodedExpression {
   public init(encoding expression: borrowing Expression) {
     sourceCode = expression.sourceCode
     runtimeValue = expression.runtimeValue.map(String.init(describingForTest:))
-    runtimeTypeName = expression.runtimeValue.map(\.typeInfo.fullyQualifiedName)
+    _typeInfo = expression.runtimeValue.map { ABI.EncodedTypeInfo<V>(encoding: $0.typeInfo) }
     let subexpressions = expression.subexpressions
     if !subexpressions.isEmpty {
       children = subexpressions.map(Self.init(encoding:))
@@ -69,7 +79,7 @@ extension Expression {
   public init?<V>(decoding expression: ABI.EncodedExpression<V>) {
     self.init(expression.sourceCode)
     if let runtimeValue = expression.runtimeValue,
-       let runtimeTypeName = expression.runtimeTypeName {
+       let runtimeTypeName = expression._typeInfo?.fullyQualifiedName {
       self.runtimeValue =  __Expression.Value(
         description: runtimeValue,
         typeInfo: TypeInfo(fullyQualifiedName: runtimeTypeName, mangledName: nil)

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -50,8 +50,9 @@ extension ABI {
 
     /// A comment associated with the known issue, if any.
     ///
-    /// - Warning: This property is not yet part of the JSON schema.
-    var _knownIssueComment: String?
+    /// If not nil, this is encoded as the value for `isKnown` field in the
+    /// JSON schema.
+    var knownIssueComment: String?
 
     /// The location in source where this issue occurred, if available.
     public var sourceLocation: EncodedSourceLocation<V>?
@@ -62,14 +63,17 @@ extension ABI {
     var _backtrace: EncodedBacktrace<V>?
 
     /// The error associated with this issue, if applicable.
-    ///
-    /// - Warning: Errors are not yet part of the JSON schema.
-    var _error: EncodedError<V>?
+    var error: EncodedError<V>?
 
     /// The expression associated with this issue, if applicable.
-    ///
-    /// - Warning: Expressions are not yet part of the JSON schema.
-    var _expression: EncodedExpression<V>?
+    var expression: EncodedExpression<V>?
+
+    /// The actual and expected confirmation counts associated with this issue,
+    /// if applicable.
+    var confirmationMiscount: EncodedConfirmationMiscount<V>?
+
+    /// The exceeded time limit associated with this issue, if applicable.
+    var exceededTimeLimit: Double?
 
     init(encoding issue: borrowing Issue, in eventContext: borrowing Event.Context) {
       // >= v0
@@ -85,15 +89,25 @@ extension ABI {
         isFailure = issue.isFailure
       }
 
-      // Experimental fields
-      if V.includesExperimentalFields {
+      // >= v6.5
+      if V.versionNumber >= ABI.v6_5.versionNumber {
+        if case .expectationFailed(let expectation) = issue.kind {
+          expression = EncodedExpression(encoding: expectation.evaluatedExpression)
+        }
+
+        if case .timeLimitExceeded(let components) = issue.kind {
+          exceededTimeLimit = Double(components.seconds)
+        }
+
         if let knownIssueContext = issue.knownIssueContext {
-          _knownIssueComment = knownIssueContext.comment?.rawValue
+          knownIssueComment = knownIssueContext.comment?.rawValue
         }
-        if let backtrace = issue.sourceContext.backtrace {
-          _backtrace = EncodedBacktrace(encoding: backtrace, in: eventContext)
+
+        if case .confirmationMiscounted(let actual, let expected) = issue.kind {
+          confirmationMiscount = EncodedConfirmationMiscount(encoding: (actual: actual, expected: expected))
         }
-        _error = if let error = issue.error {
+
+        error = if let error = issue.error {
           EncodedError(encoding: error)
         } else {
           switch issue.kind {
@@ -105,8 +119,12 @@ extension ABI {
             nil
           }
         }
-        if case let .expectationFailed(expectation) = issue.kind {
-          _expression = EncodedExpression(encoding: expectation.evaluatedExpression)
+      }
+
+      // Experimental fields
+      if V.includesExperimentalFields {
+        if let backtrace = issue.sourceContext.backtrace {
+          _backtrace = EncodedBacktrace(encoding: backtrace, in: eventContext)
         }
       }
     }
@@ -115,7 +133,74 @@ extension ABI {
 
 // MARK: - Codable
 
-extension ABI.EncodedIssue: Codable {}
+extension ABI.EncodedIssue: Codable {
+  private enum _CodingKeys: String, CodingKey {
+    case severity
+    case isFailure
+    case isKnown
+    case sourceLocation
+    case _backtrace
+    case error
+    case expression
+    case exceededTimeLimit
+    case confirmationMiscount
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: _CodingKeys.self)
+
+    try container.encodeIfPresent(severity, forKey: .severity)
+    try container.encodeIfPresent(isFailure, forKey: .isFailure)
+
+    // >= 6.5: isKnown is an optional field. Use knownIssueComment if present.
+    //         Omit the field if isKnown is false.
+    // <  6.5: isKnown is a required boolean field
+    if V.versionNumber >= ABI.v6_5.versionNumber {
+      if let knownIssueComment {
+        try container.encode(knownIssueComment, forKey: .isKnown)
+      } else if isKnown {
+        try container.encode(isKnown, forKey: .isKnown)
+      }
+    } else {
+      try container.encode(isKnown, forKey: .isKnown)
+    }
+    try container.encodeIfPresent(sourceLocation, forKey: .sourceLocation)
+    try container.encodeIfPresent(_backtrace, forKey: ._backtrace)
+    try container.encodeIfPresent(error, forKey: .error)
+    try container.encodeIfPresent(expression, forKey: .expression)
+    try container.encodeIfPresent(exceededTimeLimit, forKey: .exceededTimeLimit)
+    try container.encodeIfPresent(confirmationMiscount, forKey: .confirmationMiscount)
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: _CodingKeys.self)
+
+    severity = try container.decodeIfPresent(Severity.self, forKey: .severity)
+    isFailure = try container.decodeIfPresent(Bool.self, forKey: .isFailure)
+
+    // >= 6.5: isKnown is an optional field, and resolves to false if missing.
+    // <  6.5: isKnown is always present as a boolean
+    if V.versionNumber >= ABI.v6_5.versionNumber {
+      if let knownIssueComment = try? container.decodeIfPresent(String.self, forKey: .isKnown) {
+        isKnown = true
+        self.knownIssueComment = knownIssueComment
+      } else {
+        isKnown = try container.decodeIfPresent(Bool.self, forKey: .isKnown) ?? false
+      }
+    } else {
+      isKnown = try container.decode(Bool.self, forKey: .isKnown)
+    }
+
+    sourceLocation = try container.decodeIfPresent(
+      ABI.EncodedSourceLocation<V>.self, forKey: .sourceLocation)
+    _backtrace = try container.decodeIfPresent(ABI.EncodedBacktrace<V>.self, forKey: ._backtrace)
+    error = try container.decodeIfPresent(ABI.EncodedError<V>.self, forKey: .error)
+    expression = try container.decodeIfPresent(ABI.EncodedExpression<V>.self, forKey: .expression)
+    exceededTimeLimit = try container.decodeIfPresent(Double.self, forKey: .exceededTimeLimit)
+    confirmationMiscount = try container.decodeIfPresent(
+      ABI.EncodedConfirmationMiscount<V>.self, forKey: .confirmationMiscount)
+  }
+}
 extension ABI.EncodedIssue.Severity: Codable {}
 
 // MARK: - Conversion to/from library types
@@ -147,7 +232,7 @@ extension Issue {
   ///   representing a recorded issue rather than just the encoded issue.
   init?<V>(decoding issue: ABI.EncodedIssue<V>) {
     let issueKind: Issue.Kind
-    if let error = issue._error {
+    if let error = issue.error {
       switch error.domain {
       case APIMisuseError.domain:
         issueKind = .apiMisused
@@ -156,8 +241,9 @@ extension Issue {
       default:
         issueKind = .errorCaught(error)
       }
-    } else if let expression = issue._expression.flatMap(__Expression.init(decoding:)),
-              let sourceLocation = issue.sourceLocation.flatMap(SourceLocation.init) {
+    } else if let expression = issue.expression.flatMap(__Expression.init(decoding:)),
+      let sourceLocation = issue.sourceLocation.flatMap(SourceLocation.init)
+    {
       let expectation = Expectation(
         evaluatedExpression: expression,
         isPassing: false,
@@ -165,16 +251,27 @@ extension Issue {
         sourceLocation: sourceLocation
       )
       issueKind = .expectationFailed(expectation)
+    } else if let exceededTimeLimit = issue.exceededTimeLimit {
+      let duration = Duration.seconds(exceededTimeLimit)
+      issueKind = .timeLimitExceeded(timeLimitComponents: duration.components)
+    } else if let miscount = issue.confirmationMiscount {
+      let expectedRange = switch miscount.expected {
+        case .single(let expected):
+          expected...expected
+        case .range(let expected):
+          ClosedRange<Int>(decoding: expected)
+        }
+      issueKind = .confirmationMiscounted(actual: miscount.actual, expected: expectedRange)
     } else {
       // TODO: improve fidelity of issue kind reporting (especially those without associated values)
       issueKind = .unconditional
     }
     let severity: Issue.Severity = switch issue.severity {
     case .warning:
-        .warning
+      .warning
     case .error, nil:
       // Prior to 6.3, all Issues are errors
-        .error
+      .error
     }
     let sourceContext = SourceContext(
       backtrace: issue._backtrace.map { Backtrace(addresses: $0.symbolicatedAddresses.map(\.address)) },
@@ -187,7 +284,7 @@ extension Issue {
       sourceContext: sourceContext
     )
     if issue.isKnown {
-      let knownIssueComment = issue._knownIssueComment.map(Comment.init(rawValue:))
+      let knownIssueComment = issue.knownIssueComment.map(Comment.init(rawValue:))
       self.knownIssueContext = Issue.KnownIssueContext(comment: knownIssueComment)
     }
   }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -133,7 +133,7 @@ extension Issue {
       return nil
     }
     self.init(decoding: issue)
-    if let comments = event._comments {
+    if let comments = event.comments {
       self.comments += comments.map(Comment.init(rawValue:))
     }
   }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -55,6 +55,8 @@ extension ABI {
     var knownIssueComment: String?
 
     /// The location in source where this issue occurred, if available.
+    ///
+    /// TODO: how to handle this no longer being available in v6.5?
     public var sourceLocation: EncodedSourceLocation<V>?
 
     /// The backtrace where this issue occurred, if available.
@@ -91,6 +93,8 @@ extension ABI {
 
       // >= v6.5
       if V.versionNumber >= ABI.v6_5.versionNumber {
+        // SourceLocation is encoded in the parent Event structure instead
+        sourceLocation = nil
         if case .expectationFailed(let expectation) = issue.kind {
           expression = EncodedExpression(encoding: expectation.evaluatedExpression)
         }
@@ -219,7 +223,7 @@ extension Issue {
     guard let issue = event.issue else {
       return nil
     }
-    self.init(decoding: issue)
+    self.init(decoding: issue, sourceLocation: event.sourceLocation)
     if let comments = event.comments {
       self.comments += comments.map(Comment.init(rawValue:))
     }
@@ -229,10 +233,15 @@ extension Issue {
   ///
   /// - Parameters:
   ///   - issue: The encoded issue to initialize this instance from.
+  ///   - sourceLocation: The source location associated with the issue.
+  ///   If the encoded issue has a non-nil source location, this takes
+  ///   precedence. Required for >=v6.5, where sourceLocation is no longer
+  ///   available as part of the encoded issue.
   ///
   /// - Note: For higher fidelity, initialize the issue with an encoded event
   ///   representing a recorded issue rather than just the encoded issue.
-  init?<V>(decoding issue: ABI.EncodedIssue<V>) {
+  init?<V>(decoding issue: ABI.EncodedIssue<V>, sourceLocation: ABI.EncodedSourceLocation<V>? = nil) {
+    let sourceLocation = sourceLocation ?? issue.sourceLocation
     let issueKind: Issue.Kind
     if let error = issue.error {
       switch error.domain {
@@ -246,7 +255,7 @@ extension Issue {
         issueKind = .errorCaught(error)
       }
     } else if let expression = issue.expression.flatMap(__Expression.init(decoding:)),
-      let sourceLocation = issue.sourceLocation.flatMap(SourceLocation.init)
+      let sourceLocation = sourceLocation.flatMap(SourceLocation.init)
     {
       let expectation = Expectation(
         evaluatedExpression: expression,
@@ -279,7 +288,7 @@ extension Issue {
     }
     let sourceContext = SourceContext(
       backtrace: issue._backtrace.map { Backtrace(addresses: $0.symbolicatedAddresses.map(\.address)) },
-      sourceLocation: issue.sourceLocation.flatMap(SourceLocation.init)
+      sourceLocation: sourceLocation.flatMap(SourceLocation.init)
     )
     self.init(
       kind: issueKind,

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -115,6 +115,8 @@ extension ABI {
             EncodedError(encoding: APIMisuseError(description: ""))
           case .system:
             EncodedError(encoding: SystemError(description: ""))
+          case .knownIssueNotRecorded:
+            EncodedError(encoding: KnownIssueNotRecordedError(description: ""))
           default:
             nil
           }
@@ -238,6 +240,8 @@ extension Issue {
         issueKind = .apiMisused
       case SystemError.domain:
         issueKind = .system
+      case KnownIssueNotRecordedError.domain:
+        issueKind = .knownIssueNotRecorded
       default:
         issueKind = .errorCaught(error)
       }

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedRange.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedRange.swift
@@ -1,0 +1,75 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if !SWT_NO_ABI_JSON_SCHEMA
+extension ABI {
+  /// A type implementing the JSON encoding of a range for the ABI entry point
+  /// and event stream output.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  struct EncodedRange<V>: Sendable where V: ABI.Version {
+    /// The inclusive lower bound of the range, if any.
+    var min: Int?
+
+    /// The inclusive upper bound of the range, if any.
+    var max: Int?
+
+    // Creates the encoded range from an expected confirmation count.
+    //
+    // Returns nil if the range could not be represented by an inclusive upper
+    // bound (e.g. `..<Int.min`), or if the range was not a supported
+    // integer-valued range.
+    //
+    // For completeness, this supports a superset of ranges allowed by the
+    // Testing library for confirmations. For example,
+    // `confirmation(expectedCount:...10)` without a explicit lower bound is
+    // considered ambiguous, but can be represented as an encoded range with a
+    // nil `min`.
+    init?(expectedRange: any RangeExpression) {
+      if let range = expectedRange as? ClosedRange<Int> {
+        min = range.lowerBound
+        max = range.upperBound
+      } else if let range = expectedRange as? Range<Int> {
+        guard range.upperBound > Int.min else { return nil }
+        min = range.lowerBound
+        max = range.upperBound - 1
+      } else if let range = expectedRange as? PartialRangeFrom<Int> {
+        min = range.lowerBound
+      } else if let range = expectedRange as? PartialRangeUpTo<Int> {
+        guard range.upperBound > Int.min else { return nil }
+        max = range.upperBound - 1
+      } else if let range = expectedRange as? PartialRangeThrough<Int> {
+        max = range.upperBound
+      } else {
+        return nil
+      }
+    }
+  }
+}
+
+// MARK: - Codable
+
+extension ABI.EncodedRange: Codable {}
+
+// MARK: - Conversion to/from library types
+
+extension ClosedRange<Int> {
+  init<V>(decoding value: ABI.EncodedRange<V>) {
+    let min = value.min ?? Int.min
+    let max = value.max ?? Int.max
+    precondition(min <= max)
+
+    self.init(uncheckedBounds: (min, max))
+  }
+}
+
+#endif

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTypeInfo.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTypeInfo.swift
@@ -1,0 +1,63 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if !SWT_NO_ABI_JSON_SCHEMA
+extension ABI {
+  /// A type implementing the JSON encoding of ``TypeInfo`` for the ABI entry
+  /// point and event stream output.
+  ///
+  /// Although ``TypeInfo`` already has a Codable conformance, this structure
+  /// provides ABI versioning support. It also allows more optional fields,
+  /// which supports type info from non-Swift types.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  struct EncodedTypeInfo<V>: Sendable where V: ABI.Version {
+    /// The fully qualified name of the type, if present.
+    var fullyQualifiedName: String?
+
+    /// The unqualified name components of the type, if present.
+    var unqualifiedName: String?
+
+    /// The mangled name of the type, if present.
+    var mangledName: String?
+
+    init(encoding typeInfo: borrowing TypeInfo) {
+      fullyQualifiedName = typeInfo.fullyQualifiedName
+      unqualifiedName = typeInfo.unqualifiedName
+      mangledName = typeInfo.mangledName
+    }
+  }
+}
+
+// MARK: - Codable
+
+extension ABI.EncodedTypeInfo: Codable {}
+
+// MARK: - Conversion to/from library types
+
+extension TypeInfo {
+  init<V>(decoding typeInfo: ABI.EncodedTypeInfo<V>) {
+    let fullyQualifiedNameComponents =
+      typeInfo.fullyQualifiedName
+      .map { fullyQualifiedName in
+        rawIdentifierAwareSplit(fullyQualifiedName, separator: ".").map(String.init)
+      } ?? []
+
+    self.init(
+      fullyQualifiedNameComponents: fullyQualifiedNameComponents,
+      unqualifiedName: typeInfo.unqualifiedName,
+      mangledName: typeInfo.mangledName
+    )
+  }
+}
+
+#endif

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(Testing
   ABI/Encoded/ABI.EncodedRange.swift
   ABI/Encoded/ABI.EncodedSourceLocation.swift
   ABI/Encoded/ABI.EncodedTest.swift
+  ABI/Encoded/ABI.EncodedTypeInfo.swift
   Attachments/Images/AttachableAsImage.swift
   Attachments/Images/_AttachableImageWrapper.swift
   Attachments/Images/AttachableImageFormat.swift

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(Testing
   ABI/ABI.swift
   ABI/Encoded/ABI.EncodedAttachment.swift
   ABI/Encoded/ABI.EncodedBacktrace.swift
+  ABI/Encoded/ABI.EncodedConfirmationMiscount.swift
   ABI/Encoded/ABI.EncodedError.swift
   ABI/Encoded/ABI.EncodedEvent.swift
   ABI/Encoded/ABI.EncodedExpression.swift
@@ -25,6 +26,7 @@ add_library(Testing
   ABI/Encoded/ABI.EncodedIssue.swift
   ABI/Encoded/ABI.EncodedMessage.swift
   ABI/Encoded/ABI.EncodedMetadata.swift
+  ABI/Encoded/ABI.EncodedRange.swift
   ABI/Encoded/ABI.EncodedSourceLocation.swift
   ABI/Encoded/ABI.EncodedTest.swift
   Attachments/Images/AttachableAsImage.swift

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -18,12 +18,14 @@ add_library(Testing
   ABI/ABI.swift
   ABI/Encoded/ABI.EncodedAttachment.swift
   ABI/Encoded/ABI.EncodedBacktrace.swift
+  ABI/Encoded/ABI.EncodedConfirmationMiscount.swift
   ABI/Encoded/ABI.EncodedError.swift
   ABI/Encoded/ABI.EncodedEvent.swift
   ABI/Encoded/ABI.EncodedExpression.swift
   ABI/Encoded/ABI.EncodedInstant.swift
   ABI/Encoded/ABI.EncodedIssue.swift
   ABI/Encoded/ABI.EncodedMessage.swift
+  ABI/Encoded/ABI.EncodedRange.swift
   ABI/Encoded/ABI.EncodedSourceLocation.swift
   ABI/Encoded/ABI.EncodedTest.swift
   Attachments/Images/AttachableAsImage.swift

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(Testing
   ABI/Encoded/ABI.EncodedRange.swift
   ABI/Encoded/ABI.EncodedSourceLocation.swift
   ABI/Encoded/ABI.EncodedTest.swift
+  ABI/Encoded/ABI.EncodedTypeInfo.swift
   Attachments/Images/AttachableAsImage.swift
   Attachments/Images/_AttachableImageWrapper.swift
   Attachments/Images/AttachableImageFormat.swift

--- a/Sources/Testing/Events/Recorder/Event.AdvancedConsoleOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.AdvancedConsoleOutputRecorder.swift
@@ -754,7 +754,7 @@ extension Event.AdvancedConsoleOutputRecorder {
     // Get the corresponding messages for this issue
     guard issueIndex < testData.issueMessages.count else {
       // Fallback to error description if available
-      if let errorDesc = issue._error?.description {
+      if let errorDesc = issue.error?.description {
         return errorDesc
       }
       return "Issue recorded"
@@ -791,7 +791,7 @@ extension Event.AdvancedConsoleOutputRecorder {
     }
     
     // Final fallback
-    if let errorDesc = issue._error?.description {
+    if let errorDesc = issue.error?.description {
       // Truncate very long error descriptions
       if errorDesc.count > 200 {
         return String(errorDesc.prefix(200)) + "..."

--- a/Sources/Testing/Running/SkipInfo.swift
+++ b/Sources/Testing/Running/SkipInfo.swift
@@ -104,7 +104,7 @@ extension SkipInfo {
 
     // Typically only a single comment is expected for SkipInfo.
     let comment = event.comments?.first.map(Comment.init(rawValue:))
-    let sourceLocation = event._sourceLocation.flatMap(SourceLocation.init(decoding:))
+    let sourceLocation = event.sourceLocation.flatMap(SourceLocation.init(decoding:))
     let sourceContext = SourceContext(backtrace: nil, sourceLocation: sourceLocation)
     self.init(comment: comment, sourceContext: sourceContext)
   }

--- a/Sources/Testing/Running/SkipInfo.swift
+++ b/Sources/Testing/Running/SkipInfo.swift
@@ -103,7 +103,7 @@ extension SkipInfo {
     }
 
     // Typically only a single comment is expected for SkipInfo.
-    let comment = event._comments?.first.map(Comment.init(rawValue:))
+    let comment = event.comments?.first.map(Comment.init(rawValue:))
     let sourceLocation = event._sourceLocation.flatMap(SourceLocation.init(decoding:))
     let sourceContext = SourceContext(backtrace: nil, sourceLocation: sourceLocation)
     self.init(comment: comment, sourceContext: sourceContext)

--- a/Sources/Testing/Support/CustomIssueRepresentable.swift
+++ b/Sources/Testing/Support/CustomIssueRepresentable.swift
@@ -89,6 +89,25 @@ struct APIMisuseError: Error, CustomStringConvertible, CustomIssueRepresentable 
   }
 }
 
+
+/// A type representing a test issue due to a known issue being expected but not
+/// recorded.
+///
+/// This type is not part of the public interface of the testing library.
+/// External callers should generally record issues by throwing their own errors
+/// or by calling ``Issue/record(_:severity:sourceLocation:)``.
+struct KnownIssueNotRecordedError: Error, CustomStringConvertible {
+  var description: String
+
+  static var domain: String {
+    "org.swift.testing.KnownIssueNotRecordedError"
+  }
+
+  var _domain: String {
+    Self.domain
+  }
+}
+
 extension ExpectationFailedError: CustomIssueRepresentable {
   func customize(_ issue: consuming Issue) -> Issue {
     // Instances of this error type are thrown by `#require()` after an issue of

--- a/Tests/TestingTests/ABI.EncodedConfirmationMiscountTests.swift
+++ b/Tests/TestingTests/ABI.EncodedConfirmationMiscountTests.swift
@@ -1,0 +1,71 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+#if !SWT_NO_ABI_JSON_SCHEMA
+@Suite struct `ABI.EncodedConfirmationMiscount Tests` {
+  @Test func `Collapses expected single element range to a single count`() throws {
+    let miscount = try #require(ABI.EncodedConfirmationMiscount<ABI.CurrentVersion>(encoding: (actual: 1, expected: 10...10)))
+
+    #expect(miscount.actual == 1)
+    guard case let .single(expected) = miscount.expected else {
+      Issue.record("Expected .single case, got \(miscount.expected)")
+      return
+    }
+    #expect(expected == 10)
+  }
+
+  @Test func `Preserves a range of expected counts`() throws {
+    let miscount = try #require(ABI.EncodedConfirmationMiscount<ABI.CurrentVersion>(encoding: (actual: 1, expected: 5...10)))
+
+    #expect(miscount.actual == 1)
+    guard case let .range(range) = miscount.expected else {
+      Issue.record("Expected .range case, got \(miscount.expected)")
+      return
+    }
+    #expect(range.min == 5)
+    #expect(range.max == 10)
+  }
+
+  @Test func `Encodes a single expected count as an integer`() throws {
+    let miscount = try #require(ABI.EncodedConfirmationMiscount<ABI.CurrentVersion>(encoding: (actual: 1, expected: 10...10)))
+    try JSON.withEncoding(of: miscount) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+      #expect(jsonString.contains("\"expected\":10"))
+    }
+  }
+
+  @Test func `Round-trips a single expected count through JSON`() throws {
+    let miscount = try #require(ABI.EncodedConfirmationMiscount<ABI.CurrentVersion>(encoding: (actual: 1, expected: 10...10)))
+    let decoded = try JSON.encodeAndDecode(miscount)
+
+    #expect(decoded.actual == 1)
+    guard case let .single(expected) = decoded.expected else {
+      Issue.record("Expected .single case, got \(decoded.expected)")
+      return
+    }
+    #expect(expected == 10)
+  }
+
+  @Test func `Round-trips a range of expected counts through JSON`() throws {
+    let miscount = try #require(ABI.EncodedConfirmationMiscount<ABI.CurrentVersion>(encoding: (actual: 1, expected: 5...10)))
+    let decoded = try JSON.encodeAndDecode(miscount)
+
+    #expect(decoded.actual == 1)
+    guard case let .range(range) = decoded.expected else {
+      Issue.record("Expected .range case, got \(decoded.expected)")
+      return
+    }
+    #expect(range.min == 5)
+    #expect(range.max == 10)
+  }
+}
+#endif

--- a/Tests/TestingTests/ABI.EncodedErrorTests.swift
+++ b/Tests/TestingTests/ABI.EncodedErrorTests.swift
@@ -1,0 +1,66 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+#if !SWT_NO_ABI_JSON_SCHEMA
+@Suite struct `ABI.EncodedError Tests` {
+  struct FakeError: Error {
+    var localizedDescription: String {
+      "Some synthetic error"
+    }
+  }
+
+  private let error = ABI.EncodedError<ABI.CurrentVersion>(encoding: FakeError())
+
+  @Test func `Encodes a Swift error`() throws {
+    #expect(error.domain == "TestingTests.`ABI.EncodedError Tests`.FakeError")
+    #expect(error.description == "FakeError()")
+    #expect(error.code == 1)
+  }
+
+  @Test func `Decodes all optional error fields `() throws {
+    let encodedData = Array(
+      """
+      {}
+      """.utf8)
+    let decoded = try encodedData.withUnsafeBytes { encodedData in
+      try JSON.decode(ABI.EncodedError<ABI.CurrentVersion>.self, from: encodedData)
+    }
+
+    #expect(decoded.description == nil)
+    #expect(decoded.domain == nil)
+    #expect(decoded.code == nil)
+    #expect(decoded.typeInfo == nil)
+  }
+
+  @Test func `Expected field names`() throws {
+    let error = ABI.EncodedError<ABI.CurrentVersion>(encoding: FakeError())
+
+    try JSON.withEncoding(of: error) { buf in
+      let str = String(decoding: buf, as: UTF8.self)
+      #expect(str.contains(#""code":"#))
+      #expect(str.contains(#""domain":"#))
+      #expect(str.contains(#""description":"#))
+      #expect(str.contains(#""type":"#))
+    }
+  }
+
+  @Test func `Round-trips through JSON`() throws {
+    let encoded = ABI.EncodedError<ABI.CurrentVersion>(encoding: FakeError())
+    let decoded = try JSON.encodeAndDecode(encoded)
+
+    #expect(decoded.description == encoded.description)
+    #expect(decoded.domain == encoded.domain)
+    #expect(decoded.code == encoded.code)
+    #expect(decoded.typeInfo != nil)
+  }
+}
+#endif

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -373,9 +373,15 @@
 
   // MARK: Comments
 
-  @Test func `'comments' field only encoded in 6.5 and above`() throws {
+  @Test(arguments: [
+    Event.Kind.issueRecorded(.init(kind: .unconditional, comments: ["User provided comment"], sourceContext: sourceContext)),
+    .testSkipped(.init(comment: "User provided comment", sourceContext: sourceContext)),
+    //    .testCancelled(.init(comment: "User provided comment", sourceContext: sourceContext)),
+    .testCaseCancelled(.init(comment: "User provided comment", sourceContext: sourceContext)),
+  ])
+  func `'comments' field only encoded in 6.5 and above`(kind: Event.Kind) throws {
     let test = Test {}
-    let event = Event(.issueRecorded(.init(kind: .unconditional, comments: ["User provided comment"], sourceContext: .init())), testID: .init(["SomeValidTestID", "testFunc()"]), testCaseID: nil)
+    let event = Event(kind, testID: .init(["SomeValidTestID", "testFunc()"]), testCaseID: nil)
     let context = Event.Context(test: test, testCase: nil, iteration: 2, configuration: nil)
 
 
@@ -465,6 +471,35 @@
     let event = Event(.runStarted, testID: nil, testCaseID: nil)
     let eventContext = Event.Context(test: nil, testCase: nil, iteration: nil, configuration: nil)
     eventHandler(event, eventContext)
+  }
+
+  // MARK: Source Location
+
+  static let sourceContext = SourceContext(sourceLocation: .init(fileID: "Module/Tomato.swift", filePath: "/path/to/tomato.swift", line: 1, column: 1))
+
+  @Test(arguments: [
+    Event.Kind.issueRecorded(.init(kind: .system, sourceContext: sourceContext)),
+    .valueAttached(Attachment(Attachment("Tomato"))),
+    .testSkipped(.init(comment: "Skipped Test Comment", sourceContext: sourceContext)),
+//    .testCancelled(.init(comment: "Skipped Test Comment", sourceContext: sourceContext)),
+    .testCaseCancelled(.init(comment: "Skipped Test Comment", sourceContext: sourceContext)),
+  ])
+  func `Event-level 'sourceLocation' field only encoded in 6.5 and above`(kind: Event.Kind) throws {
+    let test = Test {}
+    let event = Event(kind, testID: .init(["TomatoTests", "testSauce()"]), testCaseID: nil)
+    let context = Event.Context(test: test, testCase: nil, iteration: 1, configuration: nil)
+
+    // v6.4
+    do {
+      let encoded = try #require(ABI.EncodedEvent<ABI.v6_4>(encoding: event, in: context))
+      #expect(encoded.sourceLocation == nil)
+    }
+
+    // v6.5
+    do {
+      let encoded = try #require(ABI.EncodedEvent<ABI.v6_5>(encoding: event, in: context))
+      #expect(encoded.sourceLocation != nil)
+    }
   }
 }
 #endif

--- a/Tests/TestingTests/ABI.EncodedEventTests.swift
+++ b/Tests/TestingTests/ABI.EncodedEventTests.swift
@@ -371,6 +371,40 @@
     }
   }
 
+  // MARK: Comments
+
+  @Test func `'comments' field only encoded in 6.5 and above`() throws {
+    let test = Test {}
+    let event = Event(.issueRecorded(.init(kind: .unconditional, comments: ["User provided comment"], sourceContext: .init())), testID: .init(["SomeValidTestID", "testFunc()"]), testCaseID: nil)
+    let context = Event.Context(test: test, testCase: nil, iteration: 2, configuration: nil)
+
+
+    // v6.4
+    do {
+      let encoded = try #require(ABI.EncodedEvent<ABI.v6_4>(encoding: event, in: context))
+
+      #expect(encoded.comments == nil)
+      try JSON.withEncoding(of: encoded) { buf in
+        let str = String(decoding: buf, as: UTF8.self)
+        #expect(!str.contains(#""comments":"#))
+      }
+    }
+
+    // v6.5
+    do {
+      let encoded = try #require(ABI.EncodedEvent<ABI.v6_5>(encoding: event, in: context))
+
+      #expect(encoded.comments == ["User provided comment"])
+      try JSON.withEncoding(of: encoded) { buf in
+        let str = String(decoding: buf, as: UTF8.self)
+        #expect(str.contains(#""comments":"#))
+      }
+    }
+
+  }
+
+  // MARK: Messages
+
   @Test func `Fails to decode v6.3 record with missing 'messages' field`() throws {
     #expect(throws: DecodingError.self) {
       _ = try encodedEvent(
@@ -387,7 +421,7 @@
 
     #expect(throws: Never.self) {
       _ = try encodedEvent(
-        ABI.ExperimentalVersion.self,
+        ABI.v6_5.self,
         """
         {
           "kind": "testStarted",

--- a/Tests/TestingTests/ABI.EncodedExpressionTests.swift
+++ b/Tests/TestingTests/ABI.EncodedExpressionTests.swift
@@ -1,0 +1,66 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+#if !SWT_NO_ABI_JSON_SCHEMA
+@Suite struct `ABI.EncodedExpression Tests` {
+  @Test func `Encodes a Swift expression`() throws {
+    let expression = Expression("1 + 1")
+    let encoded = ABI.EncodedExpression<ABI.CurrentVersion>(encoding: expression)
+
+    #expect(encoded.sourceCode == "1 + 1")
+    #expect(encoded.runtimeValue == nil)
+    #expect(encoded.runtimeTypeName == nil)
+    #expect(encoded.children == nil)
+  }
+
+  @Test func `Encodes an expression with a runtime value`() throws {
+    let expression = Expression("1 + 1", runtimeValue: .init(describing: 2))
+    let encoded = ABI.EncodedExpression<ABI.CurrentVersion>(encoding: expression)
+
+    #expect(encoded.sourceCode == "1 + 1")
+    #expect(encoded.runtimeValue == "2")
+    #expect(encoded.runtimeTypeName == "Swift.Int")
+    #expect(encoded.children == nil)
+  }
+
+  @Test func `Encodes an expression with children`() throws {
+    let lhs = Expression("foo()", runtimeValue: .init(describing: 1))
+    let rhs = Expression("bar()", runtimeValue: .init(describing: 1))
+    let expression = Expression("foo() + bar()", runtimeValue: .init(describing: 2), subexpressions: [lhs, rhs])
+    let encoded = ABI.EncodedExpression<ABI.CurrentVersion>(encoding: expression)
+
+    #expect(encoded.children?.count == 2)
+  }
+
+  @Test func `Expected field names`() throws {
+    let expression = Expression("1 + 1", runtimeValue: .init(describing: 2))
+    let encoded = ABI.EncodedExpression<ABI.CurrentVersion>(encoding: expression)
+
+    try JSON.withEncoding(of: encoded) { buf in
+      let str = String(decoding: buf, as: UTF8.self)
+      #expect(str.contains(#""sourceCode":"#))
+      #expect(str.contains(#""value":"#))
+      #expect(str.contains(#""type":"#))
+    }
+  }
+
+  @Test func `Round-trips through JSON`() throws {
+    let expression = Expression("1 + 1", runtimeValue: .init(describing: 2))
+    let encoded = ABI.EncodedExpression<ABI.CurrentVersion>(encoding: expression)
+    let decoded = try JSON.encodeAndDecode(encoded)
+
+    #expect(decoded.sourceCode == encoded.sourceCode)
+    #expect(decoded.runtimeValue == encoded.runtimeValue)
+    #expect(decoded.runtimeTypeName == encoded.runtimeTypeName)
+  }
+}
+#endif

--- a/Tests/TestingTests/ABI.EncodedIssueTests.swift
+++ b/Tests/TestingTests/ABI.EncodedIssueTests.swift
@@ -12,6 +12,7 @@
 
 #if !SWT_NO_ABI_JSON_SCHEMA
 @Suite struct `ABI.EncodedIssue Tests` {
+  // MARK: - Test Helpers
 
   /// Creates an EncodedIssue from a JSON string.
   ///
@@ -60,14 +61,21 @@
 
   // MARK: - Encode different issue types
 
-  @Test func `Encodes expectationFailed`() throws {
-    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(
-      encoding: Self.expectationFailedIssue, in: Self.sampleEventContext)
-    try JSON.withEncoding(of: encoded) { json in
-      let jsonString = String(decoding: json, as: UTF8.self)
+  struct IssueEncodingTestCase: CustomTestStringConvertible {
+    var testDescription: String {
+      "Issue to encode: \(issueToEncode.description)"
+    }
 
-      #expect(
-        jsonString == minified(##"""
+    var issueToEncode: Issue
+    /// The JSON the issue should encode into. The test should minify this
+    /// before comparing to the actual JSON.
+    var expectedJSON: String
+  }
+
+  static let issueTestCases = [
+    IssueEncodingTestCase(
+      issueToEncode: Self.expectationFailedIssue,
+      expectedJSON: ##"""
         {
           "expression":{
             "sourceCode":"#expect(a == b)",
@@ -87,24 +95,10 @@
             "line":1
           }
         }
-        """##)
-      )
-    }
-
-    let decodedIssue = try #require(Issue(decoding: encoded))
-    // Using the Issue.Kind description as a workaround to compare two values
-    // that are enums with associated values
-    #expect(Self.expectationFailedIssue.kind.description == decodedIssue.kind.description)
-  }
-
-  @Test func `Encodes errorCaught`() throws {
-    let issue = Issue(kind: .errorCaught(FakeError()))
-    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
-    try JSON.withEncoding(of: encoded) { json in
-      let jsonString = String(decoding: json, as: UTF8.self)
-
-      #expect(
-        jsonString == minified(#"""
+        """##),
+    IssueEncodingTestCase(
+      issueToEncode: Issue(kind: .errorCaught(FakeError())),
+      expectedJSON: #"""
         {
           "error":{
             "code":1,
@@ -119,22 +113,10 @@
           "isFailure":true,
           "severity":"error"
         }
-        """#)
-      )
-    }
-
-    let decodedIssue = try #require(Issue(decoding: encoded))
-    #expect(issue.kind.description == decodedIssue.kind.description)
-  }
-
-  @Test func `Encodes knownIssueNotRecorded`() throws {
-    let issue = Issue(kind: .knownIssueNotRecorded)
-    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
-    try JSON.withEncoding(of: encoded) { json in
-      let jsonString = String(decoding: json, as: UTF8.self)
-
-      #expect(
-        jsonString == minified(#"""
+        """#),
+    IssueEncodingTestCase(
+      issueToEncode: Issue(kind: .knownIssueNotRecorded),
+      expectedJSON: #"""
         {
           "error":{
             "code":1,
@@ -148,33 +130,13 @@
           "isFailure":true,
           "severity":"error"
         }
-        """#)
-      )
-    }
-
-    let decodedIssue = try #require(Issue(decoding: encoded))
-    #expect(issue.kind.description == decodedIssue.kind.description)
-  }
-
-  @Test func `Encodes timeLimitExceeded`() throws {
-    let issue = Issue(kind: .timeLimitExceeded(timeLimitComponents: (60, 0)))
-    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
-    try JSON.withEncoding(of: encoded) { json in
-      let jsonString = String(decoding: json, as: UTF8.self)
-      #expect(jsonString == #"{"exceededTimeLimit":60,"isFailure":true,"severity":"error"}"#)
-    }
-
-    let decodedIssue = try #require(Issue(decoding: encoded))
-    #expect(issue.kind.description == decodedIssue.kind.description)
-  }
-
-  @Test func `Encodes confirmationMiscounted, single expected`() throws {
-    let issue = Issue(kind: .confirmationMiscounted(actual: 5, expected: 10...10))
-    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
-    try JSON.withEncoding(of: encoded) { json in
-      let jsonString = String(decoding: json, as: UTF8.self)
-      #expect(
-        jsonString == minified(#"""
+        """#),
+    IssueEncodingTestCase(
+      issueToEncode: Issue(kind: .timeLimitExceeded(timeLimitComponents: (60, 0))),
+      expectedJSON: #"{"exceededTimeLimit":60,"isFailure":true,"severity":"error"}"#),
+    IssueEncodingTestCase(
+      issueToEncode: Issue(kind: .confirmationMiscounted(actual: 5, expected: 10...10)),
+      expectedJSON: #"""
         {
           "confirmationMiscount":{
             "actual":5,
@@ -183,21 +145,10 @@
           "isFailure":true,
           "severity":"error"
         }
-        """#)
-      )
-    }
-
-    let decodedIssue = try #require(Issue(decoding: encoded))
-    #expect(issue.kind.description == decodedIssue.kind.description)
-  }
-
-  @Test func `Encodes confirmationMiscounted, range expected`() throws {
-    let issue = Issue(kind: .confirmationMiscounted(actual: 5, expected: 10...15))
-    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
-    try JSON.withEncoding(of: encoded) { json in
-      let jsonString = String(decoding: json, as: UTF8.self)
-      #expect(
-        jsonString == minified(#"""
+        """#),
+    IssueEncodingTestCase(
+      issueToEncode: Issue(kind: .confirmationMiscounted(actual: 5, expected: 10...15)),
+      expectedJSON: #"""
         {
           "confirmationMiscount":{
             "actual":5,
@@ -209,26 +160,14 @@
           "isFailure":true,
           "severity":"error"
         }
-        """#)
-      )
-    }
-
-    let decodedIssue = try #require(Issue(decoding: encoded))
-    #expect(issue.kind.description == decodedIssue.kind.description)
-  }
-
-  @Test func `Encodes known issue with user comment`() throws {
-    let issue = {
-      var issue = Issue(kind: .errorCaught(FakeError()))
-      issue.knownIssueContext = .init(comment: "This issue was marked as known")
-      return issue
-    }()
-    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
-    try JSON.withEncoding(of: encoded) { json in
-      let jsonString = String(decoding: json, as: UTF8.self)
-
-      #expect(
-        jsonString == minified(#"""
+        """#),
+    IssueEncodingTestCase(
+      issueToEncode: {
+        var issue = Issue(kind: .errorCaught(FakeError()))
+        issue.knownIssueContext = .init(comment: "This issue was marked as known")
+        return issue
+      }(),
+      expectedJSON: #"""
         {
           "error":{
             "code":1,
@@ -244,26 +183,14 @@
           "isKnown":"This issue was marked as known",
           "severity":"error"
         }
-        """#)
-      )
-    }
-
-    let decodedIssue = try #require(Issue(decoding: encoded))
-    #expect(issue.kind.description == decodedIssue.kind.description)
-  }
-
-  @Test func `Encodes known issue without user comment`() throws {
-    let issue = {
-      var issue = Issue(kind: .errorCaught(FakeError()))
-      issue.knownIssueContext = .init()
-      return issue
-    }()
-    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
-    try JSON.withEncoding(of: encoded) { json in
-      let jsonString = String(decoding: json, as: UTF8.self)
-
-      #expect(
-        jsonString == minified(#"""
+        """#),
+    IssueEncodingTestCase(
+      issueToEncode: {
+        var issue = Issue(kind: .errorCaught(FakeError()))
+        issue.knownIssueContext = .init()
+        return issue
+      }(),
+      expectedJSON: #"""
         {
           "error":{
             "code":1,
@@ -279,12 +206,26 @@
           "isKnown":true,
           "severity":"error"
         }
-        """#)
-      )
-    }
+        """#),
+  ]
 
+  @Test(arguments: Self.issueTestCases)
+  func `Encodes issue types to expected JSON`(testCase: IssueEncodingTestCase) throws {
+    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: testCase.issueToEncode, in: Self.sampleEventContext)
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+      #expect(jsonString == minified(testCase.expectedJSON))
+    }
+  }
+
+  @Test(arguments: Self.issueTestCases)
+  func `Round trip encode/decode issue preserves issue kind`(testCase: IssueEncodingTestCase) throws {
+    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: testCase.issueToEncode, in: Self.sampleEventContext)
     let decodedIssue = try #require(Issue(decoding: encoded))
-    #expect(issue.kind.description == decodedIssue.kind.description)
+
+    // Using the Issue.Kind description as a workaround to compare two values
+    // that are enums with associated values
+    #expect(testCase.issueToEncode.kind.description == decodedIssue.kind.description)
   }
 
   // MARK: - Backwards compatibility

--- a/Tests/TestingTests/ABI.EncodedIssueTests.swift
+++ b/Tests/TestingTests/ABI.EncodedIssueTests.swift
@@ -1,0 +1,301 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+#if !SWT_NO_ABI_JSON_SCHEMA
+@Suite struct `ABI.EncodedIssue Tests` {
+
+  /// Creates an EncodedIssue from a JSON string.
+  ///
+  /// - Throws: If the JSON doesn't represent a valid EncodedIssue.
+  private func encodedIssue<V>(_ version: V.Type, _ json: String) throws -> ABI.EncodedIssue<V> {
+    var json = json
+    return try json.withUTF8 { json in
+      try JSON.decode(ABI.EncodedIssue<V>.self, from: UnsafeRawBufferPointer(json))
+    }
+  }
+
+  /// Converts pretty-printed JSON -> single line JSON by trimming out
+  /// indentation and newlines.
+  ///
+  /// This allows us to write test expectations with nicer formatting.
+  private func minified(_ json: String) -> String {
+    json.split(separator: "\n")
+      .map { $0.trimmingPrefix { $0 == " " } }
+      .joined()
+  }
+
+  static let sourceLocation = SourceLocation(fileID: "SomeTests/SomeTests.swift", filePath: "/path/to/SomeTests.swift", line: 1, column: 1)
+
+  static let expectationFailedIssue: Issue = {
+    // SourceLocation must be provided for the Issue in order for it to go from
+    // Issue -> EncodedIssue -> Issue and successfully decode its expression
+    var evaluatedExpression = __Expression("#expect(a == b)")
+    evaluatedExpression.runtimeValue = __Expression.Value(describing: false)
+    return Issue(
+      kind:
+        .expectationFailed(
+          .init(
+            evaluatedExpression: evaluatedExpression,
+            isPassing: false,
+            isRequired: true,
+            sourceLocation: sourceLocation)
+        ),
+      comments: ["My User Comment"],
+      sourceContext: .init(sourceLocation: sourceLocation))
+  }()
+
+  static let sampleEventContext: Event.Context = Event.Context(
+    test: Test {}, testCase: nil, iteration: 1, configuration: nil)
+
+  struct FakeError: Error {}
+
+  // MARK: - Encode different issue types
+
+  @Test func `Encodes expectationFailed`() throws {
+    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(
+      encoding: Self.expectationFailedIssue, in: Self.sampleEventContext)
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+
+      #expect(
+        jsonString == minified(##"""
+        {
+          "expression":{
+            "sourceCode":"#expect(a == b)",
+            "type":{
+              "fullyQualifiedName":"Swift.Bool",
+              "mangledName":"$sSb",
+              "unqualifiedName":"Bool"
+            },
+            "value":"false"
+          },
+          "isFailure":true,
+          "severity":"error",
+          "sourceLocation":{
+            "column":1,
+            "fileID":"SomeTests\/SomeTests.swift",
+            "filePath":"\/path\/to\/SomeTests.swift",
+            "line":1
+          }
+        }
+        """##)
+      )
+    }
+
+    let decodedIssue = try #require(Issue(decoding: encoded))
+    // Using the Issue.Kind description as a workaround to compare two values
+    // that are enums with associated values
+    #expect(Self.expectationFailedIssue.kind.description == decodedIssue.kind.description)
+  }
+
+  @Test func `Encodes errorCaught`() throws {
+    let issue = Issue(kind: .errorCaught(FakeError()))
+    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+
+      #expect(
+        jsonString == minified(#"""
+        {
+          "error":{
+            "code":1,
+            "description":"FakeError()",
+            "domain":"TestingTests.`ABI.EncodedIssue Tests`.FakeError",
+            "type":{
+              "fullyQualifiedName":"TestingTests.`ABI.EncodedIssue Tests`.FakeError",
+              "mangledName":"s12TestingTests0035ABIEncodedIssueTests_wtaFABFCjAGawaV9FakeErrorV",
+              "unqualifiedName":"FakeError"
+            }
+          },
+          "isFailure":true,
+          "severity":"error"
+        }
+        """#)
+      )
+    }
+
+    let decodedIssue = try #require(Issue(decoding: encoded))
+    #expect(issue.kind.description == decodedIssue.kind.description)
+  }
+
+  @Test func `Encodes knownIssueNotRecorded`() throws {
+    let issue = Issue(kind: .knownIssueNotRecorded)
+    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+
+      #expect(jsonString == #"{"isFailure":true,"severity":"error"}"#)
+    }
+
+    let decodedIssue = try #require(Issue(decoding: encoded))
+    #expect(issue.kind.description == decodedIssue.kind.description)
+  }
+
+  @Test func `Encodes timeLimitExceeded`() throws {
+    let issue = Issue(kind: .timeLimitExceeded(timeLimitComponents: (60, 0)))
+    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+      #expect(jsonString == #"{"exceededTimeLimit":60,"isFailure":true,"severity":"error"}"#)
+    }
+
+    let decodedIssue = try #require(Issue(decoding: encoded))
+    #expect(issue.kind.description == decodedIssue.kind.description)
+  }
+
+  @Test func `Encodes confirmationMiscounted`() throws {
+    let issue = Issue(kind: .confirmationMiscounted(actual: 5, expected: 10...10))
+    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+      #expect(
+        jsonString == minified(#"""
+        {
+          "confirmationMiscount":{
+            "actual":5,
+            "expected":10
+          },
+          "isFailure":true,
+          "severity":"error"
+        }
+        """#)
+      )
+    }
+
+    let decodedIssue = try #require(Issue(decoding: encoded))
+    #expect(issue.kind.description == decodedIssue.kind.description)
+  }
+
+  @Test func `Encodes known issue`() throws {
+    let issue = {
+      var issue = Issue(kind: .errorCaught(FakeError()))
+      issue.knownIssueContext = .init(comment: "This issue was marked as known")
+      return issue
+    }()
+    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+
+      #expect(
+        jsonString == minified(#"""
+        {
+          "error":{
+            "code":1,
+            "description":"FakeError()",
+            "domain":"TestingTests.`ABI.EncodedIssue Tests`.FakeError",
+            "type":{
+              "fullyQualifiedName":"TestingTests.`ABI.EncodedIssue Tests`.FakeError",
+              "mangledName":"$s12TestingTests0035ABIEncodedIssueTests_wtaFABFCjAGawaV9FakeErrorV",
+              "unqualifiedName":"FakeError"
+            }
+          },
+          "isFailure":false,
+          "isKnown":"This issue was marked as known",
+          "severity":"error"
+        }
+        """#)
+      )
+    }
+
+    let decodedIssue = try #require(Issue(decoding: encoded))
+    #expect(issue.kind.description == decodedIssue.kind.description)
+  }
+
+  // MARK: - Backwards compatibility
+
+  @Test func `Decodes v6.4 JSON`() throws {
+    _ = try encodedIssue(
+      ABI.v6_4.self,
+      """
+      {
+        "isKnown": false,
+        "severity": "error",
+        "isFailure": true,
+      }
+      """
+    )
+  }
+
+  @Test func `Fails to decode v6.4 with missing isKnown field`() throws {
+    #expect(throws: DecodingError.self) {
+      _ = try encodedIssue(
+        ABI.v6_4.self,
+        """
+        {
+          "severity": "error",
+          "isFailure": true,
+        }
+        """
+      )
+    }
+  }
+
+  /// isKnown became optional in 6.5
+  @Test func `Decodes current ABI with missing isKnown field`() throws {
+    #expect(throws: Never.self) {
+      _ = try encodedIssue(
+        ABI.CurrentVersion.self,
+        """
+        {
+          "severity": "error",
+          "isFailure": true,
+        }
+        """
+      )
+    }
+  }
+
+  /// Each of these issue kinds contain extra information that is only encoded
+  /// in v6.5 of the issue, so they should all encode to the same JSON in v6.4.
+  @Test(arguments: [
+    Self.expectationFailedIssue,
+    Issue(kind: .errorCaught(FakeError()), sourceContext: .init(sourceLocation: Self.sourceLocation)),
+    Issue(kind: .knownIssueNotRecorded, sourceContext: .init(sourceLocation: Self.sourceLocation)),
+    Issue(kind: .timeLimitExceeded(timeLimitComponents: (60, 0)), sourceContext: .init(sourceLocation: Self.sourceLocation)),
+    Issue(kind: .confirmationMiscounted(actual: 5, expected: 10...10), sourceContext: .init(sourceLocation: Self.sourceLocation)),
+  ])
+  func `Encodes v6.4 issues without fields added in v6.5`(issue: Issue) throws {
+    let encoded = ABI.EncodedIssue<ABI.v6_4>(encoding: issue, in: Self.sampleEventContext)
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+
+      #expect(jsonString == minified(#"""
+        {
+          "isFailure":true,
+          "isKnown":false,
+          "severity":"error",
+          "sourceLocation":{
+            "column":1,
+            "fileID":"SomeTests\/SomeTests.swift",
+            "filePath":"\/path\/to\/SomeTests.swift",
+            "line":1
+          }
+        }
+        """#)
+      )
+    }
+  }
+
+  @Test func `Encodes v6.4 known issue without including comment`() throws {
+    let encoded = {
+      var issue = Issue(kind: .errorCaught(FakeError()))
+      issue.knownIssueContext = .init(comment: "This issue was marked as known")
+      return ABI.EncodedIssue<ABI.v6_4>(encoding: issue, in: Self.sampleEventContext)
+    }()
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+
+      #expect(jsonString == #"{"isFailure":false,"isKnown":true,"severity":"error"}"#)
+    }
+  }
+}
+#endif

--- a/Tests/TestingTests/ABI.EncodedIssueTests.swift
+++ b/Tests/TestingTests/ABI.EncodedIssueTests.swift
@@ -112,7 +112,7 @@
             "domain":"TestingTests.`ABI.EncodedIssue Tests`.FakeError",
             "type":{
               "fullyQualifiedName":"TestingTests.`ABI.EncodedIssue Tests`.FakeError",
-              "mangledName":"s12TestingTests0035ABIEncodedIssueTests_wtaFABFCjAGawaV9FakeErrorV",
+              "mangledName":"$s12TestingTests0035ABIEncodedIssueTests_wtaFABFCjAGawaV9FakeErrorV",
               "unqualifiedName":"FakeError"
             }
           },

--- a/Tests/TestingTests/ABI.EncodedIssueTests.swift
+++ b/Tests/TestingTests/ABI.EncodedIssueTests.swift
@@ -87,13 +87,7 @@
             "value":"false"
           },
           "isFailure":true,
-          "severity":"error",
-          "sourceLocation":{
-            "column":1,
-            "fileID":"SomeTests\/SomeTests.swift",
-            "filePath":"\/path\/to\/SomeTests.swift",
-            "line":1
-          }
+          "severity":"error"
         }
         """##),
     IssueEncodingTestCase(
@@ -219,13 +213,18 @@
   }
 
   @Test(arguments: Self.issueTestCases)
-  func `Round trip encode/decode issue preserves issue kind`(testCase: IssueEncodingTestCase) throws {
-    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: testCase.issueToEncode, in: Self.sampleEventContext)
+  func `Issue -> EncodedEvent -> Issue preserves issue kind, comments, and source location`(testCase: IssueEncodingTestCase) throws {
+    var issue = testCase.issueToEncode
+    issue.comments = ["Some User Comment"]
+    issue.sourceContext = .init(sourceLocation: Self.sourceLocation)
+    let encoded = try #require(ABI.EncodedEvent<ABI.CurrentVersion>(encoding: .init(.issueRecorded(issue), testID: nil, testCaseID: nil),  in: Self.sampleEventContext))
     let decodedIssue = try #require(Issue(decoding: encoded))
 
     // Using the Issue.Kind description as a workaround to compare two values
     // that are enums with associated values
     #expect(testCase.issueToEncode.kind.description == decodedIssue.kind.description)
+    #expect(decodedIssue.sourceLocation != nil)
+    #expect(!decodedIssue.comments.isEmpty)
   }
 
   // MARK: - Backwards compatibility
@@ -274,6 +273,7 @@
 
   /// Each of these issue kinds contain extra information that is only encoded
   /// in v6.5 of the issue, so they should all encode to the same JSON in v6.4.
+  /// sourceLocation is also removed in v6.5, but needs to stay for v6.4.
   @Test(arguments: [
     Self.expectationFailedIssue,
     Issue(kind: .errorCaught(FakeError()), sourceContext: .init(sourceLocation: Self.sourceLocation)),
@@ -281,7 +281,7 @@
     Issue(kind: .timeLimitExceeded(timeLimitComponents: (60, 0)), sourceContext: .init(sourceLocation: Self.sourceLocation)),
     Issue(kind: .confirmationMiscounted(actual: 5, expected: 10...10), sourceContext: .init(sourceLocation: Self.sourceLocation)),
   ])
-  func `Encodes v6.4 issues without fields added in v6.5`(issue: Issue) throws {
+  func `Maintains original encoding for v6.4 issues`(issue: Issue) throws {
     let encoded = ABI.EncodedIssue<ABI.v6_4>(encoding: issue, in: Self.sampleEventContext)
     try JSON.withEncoding(of: encoded) { json in
       let jsonString = String(decoding: json, as: UTF8.self)

--- a/Tests/TestingTests/ABI.EncodedIssueTests.swift
+++ b/Tests/TestingTests/ABI.EncodedIssueTests.swift
@@ -133,7 +133,23 @@
     try JSON.withEncoding(of: encoded) { json in
       let jsonString = String(decoding: json, as: UTF8.self)
 
-      #expect(jsonString == #"{"isFailure":true,"severity":"error"}"#)
+      #expect(
+        jsonString == minified(#"""
+        {
+          "error":{
+            "code":1,
+            "domain":"org.swift.testing.KnownIssueNotRecordedError",
+            "type":{
+              "fullyQualifiedName":"Testing.KnownIssueNotRecordedError",
+              "mangledName":"$s7Testing26KnownIssueNotRecordedErrorV",
+              "unqualifiedName":"KnownIssueNotRecordedError"
+            }
+          },
+          "isFailure":true,
+          "severity":"error"
+        }
+        """#)
+      )
     }
 
     let decodedIssue = try #require(Issue(decoding: encoded))
@@ -152,7 +168,7 @@
     #expect(issue.kind.description == decodedIssue.kind.description)
   }
 
-  @Test func `Encodes confirmationMiscounted`() throws {
+  @Test func `Encodes confirmationMiscounted, single expected`() throws {
     let issue = Issue(kind: .confirmationMiscounted(actual: 5, expected: 10...10))
     let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
     try JSON.withEncoding(of: encoded) { json in
@@ -175,7 +191,33 @@
     #expect(issue.kind.description == decodedIssue.kind.description)
   }
 
-  @Test func `Encodes known issue`() throws {
+  @Test func `Encodes confirmationMiscounted, range expected`() throws {
+    let issue = Issue(kind: .confirmationMiscounted(actual: 5, expected: 10...15))
+    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+      #expect(
+        jsonString == minified(#"""
+        {
+          "confirmationMiscount":{
+            "actual":5,
+            "expected":{
+              "max":15,
+              "min":10
+            }
+          },
+          "isFailure":true,
+          "severity":"error"
+        }
+        """#)
+      )
+    }
+
+    let decodedIssue = try #require(Issue(decoding: encoded))
+    #expect(issue.kind.description == decodedIssue.kind.description)
+  }
+
+  @Test func `Encodes known issue with user comment`() throws {
     let issue = {
       var issue = Issue(kind: .errorCaught(FakeError()))
       issue.knownIssueContext = .init(comment: "This issue was marked as known")
@@ -200,6 +242,41 @@
           },
           "isFailure":false,
           "isKnown":"This issue was marked as known",
+          "severity":"error"
+        }
+        """#)
+      )
+    }
+
+    let decodedIssue = try #require(Issue(decoding: encoded))
+    #expect(issue.kind.description == decodedIssue.kind.description)
+  }
+
+  @Test func `Encodes known issue without user comment`() throws {
+    let issue = {
+      var issue = Issue(kind: .errorCaught(FakeError()))
+      issue.knownIssueContext = .init()
+      return issue
+    }()
+    let encoded = ABI.EncodedIssue<ABI.CurrentVersion>(encoding: issue, in: Self.sampleEventContext)
+    try JSON.withEncoding(of: encoded) { json in
+      let jsonString = String(decoding: json, as: UTF8.self)
+
+      #expect(
+        jsonString == minified(#"""
+        {
+          "error":{
+            "code":1,
+            "description":"FakeError()",
+            "domain":"TestingTests.`ABI.EncodedIssue Tests`.FakeError",
+            "type":{
+              "fullyQualifiedName":"TestingTests.`ABI.EncodedIssue Tests`.FakeError",
+              "mangledName":"$s12TestingTests0035ABIEncodedIssueTests_wtaFABFCjAGawaV9FakeErrorV",
+              "unqualifiedName":"FakeError"
+            }
+          },
+          "isFailure":false,
+          "isKnown":true,
           "severity":"error"
         }
         """#)

--- a/Tests/TestingTests/ABI.EncodedRangeTests.swift
+++ b/Tests/TestingTests/ABI.EncodedRangeTests.swift
@@ -1,0 +1,76 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+#if !SWT_NO_ABI_JSON_SCHEMA
+@Suite struct `ABI.EncodedRange Tests` {
+  @Test(arguments: [
+    (ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: 1...10), 1 as Int?, 10 as Int?),
+    (ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: 1..<10), 1, 9),
+    (ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: 1...), 1, nil),
+    // The following ranges are NOT supported by confirmation, but are included for completeness.
+    (ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: ...10), nil, 10),
+    (ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: ..<10), nil, 9),
+  ]) func `Encodes a closed range`(range: ABI.EncodedRange<ABI.CurrentVersion>?, min: Int?, max: Int?) throws {
+    let range = try #require(range)
+    #expect(range.min == min)
+    #expect(range.max == max)
+  }
+
+  @Test(arguments: [
+    ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: 1...10),
+    ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: 1..<10),
+    ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: 1...),
+    ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: ...10),
+    ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: ..<10),
+  ]) func `Round-trips through JSON`(range: ABI.EncodedRange<ABI.CurrentVersion>?) throws {
+    let range = try #require(range)
+    let decoded = try JSON.encodeAndDecode(range)
+    #expect(decoded.min == range.min)
+    #expect(decoded.max == range.max)
+  }
+
+  @Test func `Unsupported ranges fail to decode`() {
+    #expect(ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: ..<Int.min) == nil)
+    #expect(ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: Int.min..<Int.min) == nil)
+
+    // Unsupported non-integer range
+    #expect(ABI.EncodedRange<ABI.CurrentVersion>(expectedRange: 0.0..<1.5) == nil)
+  }
+
+  @Test(arguments: [
+    (1 as Int?, 10 as Int?, 1...10),
+
+    (1, nil, 1...Int.max),
+    (1, Int.max, 1...Int.max),
+
+    (nil, 10, Int.min...10),
+    (Int.min, 10, Int.min...10),
+  ])
+  func `EncodedRange -> ClosedRange<Int>`(min: Int?, max: Int?, expected: ClosedRange<Int>) throws {
+    let range = try ABI.EncodedRange<ABI.CurrentVersion>.rangeWithBounds(min: min, max: max)
+    #expect(ClosedRange<Int>(decoding: range) == expected)
+  }
+}
+
+extension ABI.EncodedRange {
+  /// Construct a range with custom bounds for ease of test setup.
+  static func rangeWithBounds(min: Int?, max: Int?) throws -> Self {
+    if let min, let max {
+      try #require(min <= max)
+    }
+    var range = try #require(Self(expectedRange: 0...10))
+    range.min = min
+    range.max = max
+    return range
+  }
+}
+#endif

--- a/Tests/TestingTests/ABI.EncodedTypeInfoTests.swift
+++ b/Tests/TestingTests/ABI.EncodedTypeInfoTests.swift
@@ -1,0 +1,67 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(ForToolsIntegrationOnly) import Testing
+
+#if !SWT_NO_ABI_JSON_SCHEMA
+@Suite struct `ABI.EncodedTypeInfo Tests` {
+  @Test func `Encodes TypeInfo`() {
+    let typeInfo = TypeInfo(describing: Bool.self)
+    let encoded = ABI.EncodedTypeInfo<ABI.CurrentVersion>(encoding: typeInfo)
+
+    #expect(encoded.fullyQualifiedName == "Swift.Bool")
+    #expect(encoded.unqualifiedName == "Bool")
+    #expect(encoded.mangledName == "$sSb")
+  }
+
+  @Test func `Round-trips through JSON`() throws {
+    let typeInfo = TypeInfo(describing: Bool.self)
+    let encoded = ABI.EncodedTypeInfo<ABI.CurrentVersion>(encoding: typeInfo)
+    let decoded = try JSON.encodeAndDecode(encoded)
+
+    #expect(decoded.fullyQualifiedName == encoded.fullyQualifiedName)
+    #expect(decoded.unqualifiedName == encoded.unqualifiedName)
+    #expect(decoded.mangledName == encoded.mangledName)
+  }
+
+  @Test func `Decode succeeds with missing fields`() throws {
+    let encodedData = Array(
+      """
+      {
+        "unqualifiedName": "string"
+      }
+      """.utf8)
+    let decoded = try encodedData.withUnsafeBytes { encodedData in
+      try JSON.decode(ABI.EncodedTypeInfo<ABI.CurrentVersion>.self, from: encodedData)
+    }
+
+    #expect(decoded.fullyQualifiedName == nil)
+    #expect(decoded.unqualifiedName == "string")
+    #expect(decoded.mangledName == nil)
+  }
+
+  @Test func `Round trips TypeInfo`() {
+    let typeInfo = TypeInfo(describing: Bool.self)
+    let encoded = ABI.EncodedTypeInfo<ABI.CurrentVersion>(encoding: typeInfo)
+    let decoded = TypeInfo(decoding: encoded)
+
+    #expect(typeInfo == decoded)
+  }
+
+  @Test func `Round trips TypeInfo with raw identifier name`() {
+    struct `Period.Delimited.Type` {}
+    let typeInfo = TypeInfo(describing: `Period.Delimited.Type`.self)
+    let encoded = ABI.EncodedTypeInfo<ABI.CurrentVersion>(encoding: typeInfo)
+    let decoded = TypeInfo(decoding: encoded)
+
+    #expect(typeInfo == decoded)
+  }
+}
+#endif

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -1070,7 +1070,7 @@ extension AttachmentTests {
       {
         "kind": "valueAttached",
         "instant": { "since1970": 0, "absolute": 0 },
-        "_sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
+        "sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
         "attachment": { "_bytes": "YWJjMTIz" }
       }
       """#

--- a/Tests/TestingTests/SkipInfoTests.swift
+++ b/Tests/TestingTests/SkipInfoTests.swift
@@ -44,7 +44,7 @@ struct SkipInfoTests {
         "instant": { "since1970": 0, "absolute": 0 },
         "messages": [],
         "comments": ["Skipped Test"],
-        "_sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
+        "sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
       }
       """#
     let event = try json.withUTF8 { json in
@@ -65,7 +65,7 @@ struct SkipInfoTests {
         "instant": { "since1970": 0, "absolute": 0 },
         "messages": [],
         "comments": ["Skipped Test"],
-        "_sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
+        "sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
       }
       """#
     let event = try json.withUTF8 { json in

--- a/Tests/TestingTests/SkipInfoTests.swift
+++ b/Tests/TestingTests/SkipInfoTests.swift
@@ -43,7 +43,7 @@ struct SkipInfoTests {
         "kind": "\#(kind)",
         "instant": { "since1970": 0, "absolute": 0 },
         "messages": [],
-        "_comments": ["Skipped Test"],
+        "comments": ["Skipped Test"],
         "_sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
       }
       """#
@@ -64,7 +64,7 @@ struct SkipInfoTests {
         "kind": "testStarted",
         "instant": { "since1970": 0, "absolute": 0 },
         "messages": [],
-        "_comments": ["Skipped Test"],
+        "comments": ["Skipped Test"],
         "_sourceLocation": { "filePath": "/a/b/c", "line": 12345, "column": 67890 },
       }
       """#


### PR DESCRIPTION
Add fields to the EncodedIssue structure

Reviewers: I've split this change up by commit which you might have an easier time reviewing. Let me know any feedback on this structure too, thanks!

### Motivation:

Provider richer issue metadata for tools to work with.

This is the implementation that accompanies the pitch "Include
additional issue metadata in event stream", which contains additional
context and motivation. https://github.com/jerryjrchen/swift-evolution/blob/update-issue-json-abi/proposals/testing/nnnn-add-issue-metadata-event-stream.md

### Modifications:

Add custom Codable conformances to many ABI.Encoded... types as a
consequence of the more complex issue encoding scheme.

For example, the isKnown field can be encoded as either a boolean or a
string depending on the presence of _knownIssueComment.

Issue schema additions:

* Expression
* Time limit exceeded
* Error
* isKnown (modified to encode as _knownIssueComment if present)
* Confirmation miscount

Event schema changes:

* Add comments
* Messages is already optional (#1827), but is now formally included in
  this proposal for 6.5. Update the version checks for
  always[Encode,Decode]MessagesField to < ABI.v6_5.

Resolves rdar://173944877

### Checklist:

- [ ] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [ ] If public symbols are renamed or modified, DocC references should be updated.
