### PR TITLE
Add a dedicated argument parser system.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/CommandLineArgumentList.swift
+++ b/Sources/Testing/ABI/EntryPoints/CommandLineArgumentList.swift
@@ -1,0 +1,320 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023–2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// A type that can perform basic parsing of command-line arguments.
+///
+/// The testing library uses this type to parse command-line arguments in its
+/// entry point function and in its associated executable targets.
+///
+/// - Important: This type is provided because the testing library cannot link
+///   directly to Swift Argument Parser. Other tools and libraries should
+///   generally prefer to use Swift Argument Parser and should not use or copy
+///   this type or its logic.
+@_spi(ForToolsIntegrationOnly)
+public struct CommandLineArgumentList: Sendable {
+  /// An enumeration describing how to handle a command-line argument.
+  public enum Descriptor: Sendable, Equatable, Hashable {
+    /// An argument that has no label.
+    case anonymous
+
+    /// A subcommand argument (one that does not take a value and does not start
+    /// with a dash character).
+    ///
+    /// - Parameters:
+    ///   - commandName: The name of the subcommand.
+    ///
+    /// The testing library does not enforce that subcommand arguments must come
+    /// before other arguments.
+    case subcommand(_ commandName: String)
+
+    /// An argument that takes a value.
+    ///
+    /// - Parameters:
+    ///   - label: The option's label, including leading dashes.
+    ///
+    /// If an option is specified more than once, the testing library builds an
+    /// array of values for that option in the order the values are parsed.
+    case option(_ label: String)
+
+    /// An argument that does not take a value.
+    ///
+    /// - Parameters:
+    ///   - label: The flag's label, including leading dashes.
+    ///
+    /// The testing library does not enforce that a flag can only be specified
+    /// once.
+    case flag(_ label: String)
+
+    /// The argument's label, if any.
+    fileprivate var label: String? {
+      switch self {
+      case .anonymous, .subcommand:
+        nil
+      case let .option(label), let .flag(label):
+        label
+      }
+    }
+  }
+
+  /// Storage for ``anonymousArgumentValues``.
+  private var _anonymousArgumentValues: [String] = []
+
+  /// Storage for ``subcommandNames``.
+  private var _subcommandNames: [String] = []
+
+  /// Storage for ``option(withLabel:)`` and ``options(withLabel:)``.
+  private var _options: [String: [String]] = [:]
+
+  /// Storage for ``hasFlag(withLabel:)``.
+  private var _flags: Set<String> = []
+
+  /// Parse a single argument.
+  ///
+  /// - Parameters:
+  ///   - arg: The argument to parse.
+  ///   - descriptors: An array of argument descriptors that tell the testing
+  ///     library how to handle `arg` and other arguments.
+  ///   - describeUnrecognizedArgument: A closure to call if `arg` is not
+  ///     recognized.
+  ///   - getValue: A closure to call to get the value of the argument if it is
+  ///     an option (i.e. takes a value).
+  ///
+  /// - Returns: A tuple containing the argument descriptor matching `arg` and,
+  ///   if `arg` is anonymous or is an option, its value.
+  ///
+  /// - Throws: Any error that occurs while parsing `arg`.
+  private static func _parseArgument(
+    _ arg: String,
+    describedBy descriptors: [Descriptor],
+    describingUnrecognizedArgumentWith describeUnrecognizedArgument: ((String) throws -> Descriptor)?,
+    gettingValueWith getValue: () -> String?
+  ) throws -> (descriptor: Descriptor, value: String?) {
+    var descriptor: Descriptor?
+    var value: String?
+
+    // Find a descriptor matching the raw argument string.
+    if arg.first == "-" {
+      // Looks like an argument label like -f or --foo.
+      descriptor = descriptors.first { $0.label == arg }
+      if descriptor == nil,
+         case let splitByEquals = arg.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false),
+         splitByEquals.count > 1 {
+        // It appears to be of the form "--foo=bar".
+        let label = String(splitByEquals[0])
+        let possibleDescriptor: Descriptor = .option(label)
+        if descriptors.contains(possibleDescriptor) {
+          descriptor = possibleDescriptor
+          value = String(splitByEquals[1])
+        }
+      }
+    } else {
+      descriptor = descriptors.first { $0 == .subcommand(arg) }
+      if descriptor == nil && descriptors.contains(.anonymous) {
+        descriptor = .anonymous
+      }
+    }
+
+    // If we couldn't find a matching descriptor, ask the fallback callback (!)
+    // for one before we give up and throw.
+    if descriptor == nil {
+      descriptor = try describeUnrecognizedArgument?(arg)
+    }
+    guard let descriptor else {
+      throw ParseError.unexpectedArgument(arg)
+    }
+
+
+    // If the argument is an option, it must have a value. If we haven't already
+    // split one out of the raw argument string (e.g. "--foo=bar"), get the
+    // value from the callback.
+    switch descriptor {
+    case .anonymous:
+      value = arg
+    case let .option(label):
+      if value == nil {
+        value = getValue()
+      }
+      if value == nil {
+        throw ParseError.missingValue(label: label)
+      }
+    default:
+      assert(value == nil, "Set a value when parsing an argument '\(arg)' that shouldn't have one. \(fileABugMessage)")
+    }
+
+    return (descriptor, value)
+  }
+
+  /// Initialize an instance of this type by parsing the given sequence of
+  /// command-line arguments.
+  ///
+  /// - Parameters:
+  ///   - arguments: A sequence of command-line arguments. The first element of
+  ///     the sequence is assumed to be the program name and is discarded
+  ///     automatically.
+  ///   - descriptors: An array of argument descriptors that tell the testing
+  ///     library how to handle the strings in `arguments`.
+  ///   - describeUnrecognizedArgument: A closure to call if an unrecognized
+  ///     argument is found in `arguments`. This function can customize how the
+  ///     testing library handles that argument, or throw an error if it is not
+  ///     supported. If `nil`, unrecognized arguments cause this initializer to
+  ///     throw an error.
+  ///
+  /// - Throws: Any error that occurs while parsing `arguments`.
+  init(
+    parsing arguments: some Sequence<String>,
+    describedBy descriptors: [Descriptor],
+    describingUnrecognizedArgumentWith describeUnrecognizedArgument: ((String) throws -> Descriptor)? = nil
+  ) throws {
+    var i = arguments.makeIterator()
+    _ = i.next() // drop argv[0]
+    while let arg = i.next() {
+      let (descriptor, value) = try Self._parseArgument(
+        arg,
+        describedBy: descriptors,
+        describingUnrecognizedArgumentWith: describeUnrecognizedArgument,
+        gettingValueWith: { i.next() }
+      )
+      switch descriptor {
+      case .anonymous:
+        _anonymousArgumentValues.append(value!)
+      case let .subcommand(subcommandName):
+        _subcommandNames.append(subcommandName)
+      case let .option(label):
+        _options[label, default: []].append(value!)
+      case let .flag(label):
+        _flags.insert(label)
+      }
+    }
+  }
+}
+
+// MARK: - Getting parsed arguments
+
+extension CommandLineArgumentList {
+  /// All anonymous argument values found during argument parsing.
+  ///
+  /// For example, given the following command line parsed with appropriate
+  /// descriptors:
+  ///
+  /// ```sh
+  /// ./mytool --foo bar abc 123
+  /// ```
+  ///
+  /// The value of this property would be `["abc", "123"]`.
+  public var anonymousArgumentValues: [String] {
+    _anonymousArgumentValues
+  }
+
+  /// All subcommand names found during argument parsing, in the order they were
+  /// found.
+  ///
+  /// For example, given the following command line parsed with appropriate
+  /// descriptors (in particular, with the descriptor `.subcommand("abc")`:
+  ///
+  /// ```sh
+  /// ./mytool --foo bar abc 123
+  /// ```
+  ///
+  /// The value of this property would be `["abc"]`.
+  public var subcommandNames: [String] {
+    _subcommandNames
+  }
+
+  /// Get the first value found during argument parsing for the option with the
+  /// given label.
+  ///
+  /// - Parameters:
+  ///   - label: The option's label, including leading dashes.
+  ///
+  /// - Returns: The first value found for the given option, or `nil` if none
+  ///   was found during parsing.
+  ///
+  /// For example, given the following command line parsed with appropriate
+  /// descriptors:
+  ///
+  /// ```sh
+  /// ./mytool --foo bar --foo baz --quux 123
+  /// ```
+  ///
+  /// For the label `"foo"`, the result is `"bar"`.
+  public func option(withLabel label: String) -> String? {
+    _options[label]?.first
+  }
+
+  /// Get all values found during argument parsing for the option with the
+  /// given label, in the order they were found.
+  ///
+  /// - Parameters:
+  ///   - label: The option's label, including leading dashes.
+  ///
+  /// - Returns: An array of values found for the given option, or the empty
+  ///   array if none was found during parsing.
+  ///
+  /// For example, given the following command line parsed with appropriate
+  /// descriptors:
+  ///
+  /// ```sh
+  /// ./mytool --foo bar --foo baz --quux 123
+  /// ```
+  ///
+  /// For the label `"foo"`, the result is `["bar", "baz"]`.
+  public func options(withLabel label: String) -> [String] {
+    _options[label, default: []]
+  }
+
+  /// Check whether the given flag was found during argument parsing.
+  ///
+  /// - Parameters:
+  ///   - label: The flag's label, including leading dashes.
+  ///
+  /// - Returns: Whether or not the given flag was found during parsing.
+  ///
+  /// For example, given the following command line:
+  ///
+  /// ```sh
+  /// ./mytool --make-grommet --eat-pizza
+  /// ```
+  ///
+  /// For the label `"--make-grommet"`, the result is `true`, and for the label
+  /// `"--unwrap-present"`, the result is `false`.
+  public func hasFlag(withLabel label: String) -> Bool {
+    _flags.contains(label)
+  }
+}
+
+// MARK: -
+
+extension CommandLineArgumentList {
+  /// Errors thrown by ``CommandLineArgumentList`` when parsing fails.
+  enum ParseError: Error, Equatable {
+    /// The testing library encountered an unexpected argument.
+    ///
+    /// - Parameters:
+    ///   - arg: The unexpected argument.
+    case unexpectedArgument(_ arg: String)
+
+    /// The testing library encountered an option with no value specified.
+    ///
+    /// - Parameters:
+    ///   - label: The option's label.
+    case missingValue(label: String)
+  }
+}
+
+extension CommandLineArgumentList.ParseError: CustomStringConvertible {
+  var description: String {
+    switch self {
+    case let .unexpectedArgument(arg):
+      #"Unexpected argument "\#(arg)"."#
+    case let .missingValue(label):
+      #"Missing value for argument "\#(label)"."#
+    }
+  }
+}

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -387,45 +387,6 @@ extension __CommandLineArguments_v0: Codable {
 }
 #endif
 
-extension RandomAccessCollection<String> {
-  /// Get the value of the command line argument with the given name.
-  ///
-  /// - Parameters:
-  ///   - label: The label or name of the argument, e.g. `"--attachments-path"`.
-  ///   - index: The index where `label` should be found, or `nil` to search the
-  ///     entire collection.
-  ///
-  /// - Returns: The value of the argument named by `label` at `index`. If no
-  ///   value is available, or if `index` is not `nil` and the argument at
-  ///   `index` is not named `label`, returns `nil`.
-  ///
-  /// This function handles arguments of the form `--label value` and
-  /// `--label=value`. Other argument syntaxes are not supported.
-  fileprivate func argumentValue(forLabel label: String, at index: Index? = nil) -> String? {
-    guard let index else {
-      return indices.lazy
-        .compactMap { argumentValue(forLabel: label, at: $0) }
-        .first
-    }
-
-    let element = self[index]
-    if element == label {
-      let nextIndex = self.index(after: index)
-      if nextIndex < endIndex {
-        return self[nextIndex]
-      }
-    } else {
-      // Find an element equal to something like "--foo=bar" and split it.
-      let prefix = "\(label)="
-      if element.hasPrefix(prefix), let equalsIndex = element.firstIndex(of: "=") {
-        return String(element[equalsIndex...].dropFirst())
-      }
-    }
-
-    return nil
-  }
-}
-
 /// Initialize this instance given a sequence of command-line arguments passed
 /// from Swift Package Manager.
 ///
@@ -438,7 +399,24 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   var result = __CommandLineArguments_v0()
 
   // Do not consider the executable path AKA argv[0].
-  let args = args.dropFirst()
+  let args = try CommandLineArgumentList(
+    parsing: args,
+    describedBy: [
+      .flag("--list-tests"), .subcommand("list"),
+      .option("--configuration-path"), .option("--experimental-configuration-path"),
+      .option("--event-stream-output-path"), .option("--experimental-event-stream-output"),
+      .option("--event-stream-version"), .option("--experimental-event-stream-version"),
+      .option("--xunit-output"),
+      .option("--attachments-path"), .option("--experimental-attachments-path"),
+      .flag("--parallel"), .flag("--no-parallel"),
+      .option("--experimental-maximum-parallelization-width"),
+      .option("--symbolicate-backtraces"),
+      .option("--verbosity"), .flag("--verbose"), .flag("-v"), .flag("--very-verbose"), .flag("--vv"), .flag("--quiet"), .flag("-q"),
+      .option("--filter"), .option("--skip"),
+      .option("--repetitions"), .option("--repeat-until"),
+    ],
+    describingUnrecognizedArgumentWith: { _ in .anonymous }
+  )
 
 #if !SWT_NO_FILE_IO
 #if !SWT_NO_CODABLE
@@ -449,7 +427,7 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   // NOTE: While the output event stream is opened later, it is necessary to
   // open the configuration file early (here) in order to correctly construct
   // the resulting __CommandLineArguments_v0 instance.
-  if let path = args.argumentValue(forLabel: "--configuration-path") ?? args.argumentValue(forLabel: "--experimental-configuration-path") {
+  if let path = args.option(withLabel: "--configuration-path") ?? args.option(withLabel: "--experimental-configuration-path") {
     let file = try FileHandle(forReadingAtPath: path)
     let configurationJSON = try file.readToEnd()
     result = try configurationJSON.withUnsafeBufferPointer { configurationJSON in
@@ -463,7 +441,7 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
 #endif
 
   // Event stream output
-  if let path = args.argumentValue(forLabel: "--event-stream-output-path") ?? args.argumentValue(forLabel: "--experimental-event-stream-output") {
+  if let path = args.option(withLabel: "--event-stream-output-path") ?? args.option(withLabel: "--experimental-event-stream-output") {
     result.eventStreamOutputPath = path
   }
 
@@ -471,9 +449,9 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
   do {
     var versionString: String?
     var allowExperimental = false
-    versionString = args.argumentValue(forLabel: "--event-stream-version")
+    versionString = args.option(withLabel: "--event-stream-version")
     if versionString == nil {
-      versionString = args.argumentValue(forLabel: "--experimental-event-stream-version")
+      versionString = args.option(withLabel: "--experimental-event-stream-version")
       if versionString != nil {
         allowExperimental = true
       }
@@ -499,69 +477,66 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
 #endif
 
   // XML output
-  if let xunitOutputPath = args.argumentValue(forLabel: "--xunit-output") {
+  if let xunitOutputPath = args.option(withLabel: "--xunit-output") {
     result.xunitOutput = xunitOutputPath
   }
 
   // Attachment output
-  if let attachmentsPath = args.argumentValue(forLabel: "--attachments-path") ?? args.argumentValue(forLabel: "--experimental-attachments-path") {
+  if let attachmentsPath = args.option(withLabel: "--attachments-path") ?? args.option(withLabel: "--experimental-attachments-path") {
     result.attachmentsPath = attachmentsPath
   }
 
-  if args.contains("--list-tests") {
+  if args.hasFlag(withLabel: "--list-tests") {
     result.listTests = true
-  } else if args.first == "list" {
+  } else if args.subcommandNames == ["list"] {
     // Allow the "list" subcommand explicitly in place of "--list-tests". This
     // makes invocation from e.g. Wasmtime a bit more intuitive/idiomatic.
     result.listTests = true
   }
 
   // Parallelization (on by default)
-  if args.contains("--no-parallel") {
+  if args.hasFlag(withLabel: "--no-parallel") == true {
     result.parallel = false
   }
-  if let maximumParallelizationWidth = args.argumentValue(forLabel: "--experimental-maximum-parallelization-width").flatMap(Int.init) {
+  if let maximumParallelizationWidth = args.option(withLabel: "--experimental-maximum-parallelization-width").flatMap(Int.init) {
     // TODO: decide if we want to repurpose --num-workers for this use case?
     result.experimentalMaximumParallelizationWidth = maximumParallelizationWidth
   }
 
   // Whether or not to symbolicate backtraces in the event stream.
-  if let symbolicateBacktraces = args.argumentValue(forLabel: "--symbolicate-backtraces") {
+  if let symbolicateBacktraces = args.option(withLabel: "--symbolicate-backtraces") {
     result.symbolicateBacktraces = symbolicateBacktraces
   }
 
   // Verbosity
-  if let verbosity = args.argumentValue(forLabel: "--verbosity").flatMap(Int.init) {
+  if let verbosity = args.option(withLabel: "--verbosity").flatMap(Int.init) {
     result.verbosity = verbosity
   }
-  if args.contains("--verbose") || args.contains("-v") {
+  if args.hasFlag(withLabel: "--verbose") == true || args.hasFlag(withLabel: "-v") == true {
     result.verbose = true
   }
-  if args.contains("--very-verbose") || args.contains("--vv") {
+  if args.hasFlag(withLabel: "--very-verbose") == true || args.hasFlag(withLabel: "--vv") == true {
     result.veryVerbose = true
   }
-  if args.contains("--quiet") || args.contains("-q") {
+  if args.hasFlag(withLabel: "--quiet") == true || args.hasFlag(withLabel: "-q") == true {
     result.quiet = true
   }
 
   // Filtering
-  func filterValues(forArgumentsWithLabel label: String) -> [String] {
-    args.indices.compactMap { args.argumentValue(forLabel: label, at: $0) }
-  }
-  let filter = filterValues(forArgumentsWithLabel: "--filter")
+  let filter = args.options(withLabel: "--filter")
   if !filter.isEmpty {
     result.filter = result.filter.map { $0 + filter } ?? filter
   }
-  let skip = filterValues(forArgumentsWithLabel: "--skip")
+  let skip = args.options(withLabel: "--skip")
   if !skip.isEmpty {
     result.skip = result.skip.map { $0 + skip } ?? skip
   }
 
   // Set up the iteration policy for the test run.
-  if let repetitions = args.argumentValue(forLabel: "--repetitions").flatMap(Int.init) {
+  if let repetitions = args.option(withLabel: "--repetitions").flatMap(Int.init) {
     result.repetitions = repetitions
   }
-  if let repeatUntil = args.argumentValue(forLabel: "--repeat-until") {
+  if let repeatUntil = args.option(withLabel: "--repeat-until") {
     result.repeatUntil = repeatUntil
   }
 
@@ -979,6 +954,12 @@ private enum _EntryPointError: Error {
   /// - Parameters:
   ///   - versionNumber: The experimental ABI version number.
   case experimentalABIVersion(_ versionNumber: VersionNumber)
+
+  /// A failure occurred while parsing the command line arguments list.
+  ///
+  /// - Parameters:
+  ///   - error: The underlying error that occurred.
+  case commandLineParsingFailed(_ error: CommandLineArgumentList.ParseError)
 }
 
 extension _EntryPointError: CustomStringConvertible {
@@ -990,6 +971,8 @@ extension _EntryPointError: CustomStringConvertible {
       #"Invalid value "\#(value)" for argument \#(name)"#
     case let .experimentalABIVersion(versionNumber):
       "Event stream version \(versionNumber) is experimental. Use --experimental-event-stream-version to enable it."
+    case let .commandLineParsingFailed(error):
+      String(describing: error)
     }
   }
 }

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -9,6 +9,7 @@
 include(ModuleABIName)
 add_library(Testing
   ABI/EntryPoints/ABIEntryPoint.swift
+  ABI/EntryPoints/CommandLineArgumentList.swift
   ABI/EntryPoints/EntryPoint.swift
   ABI/EntryPoints/SwiftPMEntryPoint.swift
   ABI/ABI.Context.swift

--- a/Tests/TestingTests/CommandLineArgumentListTests.swift
+++ b/Tests/TestingTests/CommandLineArgumentListTests.swift
@@ -1,0 +1,72 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(ForToolsIntegrationOnly) import Testing
+
+// NOTE: SwiftPMTests contains additional test coverage for the argument parser.
+
+struct `CommandLineArgumentList Tests` {
+  @Test func `Parse various arguments`() throws {
+    let args = ["PROGNAME", "dostuff", "hereandthere", "--foo", "bar", "--foo=baz", "--quux", "123", "--grommet", "--widget", "/path/to/nowhere"]
+    let list = try CommandLineArgumentList(
+      parsing: args,
+      describedBy: [
+        .subcommand("dostuff"),
+        .subcommand("hereandthere"),
+        .option("--foo"),
+        .option("--quux"),
+        .flag("--grommet"),
+        .flag("--widget"),
+        .anonymous,
+      ]
+    )
+
+    #expect(list.subcommandNames == ["dostuff", "hereandthere"])
+
+    #expect(list.option(withLabel: "--foo") == "bar")
+    #expect(list.options(withLabel: "--foo") == ["bar", "baz"])
+    #expect(!list.hasFlag(withLabel: "--foo"))
+
+    #expect(list.option(withLabel: "--quux") == "123")
+    #expect(list.options(withLabel: "--quux") == ["123"])
+    #expect(!list.hasFlag(withLabel: "--quux"))
+
+    #expect(list.option(withLabel: "--grommet") == nil)
+    #expect(list.hasFlag(withLabel: "--grommet"))
+    #expect(list.option(withLabel: "--widget") == nil)
+    #expect(list.hasFlag(withLabel: "--widget"))
+  }
+
+  @Test func `Error thrown for unrecognized option/flag`() throws {
+    let args = ["PROGNAME", "--foo", "--bar", "123", "--unexpected"]
+    #expect(throws: CommandLineArgumentList.ParseError.unexpectedArgument("--unexpected")) {
+      _ = try CommandLineArgumentList(
+        parsing: args,
+        describedBy: [
+          .flag("--foo"), .option("--bar"),
+        ]
+      )
+    }
+  }
+
+  @Test func `Fallback closure called for unrecognized argument`() async throws {
+    let args = ["PROGNAME", "hello", "world", "--foo", "--bar", "123", "456"]
+    try await confirmation("Called closure", expectedCount: args.count - 1) { confirmation in
+      _ = try CommandLineArgumentList(
+        parsing: args,
+        describedBy: [],
+        describingUnrecognizedArgumentWith: { _ in
+          confirmation()
+          return .anonymous
+        }
+      )
+    }
+  }
+}

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -55,6 +55,11 @@ struct SwiftPMTests {
     #expect(EXIT_NO_TESTS_FOUND != EXIT_FAILURE)
   }
 
+  @Test("Unrecognized arguments are ignored")
+  func ignoreUnrecognized() throws {
+    _ = try configurationForEntryPoint(withArguments: ["PATH", "--unrecognized", "123", "foo", "bar", "--foo=bar"])
+  }
+
   @Test("--parallel/--no-parallel argument")
   func parallel() throws {
     var configuration = try configurationForEntryPoint(withArguments: ["PATH"])
@@ -297,8 +302,12 @@ struct SwiftPMTests {
 
   @Test("--filter or --skip argument as last argument")
   func filterOrSkipAsLast() async throws {
-    _ = try configurationForEntryPoint(withArguments: ["PATH", "--filter"])
-    _ = try configurationForEntryPoint(withArguments: ["PATH", "--skip"])
+    #expect(throws: CommandLineArgumentList.ParseError.missingValue(label: "--filter")) {
+      _ = try configurationForEntryPoint(withArguments: ["PATH", "--filter"])
+    }
+    #expect(throws: CommandLineArgumentList.ParseError.missingValue(label: "--skip")) {
+      _ = try configurationForEntryPoint(withArguments: ["PATH", "--skip"])
+    }
   }
 
 #if !SWT_NO_EXIT_TESTS
@@ -361,8 +370,9 @@ struct SwiftPMTests {
   @Test("--xunit-output argument (missing path)")
   func xunitOutputWithMissingPath() throws {
     // Test that a missing path doesn't read off the end of the argument array.
-    let args = try parseCommandLineArguments(from: ["PATH", "--xunit-output"])
-    #expect(args.xunitOutput == nil)
+    #expect(throws: CommandLineArgumentList.ParseError.missingValue(label: "--xunit-output").self) {
+      _ = try parseCommandLineArguments(from: ["PATH", "--xunit-output"])
+    }
   }
 
   @Test("--xunit-output argument (writes to file)")


### PR DESCRIPTION
This PR adds `CommandLineArgumentList`, a type for parsing and interpreting command-line arguments that provides a (very constrained!) subset of the sort of functionality you'd find in Swift Argument Parser.

Swift Testing cannot directly link to Swift Argument Parser because it would cause cyclical dependencies in Swift Argument Parser's own test suites, and because Swift Argument Parser is not formally included in the Swift toolchain[^everybodyUsesItAnyway].

We _do_ need to parse command-line arguments, however, so we need a mechanism for doing so. Right now, we have logic in the exported entry point function that does some basic parsing and validation, but it's very naïve (even more so than this new implementation) and cannot be used with other targets in Swift Testing that might need to parse arguments such as the experimental testing harness in
 #1784.

[^everybodyUsesItAnyway]: A number of components in the toolchain directly link to their own copies of Swift Argument Parser. When they build using CMake, they end up building Swift Argument Parser multiple times. Improving that is beyond the scope of this PR or Swift Testing's mandate.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
