### PR TITLE
Add new "metadata recorded" event.

### DIFF
--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -18,19 +18,14 @@ extension ABI.Version {
       humanReadableOutputRecorder = Event.HumanReadableOutputRecorder()
     }
     return { [humanReadableOutputRecorder] event, context in
-      if case .testDiscovered = event.kind, let test = context.test {
-        let testRecord = ABI.Record<Self>(encoding: test)
-        recordHandler(testRecord)
-      } else {
-        var messages: [Event.HumanReadableOutputRecorder.Message] = []
-        if let humanReadableOutputRecorder {
-          var configuration = Configuration()
-          configuration.verbosity = 0
-          messages = humanReadableOutputRecorder.record(event, in: context, configuration: configuration)
-        }
-        if let eventRecord = ABI.Record<Self>(encoding: event, in: context, messages: messages) {
-          recordHandler(eventRecord)
-        }
+      var messages: [Event.HumanReadableOutputRecorder.Message] = []
+      if let humanReadableOutputRecorder {
+        var configuration = Configuration()
+        configuration.verbosity = 0
+        messages = humanReadableOutputRecorder.record(event, in: context, configuration: configuration)
+      }
+      if let record = ABI.Record<Self>(encoding: event, in: context, messages: messages) {
+        recordHandler(record)
       }
     }
   }
@@ -68,11 +63,14 @@ extension ABI.Xcode16 {
     forwardingTo recordHandler: @escaping @Sendable (_ recordJSON: UnsafeRawBufferPointer) -> Void
   ) -> Event.Handler {
     return { event, context in
-      if case .testDiscovered = event.kind {
+      switch event.kind {
+      case .testDiscovered, .metadataRecorded:
         // Discard events of this kind rather than forwarding them to avoid a
         // crash in Xcode 16 (which does not expect any events to occur before
         // .runStarted.)
         return
+      default:
+        break
       }
 
       struct EventAndContextSnapshot: Codable {

--- a/Sources/Testing/ABI/ABI.Record.swift
+++ b/Sources/Testing/ABI/ABI.Record.swift
@@ -28,6 +28,12 @@ extension ABI {
 
       /// An event record.
       case event(EncodedEvent<V>)
+
+      /// Some metadata regarding the test run, the current environment, etc.
+      ///
+      /// - Warning: Metadata is not yet part of the JSON schema.
+      @_spi(Experimental)
+      case metadata(EncodedMetadata<V>)
     }
 
     /// The kind of record.
@@ -39,6 +45,13 @@ extension ABI {
 
     public init(encoding event: borrowing EncodedEvent<V>) {
       kind = .event(copy event)
+    }
+
+    public init?(encoding metadata: borrowing EncodedMetadata<V>) {
+      guard V.includesExperimentalFields else {
+        return nil
+      }
+      kind = .metadata(copy metadata)
     }
   }
 }
@@ -52,14 +65,29 @@ extension ABI.Record {
   }
 
   init?(encoding event: borrowing Event, in eventContext: borrowing Event.Context, messages: borrowing [Event.HumanReadableOutputRecorder.Message] = []) {
-    guard let event = ABI.EncodedEvent<V>(encoding: event, in: eventContext, messages: messages) else {
-      return nil
+    switch event.kind {
+    case .testDiscovered:
+      guard let test = eventContext.test else {
+        return nil
+      }
+      self.init(encoding: test)
+    case let .metadataRecorded(metadata):
+      self.init(encoding: metadata)
+    default:
+      guard let event = ABI.EncodedEvent<V>(encoding: event, in: eventContext, messages: messages) else {
+        return nil
+      }
+      if !V.includesExperimentalFields && event.kind.rawValue.first == "_" {
+        // Don't encode experimental event kinds.
+        return nil
+      }
+      self.init(encoding: event)
     }
-    if !V.includesExperimentalFields && event.kind.rawValue.first == "_" {
-      // Don't encode experimental event kinds.
-      return nil
-    }
-    self.init(encoding: event)
+  }
+
+  init?(encoding metadata: borrowing Event.Metadata) {
+    let metadata = ABI.EncodedMetadata<V>(encoding: metadata)
+    self.init(encoding: metadata)
   }
 }
 
@@ -82,6 +110,17 @@ extension ABI.Record: Codable {
     case let .event(event):
       try container.encode("event", forKey: .kind)
       try container.encode(event, forKey: .payload)
+    case let .metadata(metadata) where V.includesExperimentalFields:
+      try container.encode("_metadata", forKey: .kind)
+      try container.encode(metadata, forKey: .payload)
+    default:
+      throw EncodingError.invalidValue(
+        kind,
+        EncodingError.Context(
+          codingPath: encoder.codingPath + CollectionOfOne(CodingKeys.payload as any CodingKey),
+          debugDescription: "Record version \(V.versionNumber) does not support encoding records of kind \(kind)."
+        )
+      )
     }
   }
 
@@ -114,6 +153,9 @@ extension ABI.Record: Codable {
     case "event":
       let event = try container.decode(ABI.EncodedEvent<V>.self, forKey: .payload)
       kind = .event(event)
+    case "_metadata" where V.includesExperimentalFields:
+      let metadata = try container.decode(ABI.EncodedMetadata<V>.self, forKey: .payload)
+      kind = .metadata(metadata)
     case let kind:
       throw DecodingError.dataCorrupted(
         DecodingError.Context(

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -214,6 +214,14 @@ extension ABI.Version {
         event,
         Event.Context(test: test, testCase: nil, iteration: encodedEvent.iteration, configuration: nil)
       )
+    case let .metadata(encodedMetadata):
+      guard let metadata = Event.Metadata(decoding: encodedMetadata) else {
+        return nil
+      }
+      result = (
+        Event(.metadataRecorded(metadata), testID: nil, testCaseID: nil),
+        Event.Context(test: nil, testCase: nil, iteration: nil, configuration: nil)
+      )
     }
 
     return result

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedMetadata.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedMetadata.swift
@@ -1,0 +1,56 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if !SWT_NO_ABI_JSON_SCHEMA
+@_spi(Experimental)
+extension ABI {
+  /// A type implementing the JSON encoding of ``Event/Metadata`` for the ABI
+  /// entry point and event stream output.
+  ///
+  /// This type is not part of the public interface of the testing library. It
+  /// assists in converting values to JSON; clients that consume this JSON are
+  /// expected to write their own decoders.
+  public struct EncodedMetadata<V>: Sendable where V: ABI.Version {
+    /// The name of the datum.
+    var name: String
+
+    /// The value of the datum.
+    var value: String
+  }
+}
+
+// MARK: - Codable
+
+extension ABI.EncodedMetadata: Codable {}
+
+// MARK: - Conversion to/from library types
+
+extension ABI.EncodedMetadata {
+  /// Initialize an instance of this type from the given value.
+  ///
+  /// - Parameters:
+  ///   - metadata: The metadata to initialize this instance from.
+  public init(encoding metadata: borrowing Event.Metadata) {
+    name = metadata.name
+    value = metadata.value
+  }
+}
+
+@_spi(Experimental) @_spi(ForToolsIntegrationOnly)
+extension Event.Metadata {
+  /// Initialize an instance of this type from the given value.
+  ///
+  /// - Parameters:
+  ///   - metadata: The encoded metadata to initialize this instance from.
+  public init?<V>(decoding metadata: ABI.EncodedMetadata<V>) {
+    self.init(name: metadata.name, value: metadata.value)
+  }
+}
+#endif

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedMetadata.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedMetadata.swift
@@ -17,6 +17,8 @@ extension ABI {
   /// This type is not part of the public interface of the testing library. It
   /// assists in converting values to JSON; clients that consume this JSON are
   /// expected to write their own decoders.
+  ///
+  /// - Warning: Metadata is not yet part of the JSON schema.
   public struct EncodedMetadata<V>: Sendable where V: ABI.Version {
     /// The name of the datum.
     var name: String

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(Testing
   ABI/Encoded/ABI.EncodedInstant.swift
   ABI/Encoded/ABI.EncodedIssue.swift
   ABI/Encoded/ABI.EncodedMessage.swift
+  ABI/Encoded/ABI.EncodedMetadata.swift
   ABI/Encoded/ABI.EncodedSourceLocation.swift
   ABI/Encoded/ABI.EncodedTest.swift
   Attachments/Images/AttachableAsImage.swift
@@ -36,6 +37,7 @@ add_library(Testing
   Attachments/Attachment.swift
   Events/Clock.swift
   Events/Event.swift
+  Events/Event.Metadata.swift
   Events/Event+FallbackEventHandler.swift
   Events/Recorder/Event.AdvancedConsoleOutputRecorder.swift
   Events/Recorder/Event.ConsoleOutputRecorder.swift

--- a/Sources/Testing/Events/Event.Metadata.swift
+++ b/Sources/Testing/Events/Event.Metadata.swift
@@ -15,6 +15,10 @@ extension Event {
   /// Metadata is human-readable information such as the operating system
   /// version that can be used to help diagnose issues recorded during a test
   /// run.
+  ///
+  /// - Important: The properties of instances of this type are human-readable.
+  ///   They are not guaranteed to remain stable over multiple releases of the
+  ///   testing library. You should not attempt to parse them.
   public struct Metadata: Sendable {
     /// The name of the datum.
     public var name: String

--- a/Sources/Testing/Events/Event.Metadata.swift
+++ b/Sources/Testing/Events/Event.Metadata.swift
@@ -1,0 +1,97 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+extension Event {
+  /// A type describing metadata regarding a test run, the current environment,
+  /// etc.
+  ///
+  /// Metadata is human-readable information such as the operating system
+  /// version that can be used to help diagnose issues recorded during a test
+  /// run.
+  public struct Metadata: Sendable {
+    /// The name of the datum.
+    public var name: String
+
+    /// The value of the datum.
+    public var value: String
+
+    /// Whether or not this instance is recorded in human-readable output with
+    /// the given verbosity level.
+    ///
+    /// - Parameters:
+    ///   - verbosity: The verbosity level at which output is being recorded.
+    ///
+    /// - Returns: Whether or not this instance should be recorded.
+    func shouldRecord(withVerbosity verbosity: Int) -> Bool {
+      switch name {
+      case Self._testingLibraryVersionName, Self._targetPlatformName:
+        true
+      default:
+        verbosity > 0
+      }
+    }
+  }
+}
+
+// MARK: - CustomStringConvertible
+
+extension Event.Metadata: CustomStringConvertible {
+  public var description: String {
+    "\(name): \(value)"
+  }
+}
+
+// MARK: - "Standard" metadata
+
+extension Event.Metadata {
+  /// The names of various metadata that the testing library collects.
+  private static var _swiftStandardLibraryVersionName: String { "Swift Standard Library Version" }
+  private static var _swiftCompilerVersionName: String { "Swift Compiler Version" }
+  private static var _gnuCLibraryVersionName: String { "GNU C Library Version" }
+  private static var _testingLibraryVersionName: String { "Testing Library Version" }
+  private static var _targetPlatformName: String { "Target Platform" }
+  private static var _simulatorOSVersionName: String { "OS Version (Simulator)" }
+  private static var _hostOSVersionName: String { "OS Version (Host)" }
+  private static var _osVersionName: String { "OS Version" }
+  private static var _apiLevelName: String { "API Level" }
+
+  /// All metadata that the testing library collects.
+  static var all: [Self] {
+    var result = [Self]()
+
+    func append(_ name: String, _ value: some CustomStringConvertible) {
+      let metadata = Event.Metadata(name: name, value: String(describing: value))
+      result.append(metadata)
+    }
+
+    if let swiftStandardLibraryVersion {
+      append(_swiftStandardLibraryVersionName, swiftStandardLibraryVersion)
+    }
+    append(_swiftCompilerVersionName, swiftCompilerVersion)
+#if os(Linux) && canImport(Glibc)
+    append(_gnuCLibraryVersionName, glibcVersion)
+#endif
+    append(_testingLibraryVersionName, testingLibraryVersion)
+    if let targetTriple {
+      append(_targetPlatformName, targetTriple)
+    }
+#if targetEnvironment(simulator)
+    append(_simulatorOSVersionName, simulatorVersion)
+    append(_hostOSVersionName, operatingSystemVersion)
+#else
+    append(_osVersionName, operatingSystemVersion)
+#endif
+#if os(Android)
+    append(_apiLevelName, apiLevel)
+#endif
+
+    return result
+  }
+}

--- a/Sources/Testing/Events/Event.swift
+++ b/Sources/Testing/Events/Event.swift
@@ -25,6 +25,13 @@ public struct Event: Sendable {
     /// regardless of whether or not they would run.
     case testDiscovered
 
+    /// Some metadata regarding the test run, the current environment, etc. was
+    /// recorded.
+    ///
+    /// - Parameters:
+    ///   - metadata: The recorded metadata.
+    indirect case metadataRecorded(_ metadata: Metadata)
+
     /// A test run started.
     ///
     /// This event is posted when ``Runner/run()`` is called after
@@ -416,6 +423,10 @@ extension Event.Kind {
     /// regardless of whether or not they would run.
     case testDiscovered
 
+    /// Some metadata regarding the test run, the current environment, etc. was
+    /// recorded.
+    case metadataRecorded
+
     /// A test run started.
     ///
     /// This event is posted when ``Runner/run()`` is called after
@@ -541,6 +552,8 @@ extension Event.Kind.Snapshot {
       self = .testDiscovered
     case .runStarted:
       self = .runStarted
+    case .metadataRecorded:
+      self = .metadataRecorded
     case .planStepStarted:
       self = .planStepStarted
     case .testStarted:

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -50,6 +50,9 @@ extension Event {
     /// A type that contains mutable context for
     /// ``Event/ConsoleOutputRecorder``.
     fileprivate struct Context {
+      /// Metadata that has been recorded so far.
+      var metadataRecorded = [Event.Metadata]()
+
       /// The instant at which the run started.
       var runStartInstant: Test.Clock.Instant?
 
@@ -295,6 +298,11 @@ extension Event.HumanReadableOutputRecorder {
       case .runStarted:
         context.runStartInstant = instant
 
+      case let .metadataRecorded(metadata):
+        if metadata.shouldRecord(withVerbosity: verbosity) {
+          context.metadataRecorded.append(metadata)
+        }
+
       case .testStarted:
         let test = test!
         context.testData[keyPath] = .init(startInstant: instant)
@@ -367,37 +375,18 @@ extension Event.HumanReadableOutputRecorder {
       break
 
     case .runStarted:
-      var comments = [Comment]()
-      if verbosity > 0 {
-        if let swiftStandardLibraryVersion {
-          comments.append("Swift Standard Library Version: \(swiftStandardLibraryVersion)")
-        }
-        comments.append("Swift Compiler Version: \(swiftCompilerVersion)")
-#if os(Linux) && canImport(Glibc)
-        comments.append("GNU C Library Version: \(glibcVersion)")
-#endif
-      }
-      comments.append("Testing Library Version: \(testingLibraryVersion)")
-      if let targetTriple {
-        comments.append("Target Platform: \(targetTriple)")
-      }
-      if verbosity > 0 {
-#if targetEnvironment(simulator)
-        comments.append("OS Version (Simulator): \(simulatorVersion)")
-        comments.append("OS Version (Host): \(operatingSystemVersion)")
-#else
-        comments.append("OS Version: \(operatingSystemVersion)")
-#endif
-#if os(Android)
-        comments.append("API Level: \(apiLevel)")
-#endif
-      }
       return CollectionOfOne(
         Message(
           symbol: .default,
           stringValue: "Test run started."
         )
-      ) + _formattedComments(comments)
+      ) + context.metadataRecorded.map { _formattedComment("\($0)") }
+    case .metadataRecorded:
+      // Handled as part of .runStarted. WHY? So that with older JSON event
+      // stream schemas, the messages appear in the "right" place as part of the
+      // .runStarted event, and so that multiple runs using the same recorder
+      // don't emit duplicate metadata messages.
+      break
 
     case .planStepStarted, .planStepEnded:
       // Suppress events of these kinds from output as they are not generally

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -543,6 +543,9 @@ extension Runner {
       }
       schedule(tests)
 
+      for metadata in Event.Metadata.all {
+        Event.post(.metadataRecorded(metadata), for: (nil, nil), configuration: runner.configuration)
+      }
       Event.post(.runStarted, for: (nil, nil), configuration: runner.configuration)
       defer {
         Event.post(.runEnded, for: (nil, nil), configuration: runner.configuration)


### PR DESCRIPTION
This PR breaks out the metadata details we collect in the human-readable output recorder and instead emits them as separate `.metadataRecorded` events.

This allows us to collect this data even when not emitting a human-readable output stream. If/when we add it to the JSON schema, consuming tools can gather that information and present it in their own interfaces.

I've taken (some) care to ensure that, in existing JSON schemas, the `messages` field for the `.runStarted` event kind still contains this metadata. In the experimental schema, which does not generate the `messages` field by default, they are instead broken out into a new record kind, `"_metadata"`.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
