### PR TITLE
GHA: Add build verdict workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,3 +49,27 @@ jobs:
       docs_check_enabled: false
       format_check_enabled: false
       api_breakage_check_enabled: false
+  build-verdict:
+    name: Build Verdict
+    runs-on: ubuntu-latest
+    needs:
+      - list-xcodes
+      - tests
+      - soundness
+    if: always()  # Runs even if previous jobs fail so it can evaluate them
+    steps:
+      - name: Install required tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends coreutils jq
+      - name: Check upstream job statuses
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failed=$(printf '%s' "$NEEDS_JSON" | jq -r 'to_entries | map(select(.value.result != "success")) | .[] | "\(.key): \(.value.result)"')
+          if [ -n "$failed" ]; then
+            echo "The following required jobs did not succeed:"
+            printf '%s\n' "$failed"
+            exit 1
+          fi
+          echo "All required jobs succeeded."


### PR DESCRIPTION
Add a build verdict worflow that emits all the jobs that failed.  This can be useful to mark this build as required should the CI builds want to be gating before a PR is merged.