### PR TITLE
Remove some old workarounds.

### DIFF
--- a/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedError.swift
@@ -90,15 +90,11 @@ extension ABI.EncodedError {
     if !description.isEmpty {
       self.description = description
     }
-#if !hasFeature(Embedded)
     let domain = error._domain
     if domain != Self.unknownDomain {
       self.domain = domain
     }
     code = error._code
-#else
-    code = -1
-#endif
   }
 }
 

--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -550,12 +550,7 @@ extension Attachment where AttachableValue: ~Copyable {
         let preferredPath = appendPathComponent(preferredName, to: directoryPath)
 
         func isEEXIST(_ error: any Error) -> Bool {
-#if !hasFeature(Embedded)
           error._code == swt_EEXIST() && error._domain == "NSPOSIXErrorDomain"
-#else
-          // TODO: detect EEXIST without using _code/_domain?
-          false
-#endif
         }
 
         // Propagate any error *except* EEXIST, which would indicate that the

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -262,18 +262,6 @@ extension Issue: CustomStringConvertible, CustomDebugStringConvertible {
   }
 }
 
-#if !hasFeature(Embedded)
-/// An empty protocol defining a type that conforms to `RangeExpression<Int>`.
-///
-/// In the future, when our minimum deployment target supports casting a value
-/// to a constrained existential type ([SE-0353](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0353-constrained-existential-types.md#effect-on-abi-stability)),
-/// we can remove this protocol and cast to `RangeExpression<Int>` instead.
-private protocol _RangeExpressionOverIntValues: RangeExpression & Sequence where Bound == Int, Element == Int {}
-extension ClosedRange<Int>: _RangeExpressionOverIntValues {}
-extension PartialRangeFrom<Int>: _RangeExpressionOverIntValues {}
-extension Range<Int>: _RangeExpressionOverIntValues {}
-#endif
-
 extension Issue.Kind: CustomStringConvertible {
   public var description: String {
     switch self {
@@ -292,7 +280,7 @@ extension Issue.Kind: CustomStringConvertible {
       }
     case let .confirmationMiscounted(actual: actual, expected: expected):
 #if !hasFeature(Embedded)
-      if let expected = expected as? any _RangeExpressionOverIntValues {
+      if let expected = expected as? any Sequence<Int> {
         let lowerBound = expected.first { _ in true }
         if let lowerBound {
           // Not actually an upper bound, just "any value greater than the lower


### PR DESCRIPTION
Remove workarounds for `Error` not having underscored properties in Embedded Swift (fixed in https://github.com/swiftlang/swift/pull/88954) and for the lack of constrained existential casts (our minimum deployment targets support it now).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
