### PR TITLE
Update reference to interop modes for `SWIFT_TESTING_XCTEST_INTEROP_MODE`

### DIFF
--- a/Documentation/EnvironmentVariables.md
+++ b/Documentation/EnvironmentVariables.md
@@ -65,8 +65,8 @@ names prefixed with `SWT_`.
 | `HOME`[\*](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html) | `String` | Used to determine the user's home directory. |
 | `SIMULATOR_RUNTIME_BUILD_VERSION`\* | `String` | Used when running in the iOS (etc.) Simulator to determine the simulator's version. |
 | `SIMULATOR_RUNTIME_VERSION`\* | `String` | Used when running in the iOS (etc.) Simulator to determine the simulator's version. |
-| `SWIFT_TESTING_XCTEST_INTEROP_MODE` | `String` | Overrides the behavior for handling XCTest assertion failures recorded during a Swift Testing test. One of `none`, `limited`, `complete`, or `strict`. Explanation of modes can be found in [ST-0021][interop-modes]. | <!--prefer to link to MigratingFromXCTest.md once it is updated with interop-->
+| `SWIFT_TESTING_XCTEST_INTEROP_MODE` | `String` | Overrides the behavior for handling XCTest assertion failures recorded during a Swift Testing test. One of `none`, `limited`, `complete`, or `strict`. Explanation of modes can be found in [Migrating a test from XCTest][interop-modes]. |
 | `SWT_EXPERIMENTAL_SERIALIZED_TRAIT_APPLIES_GLOBALLY` | `Bool` | Whether or not `.serialized` applies globally or just to its branch of the test graph. |
 | `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` | `Int` | The default parallelization width when parallelized testing is enabled. |
 
-[interop-modes]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0021-targeted-interoperability-swift-testing-and-xctest.md#interoperability-modes
+[interop-modes]: ../Sources/Testing/Testing.docc/MigratingFromXCTest.md

--- a/Documentation/EnvironmentVariables.md
+++ b/Documentation/EnvironmentVariables.md
@@ -69,4 +69,4 @@ names prefixed with `SWT_`.
 | `SWT_EXPERIMENTAL_SERIALIZED_TRAIT_APPLIES_GLOBALLY` | `Bool` | Whether or not `.serialized` applies globally or just to its branch of the test graph. |
 | `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` | `Int` | The default parallelization width when parallelized testing is enabled. |
 
-[interop-modes]: ../Sources/Testing/Testing.docc/MigratingFromXCTest.md
+[interop-modes]: https://docs.swift.org/latest/documentation/testing/migratingfromxctest


### PR DESCRIPTION


### Motivation:

Link to MigratingFromXCTest, which has a more polished description of interoperability.

I decided not to link to just the article rather than the specific header anchor because:
1. interop appears pretty early on, so it's fairly easy to find
2. I don't want the link to break if we renamed the section title

### Modifications:

Update link in EnvironmentVariables.md.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.