### PR TITLE
Promote `#sourceLocation` to API.

### DIFF
--- a/Sources/Overlays/_Testing_CoreTransferable/Attachments/Attachment+Transferable.swift
+++ b/Sources/Overlays/_Testing_CoreTransferable/Attachments/Attachment+Transferable.swift
@@ -62,7 +62,7 @@ extension Attachment {
     exporting transferableValue: T,
     as contentType: UTType? = nil,
     named preferredName: String? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) async throws where T: Transferable & Sendable, AttachableValue == _AttachableTransferableWrapper<T> {
     let transferableWrapper = try await _AttachableTransferableWrapper(exporting: transferableValue, as: contentType)
     self.init(transferableWrapper, named: preferredName, sourceLocation: sourceLocation)

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
@@ -62,7 +62,7 @@ extension Attachment where AttachableValue == _AttachableURLWrapper {
   public init(
     contentsOf url: URL,
     named preferredName: String? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) async throws {
     guard url.isFileURL else {
       // TODO: network URLs?

--- a/Sources/Testing/Attachments/Attachment.swift
+++ b/Sources/Testing/Attachments/Attachment.swift
@@ -107,7 +107,7 @@ extension Attachment where AttachableValue: ~Copyable {
   ///   @Available(Swift, introduced: 6.2)
   ///   @Available(Xcode, introduced: 26.0)
   /// }
-  public init(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #_sourceLocation) {
+  public init(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #Testing::sourceLocation) {
     self._storage = Allocated(attachableValue)
     self._preferredName = preferredName
     self.sourceLocation = sourceLocation
@@ -276,7 +276,7 @@ extension Attachment where AttachableValue: Sendable & ~Copyable {
   ///   @Available(Xcode, introduced: 26.0)
   /// }
   @_documentation(visibility: private)
-  public static func record(_ attachment: consuming Self, sourceLocation: SourceLocation = #_sourceLocation) {
+  public static func record(_ attachment: consuming Self, sourceLocation: SourceLocation = #Testing::sourceLocation) {
     let attachmentCopy = Attachment<AnyAttachable>(attachment)
     Event.post(.valueAttached(attachmentCopy))
   }
@@ -306,7 +306,7 @@ extension Attachment where AttachableValue: Sendable & ~Copyable {
   ///   @Available(Xcode, introduced: 26.0)
   /// }
   @_documentation(visibility: private)
-  public static func record(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #_sourceLocation) {
+  public static func record(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #Testing::sourceLocation) {
     record(Self(attachableValue, named: preferredName, sourceLocation: sourceLocation), sourceLocation: sourceLocation)
   }
 }
@@ -330,7 +330,7 @@ extension Attachment where AttachableValue: ~Copyable {
   ///   @Available(Swift, introduced: 6.2)
   ///   @Available(Xcode, introduced: 26.0)
   /// }
-  public static func record(_ attachment: consuming Self, sourceLocation: SourceLocation = #_sourceLocation) {
+  public static func record(_ attachment: consuming Self, sourceLocation: SourceLocation = #Testing::sourceLocation) {
     do {
       let bufferCopy = try attachment.withUnsafeBytes { Array($0) }
       Attachment<Array>.record(bufferCopy, sourceLocation: sourceLocation)
@@ -364,7 +364,7 @@ extension Attachment where AttachableValue: ~Copyable {
   ///   @Available(Swift, introduced: 6.2)
   ///   @Available(Xcode, introduced: 26.0)
   /// }
-  public static func record(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #_sourceLocation) {
+  public static func record(_ attachableValue: consuming AttachableValue, named preferredName: String? = nil, sourceLocation: SourceLocation = #Testing::sourceLocation) {
     record(Self(attachableValue, named: preferredName, sourceLocation: sourceLocation), sourceLocation: sourceLocation)
   }
 }

--- a/Sources/Testing/Attachments/Images/Attachment+AttachableAsImage.swift
+++ b/Sources/Testing/Attachments/Images/Attachment+AttachableAsImage.swift
@@ -46,7 +46,7 @@ extension Attachment {
     _ image: T,
     named preferredName: String? = nil,
     as imageFormat: AttachableImageFormat? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) where AttachableValue: _AttachableImageWrapper<T> & AttachableWrapper {
     let imageWrapper = AttachableValue(image: image, imageFormat: imageFormat)
     self.init(imageWrapper, named: preferredName, sourceLocation: sourceLocation)
@@ -80,7 +80,7 @@ extension Attachment {
     _ image: T,
     named preferredName: String? = nil,
     as imageFormat: AttachableImageFormat? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) where AttachableValue: _AttachableImageWrapper<T> & AttachableWrapper {
 #if !SWT_NO_IMAGE_ATTACHMENTS
     let attachment = Self(image, named: preferredName, as: imageFormat, sourceLocation: sourceLocation)

--- a/Sources/Testing/Expectations/Expectation+Macro.swift
+++ b/Sources/Testing/Expectations/Expectation+Macro.swift
@@ -23,7 +23,7 @@
 @freestanding(expression) public macro expect(
   _ condition: Bool,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation
+  sourceLocation: SourceLocation = #Testing::sourceLocation
 ) = #externalMacro(module: "TestingMacros", type: "ExpectMacro")
 
 /// Check that an expectation has passed after a condition has been evaluated
@@ -44,7 +44,7 @@
 @freestanding(expression) public macro require(
   _ condition: Bool,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation
+  sourceLocation: SourceLocation = #Testing::sourceLocation
 ) = #externalMacro(module: "TestingMacros", type: "RequireMacro")
 
 // MARK: - Optional checking
@@ -68,7 +68,7 @@
 @freestanding(expression) public macro require<T>(
   _ optionalValue: T?,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation
+  sourceLocation: SourceLocation = #Testing::sourceLocation
 ) -> T = #externalMacro(module: "TestingMacros", type: "RequireMacro")
 
 /// Unwrap an optional boolean value or, if it is `nil`, fail and throw an
@@ -98,7 +98,7 @@
 public macro require(
   _ optionalValue: Bool?,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation
+  sourceLocation: SourceLocation = #Testing::sourceLocation
 ) -> Bool = #externalMacro(module: "TestingMacros", type: "AmbiguousRequireMacro")
 
 /// Unwrap an optional value or, if it is `nil`, fail and throw an error.
@@ -126,7 +126,7 @@ public macro require(
 public macro require<T>(
   _ optionalValue: T,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation
+  sourceLocation: SourceLocation = #Testing::sourceLocation
 ) -> T = #externalMacro(module: "TestingMacros", type: "NonOptionalRequireMacro")
 
 // MARK: - Matching errors by type
@@ -193,7 +193,7 @@ public macro require<T>(
 public macro expect<E, R>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () throws -> R
 ) -> E? = #externalMacro(module: "TestingMacros", type: "ExpectThrowsMacro") where E: Error
 
@@ -257,7 +257,7 @@ public macro expect<E, R>(
 @freestanding(expression) public macro expect<E, R>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () async throws -> R
 ) -> E? = #externalMacro(module: "TestingMacros", type: "ExpectThrowsMacro") where E: Error
 
@@ -307,7 +307,7 @@ public macro expect<E, R>(
 public macro require<E, R>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () throws -> R
 ) -> E = #externalMacro(module: "TestingMacros", type: "RequireThrowsMacro") where E: Error
 
@@ -355,7 +355,7 @@ public macro require<E, R>(
 @freestanding(expression) public macro require<E, R>(
   throws errorType: E.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () async throws -> R
 ) -> E = #externalMacro(module: "TestingMacros", type: "RequireThrowsMacro") where E: Error
 
@@ -375,7 +375,7 @@ public macro require<E, R>(
 public macro require<R>(
   throws _: Never.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "RequireThrowsNeverMacro")
 
@@ -395,7 +395,7 @@ public macro require<R>(
 public macro require<R>(
   throws _: Never.Type,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () async throws -> R
 ) = #externalMacro(module: "TestingMacros", type: "RequireThrowsNeverMacro")
 
@@ -439,7 +439,7 @@ public macro require<R>(
 public macro expect<E, R>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () throws -> R
 ) -> E? = #externalMacro(module: "TestingMacros", type: "ExpectThrowsMacro") where E: Error & Equatable
 
@@ -479,7 +479,7 @@ public macro expect<E, R>(
 @freestanding(expression) public macro expect<E, R>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () async throws -> R
 ) -> E? = #externalMacro(module: "TestingMacros", type: "ExpectThrowsMacro") where E: Error & Equatable
 
@@ -525,7 +525,7 @@ public macro expect<E, R>(
 public macro require<E, R>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () throws -> R
 ) -> E = #externalMacro(module: "TestingMacros", type: "RequireThrowsMacro") where E: Error & Equatable
 
@@ -569,7 +569,7 @@ public macro require<E, R>(
 @freestanding(expression) public macro require<E, R>(
   throws error: E,
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () async throws -> R
 ) -> E = #externalMacro(module: "TestingMacros", type: "RequireThrowsMacro") where E: Error & Equatable
 
@@ -634,7 +634,7 @@ public macro require<E, R>(
 @_documentation(visibility: private)
 public macro expect<R>(
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () throws -> R,
   throws errorMatcher: (any Error) throws -> Bool
 ) -> (any Error)? = #externalMacro(module: "TestingMacros", type: "ExpectThrowsMacro")
@@ -696,7 +696,7 @@ public macro expect<R>(
 @discardableResult
 @freestanding(expression) public macro expect<R>(
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () async throws -> R,
   throws errorMatcher: (any Error) async throws -> Bool
 ) -> (any Error)? = #externalMacro(module: "TestingMacros", type: "ExpectThrowsMacro")
@@ -767,7 +767,7 @@ public macro expect<R>(
 @_documentation(visibility: private)
 public macro require<R>(
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () throws -> R,
   throws errorMatcher: (any Error) throws -> Bool
 ) -> any Error = #externalMacro(module: "TestingMacros", type: "RequireThrowsMacro")
@@ -836,7 +836,7 @@ public macro require<R>(
 @discardableResult
 @freestanding(expression) public macro require<R>(
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: () async throws -> R,
   throws errorMatcher: (any Error) async throws -> Bool
 ) -> any Error = #externalMacro(module: "TestingMacros", type: "RequireThrowsMacro")
@@ -884,7 +884,7 @@ public macro expect(
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: @escaping @Sendable () async throws -> Void
 ) -> ExitTest.Result? = #externalMacro(module: "TestingMacros", type: "ExitTestExpectMacro")
 
@@ -930,7 +930,7 @@ public macro expect(
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: @escaping @Sendable () throws -> Void
 ) -> ExitTest.Result? = #externalMacro(module: "TestingMacros", type: "ExitTestExpectMacro")
 
@@ -978,7 +978,7 @@ public macro require(
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: @escaping @Sendable () async throws -> Void
 ) -> ExitTest.Result = #externalMacro(module: "TestingMacros", type: "ExitTestRequireMacro")
 
@@ -1027,7 +1027,7 @@ public macro require(
   processExitsWith expectedExitCondition: ExitTest.Condition,
   observing observedValues: [any PartialKeyPath<ExitTest.Result> & Sendable] = [],
   _ comment: @autoclosure () -> Comment? = nil,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   performing expression: @escaping @Sendable () throws -> Void
 ) -> ExitTest.Result = #externalMacro(module: "TestingMacros", type: "ExitTestRequireMacro")
 

--- a/Sources/Testing/Issues/Confirmation.swift
+++ b/Sources/Testing/Issues/Confirmation.swift
@@ -102,7 +102,7 @@ public func confirmation<R>(
   _ comment: Comment? = nil,
   expectedCount: Int = 1,
   isolation: isolated (any Actor)? = #isolation,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   _ body: (Confirmation) async throws -> sending R
 ) async rethrows -> R {
   try await confirmation(
@@ -176,7 +176,7 @@ public func confirmation<R>(
   _ comment: Comment? = nil,
   expectedCount: some RangeExpression<Int> & Sequence<Int> & Sendable,
   isolation: isolated (any Actor)? = #isolation,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   _ body: (Confirmation) async throws -> sending R
 ) async rethrows -> R {
   let confirmation = Confirmation()
@@ -205,7 +205,7 @@ public func confirmation<R>(
   _ comment: Comment? = nil,
   expectedCount: UnboundedRange,
   isolation: isolated (any Actor)? = #isolation,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   _ body: (Confirmation) async throws -> R
 ) async rethrows -> R {
   swt_unreachable()
@@ -222,7 +222,7 @@ public func confirmation<R>(
   _ comment: Comment? = nil,
   expectedCount: PartialRangeThrough<Int>,
   isolation: isolated (any Actor)? = #isolation,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   _ body: (Confirmation) async throws -> R
 ) async rethrows -> R {
   swt_unreachable()
@@ -239,7 +239,7 @@ public func confirmation<R>(
   _ comment: Comment? = nil,
   expectedCount: PartialRangeUpTo<Int>,
   isolation: isolated (any Actor)? = #isolation,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   _ body: (Confirmation) async throws -> R
 ) async rethrows -> R {
   swt_unreachable()

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -66,7 +66,7 @@ extension Issue {
   @available(*, deprecated, message: "Use record(_:severity:sourceLocation:) instead.")
   @discardableResult public static func record(
     _ comment: Comment? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) -> Self {
     record(comment, severity: .error, sourceLocation: sourceLocation)
   }
@@ -94,7 +94,7 @@ extension Issue {
   @discardableResult public static func record(
     _ comment: Comment? = nil,
     severity: Severity = .error,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) -> Self {
     let sourceContext = SourceContext(backtrace: .current(), sourceLocation: sourceLocation)
     let issue = Issue(kind: .unconditional, severity: severity, comments: Array(comment), sourceContext: sourceContext)
@@ -122,7 +122,7 @@ extension Issue {
   @discardableResult public static func record(
     _ error: any Error,
     _ comment: Comment? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) -> Self {
     record(error, comment, severity: .error, sourceLocation: sourceLocation)
   }
@@ -147,7 +147,7 @@ extension Issue {
     _ error: any Error,
     _ comment: Comment? = nil,
     severity: Severity,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) -> Self {
     let backtrace = Backtrace(forFirstThrowOf: error) ?? Backtrace.current()
     let sourceContext = SourceContext(backtrace: backtrace, sourceLocation: sourceLocation)

--- a/Sources/Testing/Issues/KnownIssue.swift
+++ b/Sources/Testing/Issues/KnownIssue.swift
@@ -166,7 +166,7 @@ public typealias KnownIssueMatcher = @Sendable (_ issue: Issue) -> Bool
 public func withKnownIssue(
   _ comment: Comment? = nil,
   isIntermittent: Bool = false,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   _ body: () throws -> Void
 ) {
   try? withKnownIssue(comment, isIntermittent: isIntermittent, sourceLocation: sourceLocation, body, matching: { _ in true })
@@ -223,7 +223,7 @@ public func withKnownIssue(
 public func withKnownIssue(
   _ comment: Comment? = nil,
   isIntermittent: Bool = false,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   _ body: () throws -> Void,
   when precondition: () -> Bool = { true },
   matching issueMatcher: @escaping KnownIssueMatcher = { _ in true }
@@ -283,7 +283,7 @@ public func withKnownIssue(
   _ comment: Comment? = nil,
   isIntermittent: Bool = false,
   isolation: isolated (any Actor)? = #isolation,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   _ body: () async throws -> Void
 ) async {
   try? await withKnownIssue(comment, isIntermittent: isIntermittent, isolation: isolation, sourceLocation: sourceLocation, body, matching: { _ in true })
@@ -342,7 +342,7 @@ public func withKnownIssue(
   _ comment: Comment? = nil,
   isIntermittent: Bool = false,
   isolation: isolated (any Actor)? = #isolation,
-  sourceLocation: SourceLocation = #_sourceLocation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
   _ body: () async throws -> Void,
   when precondition: () async -> Bool = { true },
   matching issueMatcher: @escaping KnownIssueMatcher = { _ in true }

--- a/Sources/Testing/SourceAttribution/SourceLocation+Macro.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation+Macro.swift
@@ -25,10 +25,15 @@
 /// default argument to a function.
 ///
 /// ```swift
-/// func cookBurger(sourceLocation: SourceLocation = #_sourceLocation) {
+/// func cookBurger(sourceLocation: SourceLocation = #Testing::sourceLocation) {
 ///   // ...
 /// }
 /// ```
+///
+/// @DeprecationSummary {
+///   Use [`#Testing::sourceLocation`](``Testing/sourceLocation()``) instead.
+/// }
+@available(swift, deprecated: 100000.0, message: "Use '#Testing::sourceLocation' instead.")
 @freestanding(expression) public macro _sourceLocation() -> SourceLocation = #externalMacro(module: "TestingMacros", type: "SourceLocationMacro")
 
 /// Get the current source location.
@@ -60,14 +65,17 @@
 ///   // ...
 /// }
 /// ```
-@_spi(Experimental)
+///
+/// @Metadata {
+///   @Available(Swift, introduced: 6.5)
+/// }
 @freestanding(expression) public macro sourceLocation() -> SourceLocation = #externalMacro(module: "TestingMacros", type: "SourceLocationMacro")
 
 extension SourceLocation {
   /// Get the current source location as an instance of ``SourceLocation``.
   ///
-  /// - Warning: This function is used to implement the `#_sourceLocation`
-  ///   macro. Do not call it directly.
+  /// - Warning: This function is used to implement the
+  ///   `#Testing::sourceLocation` macro. Do not call it directly.
   public static func __here(
     fileID: String = #fileID,
     filePath: String = #filePath,
@@ -79,8 +87,8 @@ extension SourceLocation {
 
   /// Initialize an instance of this type without validating any arguments.
   ///
-  /// - Warning: This initializer is used to implement the `#_sourceLocation`
-  ///   macro. Do not call it directly.
+  /// - Warning: This function is used to implement the
+  ///   `#Testing::sourceLocation` macro. Do not call it directly.
   public init(__uncheckedFileID fileID: String, filePath: String, line: Int, column: Int) {
     self.fileID = fileID
     self.filePath = filePath

--- a/Sources/Testing/SourceAttribution/SourceLocation+Macro.swift
+++ b/Sources/Testing/SourceAttribution/SourceLocation+Macro.swift
@@ -31,7 +31,7 @@
 /// ```
 ///
 /// @DeprecationSummary {
-///   Use [`#Testing::sourceLocation`](``Testing/sourceLocation()``) instead.
+///   Use [`#Testing::sourceLocation`](doc:Testing/sourceLocation()) instead.
 /// }
 @available(swift, deprecated: 100000.0, message: "Use '#Testing::sourceLocation' instead.")
 @freestanding(expression) public macro _sourceLocation() -> SourceLocation = #externalMacro(module: "TestingMacros", type: "SourceLocationMacro")

--- a/Sources/Testing/Test+Cancellation.swift
+++ b/Sources/Testing/Test+Cancellation.swift
@@ -238,7 +238,7 @@ extension Test: TestCancellable {
   ///   @Available(Swift, introduced: 6.3)
   ///   @Available(Xcode, introduced: 26.4)
   /// }
-  public static func cancel(_ comment: Comment? = nil, sourceLocation: SourceLocation = #_sourceLocation) throws -> Never {
+  public static func cancel(_ comment: Comment? = nil, sourceLocation: SourceLocation = #Testing::sourceLocation) throws -> Never {
     let skipInfo = SkipInfo(comment: comment, sourceContext: SourceContext(backtrace: nil, sourceLocation: sourceLocation))
     try Self.cancel(with: skipInfo)
   }

--- a/Sources/Testing/Testing.docc/Expectations.md
+++ b/Sources/Testing/Testing.docc/Expectations.md
@@ -95,6 +95,6 @@ the test when the code doesn't satisfy a requirement, use
 ### Representing source locations
 
 - ``SourceLocation``
-<!-- - ``sourceLocation()`` -->
+- ``sourceLocation()``
 <!-- - ``SourceContext`` -->
 <!-- - ``Backtrace`` -->

--- a/Sources/Testing/Traits/AttachmentSavingTrait.swift
+++ b/Sources/Testing/Traits/AttachmentSavingTrait.swift
@@ -225,7 +225,7 @@ extension Trait where Self == AttachmentSavingTrait {
   /// evaluates `condition` and, if the condition is met, saves the attachments.
   public static func savingAttachments(
     if condition: Self.Condition,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) -> Self {
     Self(condition: condition, sourceLocation: sourceLocation)
   }
@@ -251,7 +251,7 @@ extension Trait where Self == AttachmentSavingTrait {
   /// evaluates `condition` and, if the condition is met, saves the attachments.
   public static func savingAttachments(
     if condition: @autoclosure @escaping @Sendable () throws -> Bool,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) -> Self {
     let condition = Self.Condition { _ in try condition() }
     return savingAttachments(if: condition, sourceLocation: sourceLocation)
@@ -284,7 +284,7 @@ extension Trait where Self == AttachmentSavingTrait {
   /// }
   public static func savingAttachments(
     if condition: @escaping @Sendable () async throws -> Bool,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) -> Self {
     let condition = Self.Condition { _ in try await condition() }
     return savingAttachments(if: condition, sourceLocation: sourceLocation)

--- a/Sources/Testing/Traits/ConditionTrait.swift
+++ b/Sources/Testing/Traits/ConditionTrait.swift
@@ -123,7 +123,7 @@ extension Trait where Self == ConditionTrait {
   public static func enabled(
     if condition: @autoclosure @escaping @Sendable () throws -> Bool,
     _ comment: Comment? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) -> Self {
     Self(kind: .conditional(condition), comments: Array(comment), sourceLocation: sourceLocation)
   }
@@ -141,7 +141,7 @@ extension Trait where Self == ConditionTrait {
   ///   closure you provide.
   public static func enabled(
     _ comment: Comment? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation,
+    sourceLocation: SourceLocation = #Testing::sourceLocation,
     _ condition: @escaping @Sendable () async throws -> Bool
   ) -> Self {
     Self(kind: .conditional(condition), comments: Array(comment), sourceLocation: sourceLocation)
@@ -157,7 +157,7 @@ extension Trait where Self == ConditionTrait {
   ///   test to which it is added.
   public static func disabled(
     _ comment: Comment? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) -> Self {
     Self(kind: .unconditional(false), comments: Array(comment), sourceLocation: sourceLocation)
   }
@@ -182,7 +182,7 @@ extension Trait where Self == ConditionTrait {
   public static func disabled(
     if condition: @autoclosure @escaping @Sendable () throws -> Bool,
     _ comment: Comment? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) -> Self {
     Self(kind: .conditional { !(try condition()) }, comments: Array(comment), sourceLocation: sourceLocation)
   }
@@ -200,7 +200,7 @@ extension Trait where Self == ConditionTrait {
   ///   specified closure.
   public static func disabled(
     _ comment: Comment? = nil,
-    sourceLocation: SourceLocation = #_sourceLocation,
+    sourceLocation: SourceLocation = #Testing::sourceLocation,
     _ condition: @escaping @Sendable () async throws -> Bool
   ) -> Self {
     Self(kind: .conditional { !(try await condition()) }, comments: Array(comment), sourceLocation: sourceLocation)

--- a/Tests/TestingTests/EventTests.swift
+++ b/Tests/TestingTests/EventTests.swift
@@ -55,7 +55,7 @@ struct EventTests {
   func codable(kind: Event.Kind) async throws {
     let testID = Test.ID(moduleName: "ModuleName",
                          nameComponents: ["NameComponent1", "NameComponent2"],
-                         sourceLocation: #_sourceLocation)
+                         sourceLocation: #Testing::sourceLocation)
     let testCaseID = Test.Case.ID(argumentIDs: nil, discriminator: nil, isStable: true)
     let event = Event(kind, testID: testID, testCaseID: testCaseID, instant: .now)
     let eventSnapshot = Event.Snapshot(snapshotting: event)

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -490,7 +490,7 @@ private import _TestingInternals
 
   @Test("Arguments to the macro are not captured during expansion (do not need to be literals/const)")
   func argumentsAreNotCapturedDuringMacroExpansion() async throws {
-    let unrelatedSourceLocation = #_sourceLocation
+    let unrelatedSourceLocation = #Testing::sourceLocation
     func nonConstExitCondition() async throws -> ExitTest.Condition {
       .failure
     }
@@ -698,9 +698,9 @@ private import _TestingInternals
     }
   }
 
-  @Test("Capturing #_sourceLocation")
+  @Test("Capturing #Testing::sourceLocation")
   func captureListPreservesSourceLocationMacro() async {
-    func sl(_ sl: SourceLocation = #_sourceLocation) -> SourceLocation {
+    func sl(_ sl: SourceLocation = #Testing::sourceLocation) -> SourceLocation {
       sl
     }
     await #expect(processExitsWith: .success) { [sl = sl() as SourceLocation] in

--- a/Tests/TestingTests/IssueTests.swift
+++ b/Tests/TestingTests/IssueTests.swift
@@ -1082,7 +1082,7 @@ final class IssueTests: XCTestCase {
     let issueRecorded = expectation(description: "Issue recorded")
     issueRecorded.expectedFulfillmentCount = 2
 
-    let lowerBound = #_sourceLocation
+    let lowerBound = #Testing::sourceLocation
     let upperBound = Self.testFailWithoutCurrentTestEnd
     let sourceBounds = __SourceBounds(
       __uncheckedLowerBound: lowerBound,
@@ -1091,7 +1091,7 @@ final class IssueTests: XCTestCase {
     let test = Test(sourceBounds: sourceBounds) {
       await Task.detached {
         _ = Issue.record()
-        Self.recordIssue(sourceLocation: #_sourceLocation)
+        Self.recordIssue(sourceLocation: #Testing::sourceLocation)
       }.value
     }
 
@@ -1110,7 +1110,7 @@ final class IssueTests: XCTestCase {
 
     await fulfillment(of: [issueRecorded], timeout: 0.0)
   }
-  private static let testFailWithoutCurrentTestEnd = #_sourceLocation
+  private static let testFailWithoutCurrentTestEnd = #Testing::sourceLocation
 
   func testFailWithoutCurrentTestAndNoSourceLocation() async throws {
     var configuration = Configuration()
@@ -1717,7 +1717,7 @@ final class IssueTests: XCTestCase {
 
   func testExplicitSourceContextWithoutLocation() async {
     // This just ensures that `Issue.record` with an explicit sourceContext
-    // doesn't infer the location via #_sourceLocation.
+    // doesn't infer the location via #Testing::sourceLocation.
 
     var configuration = Configuration()
     configuration.eventHandler = { event, _ in
@@ -1770,7 +1770,7 @@ struct IssueCodingTests {
   private static let issueKinds: [Issue.Kind] = [
     Issue.Kind.apiMisused,
     Issue.Kind.errorCaught(NSError(domain: "Domain", code: 13, userInfo: ["UserInfoKey": "UserInfoValue"])),
-    Issue.Kind.expectationFailed(Expectation(evaluatedExpression: .init("abc"), isPassing: true, isRequired: true, sourceLocation: #_sourceLocation)),
+    Issue.Kind.expectationFailed(Expectation(evaluatedExpression: .init("abc"), isPassing: true, isRequired: true, sourceLocation: #Testing::sourceLocation)),
     Issue.Kind.knownIssueNotRecorded,
     Issue.Kind.system,
     Issue.Kind.timeLimitExceeded(timeLimitComponents: (123, 0)),
@@ -1784,7 +1784,7 @@ struct IssueCodingTests {
     let issue = Issue(
       kind: issueKind,
       comments: ["Comment"],
-      sourceContext: SourceContext(backtrace: Backtrace.current(), sourceLocation: #_sourceLocation)
+      sourceContext: SourceContext(backtrace: Backtrace.current(), sourceLocation: #Testing::sourceLocation)
     )
     let issueSnapshot = Issue.Snapshot(snapshotting: issue)
     let decoded = try JSON.encodeAndDecode(issueSnapshot)
@@ -1859,7 +1859,7 @@ struct IssueCodingTests {
     let issue = Issue(
       kind: issueKind,
       comments: ["Comment"],
-      sourceContext: SourceContext(backtrace: Backtrace.current(), sourceLocation: #_sourceLocation)
+      sourceContext: SourceContext(backtrace: Backtrace.current(), sourceLocation: #Testing::sourceLocation)
     )
     let issueSnapshot = Issue.Snapshot(snapshotting: issue)
 

--- a/Tests/TestingTests/MiscellaneousTests.swift
+++ b/Tests/TestingTests/MiscellaneousTests.swift
@@ -323,7 +323,7 @@ struct MiscellaneousTests {
   @Test func `Suite type with raw identifier gets a display name`() throws {
     struct `Suite With De Facto Display Name` {}
     let typeInfo = TypeInfo(describing: `Suite With De Facto Display Name`.self)
-    let suite = Test(traits: [], sourceLocation: #_sourceLocation, containingTypeInfo: typeInfo, isSynthesized: true)
+    let suite = Test(traits: [], sourceLocation: #Testing::sourceLocation, containingTypeInfo: typeInfo, isSynthesized: true)
     #expect(suite.name == "`Suite With De Facto Display Name`")
     let displayName = try #require(suite.displayName)
     #expect(displayName == "Suite With De Facto Display Name")
@@ -523,7 +523,7 @@ struct MiscellaneousTests {
   @Test("Properties related to parameterization")
   func parameterizationRelatedProperties() async throws {
     do {
-      let test = Test.__type(SendableTests.self, displayName: "", traits: [], sourceBounds: __SourceBounds(lowerBoundOnly: #_sourceLocation))
+      let test = Test.__type(SendableTests.self, displayName: "", traits: [], sourceBounds: __SourceBounds(lowerBoundOnly: #Testing::sourceLocation))
       #expect(!test.isParameterized)
       #expect(test.testCases == nil)
       #expect(test.parameters == nil)
@@ -566,7 +566,7 @@ struct MiscellaneousTests {
 
   @Test("Test.id property")
   func id() async throws {
-    let typeTest = Test.__type(SendableTests.self, displayName: "SendableTests", traits: [], sourceBounds: __SourceBounds(lowerBoundOnly: #_sourceLocation))
+    let typeTest = Test.__type(SendableTests.self, displayName: "SendableTests", traits: [], sourceBounds: __SourceBounds(lowerBoundOnly: #Testing::sourceLocation))
     #expect(String(describing: typeTest.id) == "TestingTests.SendableTests")
 
     let fileID = "Module/Y.swift"
@@ -584,7 +584,7 @@ struct MiscellaneousTests {
     #expect(idWithParent.parent != nil)
     #expect(idWithParent.parent?.parent == nil)
 
-    let functionIDWithParent = Test.ID(moduleName: "A", nameComponents: ["B"], sourceLocation: #_sourceLocation)
+    let functionIDWithParent = Test.ID(moduleName: "A", nameComponents: ["B"], sourceLocation: #Testing::sourceLocation)
     let parentOfFunctionID = try #require(functionIDWithParent.parent)
     #expect(parentOfFunctionID.moduleName == "A")
     #expect(parentOfFunctionID.nameComponents == ["B"])

--- a/Tests/TestingTests/SkipInfoTests.swift
+++ b/Tests/TestingTests/SkipInfoTests.swift
@@ -20,11 +20,11 @@ struct SkipInfoTests {
   }
 
   @Test("sourceLocation property") func sourceLocation() {
-    let sourceLocation1 = #_sourceLocation
+    let sourceLocation1 = #Testing::sourceLocation
     var skipInfo = SkipInfo(sourceContext: .init(sourceLocation: sourceLocation1))
     #expect(skipInfo.sourceLocation == sourceLocation1)
 
-    let sourceLocation2 = #_sourceLocation
+    let sourceLocation2 = #Testing::sourceLocation
     skipInfo.sourceLocation = sourceLocation2
     #expect(skipInfo.sourceLocation == sourceLocation2)
   }

--- a/Tests/TestingTests/TestCancellationTests.swift
+++ b/Tests/TestingTests/TestCancellationTests.swift
@@ -72,7 +72,7 @@
   }
 
   @Test func `Cancelling a test propagates its SkipInfo to its test cases`() async {
-    let sourceLocation = #_sourceLocation
+    let sourceLocation = #Testing::sourceLocation
     await testCancellation(testCancelled: 1, testCaseCancelled: 1) { configuration in
       await Test {
         try Test.cancel("Cancelled test", sourceLocation: sourceLocation)

--- a/Tests/TestingTests/TestCaseIterationTests.swift
+++ b/Tests/TestingTests/TestCaseIterationTests.swift
@@ -121,7 +121,7 @@ struct TestCaseIterationTests {
   private func assertEncodedEventKinds(
     _ test: Test,
     equals expected: [ABI.EncodedEvent<ABI.CurrentVersion>.Kind],
-    sourceLocation: SourceLocation = #_sourceLocation
+    sourceLocation: SourceLocation = #Testing::sourceLocation
   ) async {
     let events = Mutex<[ABI.EncodedEvent<ABI.CurrentVersion>]>([])
     var configuration = Configuration()

--- a/Tests/TestingTests/TestSupport/TestingAdditions.swift
+++ b/Tests/TestingTests/TestSupport/TestingAdditions.swift
@@ -168,7 +168,7 @@ extension Test {
   /// the `@Test` macro.
   init(
     _ traits: any TestTrait...,
-    sourceLocation: SourceLocation = #_sourceLocation,
+    sourceLocation: SourceLocation = #Testing::sourceLocation,
     sourceBounds: __SourceBounds? = nil,
     name: String = #function,
     testFunction: @escaping @Sendable () async throws -> Void
@@ -199,7 +199,7 @@ extension Test {
     parameters: [Parameter] = [
       Parameter(index: 0, firstName: "x", type: C.Element.self),
     ],
-    sourceLocation: SourceLocation = #_sourceLocation,
+    sourceLocation: SourceLocation = #Testing::sourceLocation,
     sourceBounds: __SourceBounds? = nil,
     column: Int = #column,
     name: String = #function,
@@ -216,7 +216,7 @@ extension Test {
     parameters: [Parameter] = [
       Parameter(index: 0, firstName: "x", type: C.Element.self),
     ],
-    sourceLocation: SourceLocation = #_sourceLocation,
+    sourceLocation: SourceLocation = #Testing::sourceLocation,
     sourceBounds: __SourceBounds? = nil,
     column: Int = #column,
     name: String = #function,
@@ -252,7 +252,7 @@ extension Test {
       Parameter(index: 0, firstName: "x", type: C1.Element.self),
       Parameter(index: 1, firstName: "y", type: C2.Element.self),
     ],
-    sourceLocation: SourceLocation = #_sourceLocation,
+    sourceLocation: SourceLocation = #Testing::sourceLocation,
     sourceBounds: __SourceBounds? = nil,
     name: String = #function,
     testFunction: @escaping @Sendable (C1.Element, C2.Element) async throws -> Void
@@ -280,7 +280,7 @@ extension Test {
       Parameter(index: 0, firstName: "x", type: C1.Element.self),
       Parameter(index: 1, firstName: "y", type: C2.Element.self),
     ],
-    sourceLocation: SourceLocation = #_sourceLocation,
+    sourceLocation: SourceLocation = #Testing::sourceLocation,
     sourceBounds: __SourceBounds? = nil,
     name: String = #function,
     testFunction: @escaping @Sendable ((C1.Element, C2.Element)) async throws -> Void

--- a/Tests/TestingTests/Traits/ConditionTraitTests.swift
+++ b/Tests/TestingTests/Traits/ConditionTraitTests.swift
@@ -40,7 +40,7 @@ struct ConditionTraitTests {
   
   @Test
   func evaluateCondition() async throws {
-    let trueUnconditional = ConditionTrait(kind: .unconditional(true), comments: [], sourceLocation: #_sourceLocation)
+    let trueUnconditional = ConditionTrait(kind: .unconditional(true), comments: [], sourceLocation: #Testing::sourceLocation)
     let falseUnconditional = ConditionTrait.disabled()
     let enabledTrue = ConditionTrait.enabled(if: true)
     let enabledFalse = ConditionTrait.enabled(if: false)


### PR DESCRIPTION
As promised! For [ST-0027](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0027-sourcelocation-macro.md).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
