### PR TITLE
[6.4.x] Remove Amazon Linux 2 from our GHA workflows.

### DIFF
--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
       linux_swift_versions: '["nightly-main"]'
-      linux_os_versions: '["amazonlinux2", "jammy"]'
+      linux_os_versions: '["jammy"]'
       linux_static_sdk_versions: '["nightly-main"]'
       windows_swift_versions: '["nightly-main"]'
       enable_macos_checks: true

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -18,7 +18,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
       linux_swift_versions: '["nightly-6.3"]'
-      linux_os_versions: '["amazonlinux2", "jammy"]'
+      linux_os_versions: '["jammy"]'
       linux_static_sdk_versions: '["6.3", "nightly-6.3"]'
       windows_swift_versions: '["6.3", "nightly-6.3"]'
       enable_macos_checks: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
       linux_swift_versions: '["nightly-main", "nightly-6.3"]'
-      linux_os_versions: '["amazonlinux2", "jammy"]'
+      linux_os_versions: '["jammy"]'
       linux_static_sdk_versions: '["6.3", "nightly-main", "nightly-6.3"]'
       windows_swift_versions: '["6.3", "nightly-main", "nightly-6.3"]'
       enable_macos_checks: true


### PR DESCRIPTION
Swift no longer builds for Amazon Linux 2, so remove it from our 6.4 workflows to get CI green again.

No source impact.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
