### PR TITLE
Check for feature flags in the environment block when building as a package.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,9 @@
 
 import PackageDescription
 import CompilerPluginSupport
+#if canImport(Foundation)
+import Foundation
+#endif
 
 /// Information about the current state of the package's git repository.
 let git = Context.gitInformation
@@ -559,8 +562,26 @@ extension Array where Element: _LanguageBuildSetting {
       "SWT_NO_LIBDISPATCH": (platforms: .none, embedded: true),
     ]
 
+    // Let the environment block override our settings above.
+    let environmentVariables = Context.environment
+      .filter { $0.key.starts(with: "SWT_NO_") }
+      .compactMapValues { value in
+#if canImport(Foundation)
+        (value as NSString).boolValue
+#else
+        Bool(value) ?? UInt64(value).map { $0 != 0 }
+#endif
+      }
+
     for (name, details) in defines {
-      if !buildingForEmbedded {
+      if let environmentVariable = environmentVariables[name] {
+        // The environment variable is set. If the value is `true`, that means
+        // the "NO" flag should be set unconditionally. If the value is `false`,
+        // that means the flag should _not_ be set.
+        if environmentVariable {
+          append(.define(name, nil))
+        }
+      } else if !buildingForEmbedded {
         if let platforms = details.platforms {
           append(.define(name, .when(platforms: platforms)))
         } else {


### PR DESCRIPTION
This PR lets developers toggle individual feature flags like `SWT_NO_EXIT_TESTS` by setting them in the environment before calling `swift test` at the command line. For example:

```sh
export SWT_NO_FILE_CLONING=1
swift test
```

This makes it a bit easier to test out different configurations at the command line, and allows us to pre-specify various feature flags for known Embedded Swift targets that do or don't support them.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
