### PR TITLE
Support semver prerelease IDs in `ABI.VersionNumber`

### DIFF
--- a/Sources/Testing/ABI/ABI.Record+Streaming.swift
+++ b/Sources/Testing/ABI/ABI.Record+Streaming.swift
@@ -52,6 +52,8 @@ extension ABI.Version {
 // MARK: - Xcode 16 compatibility
 
 extension ABI.Xcode16 {
+  typealias Dev = Self
+
   static func eventHandler(
     forwardingTo recordHandler: @escaping @Sendable (_ record: ABI.Record<Self>) -> Void
   ) -> Event.Handler {

--- a/Sources/Testing/ABI/ABI.VersionNumber.swift
+++ b/Sources/Testing/ABI/ABI.VersionNumber.swift
@@ -42,12 +42,44 @@ extension ABI {
 
     /// The patch, revision, or bug fix version.
     var patchComponent: Component = 0
+
+    /// A type describing flags for version numbers.
+    ///
+    /// When converting a version number to or from a string, all flags are
+    /// represented as "pre-release identifiers" per the semantic versioning
+    /// specification.
+    ///
+    /// - Important: The semantic versioning specification requires that the
+    ///   order of prerelease IDs be preserved so that it can factor into
+    ///   version number comparisons. This type does _not_ follow that rule so
+    ///   we can save space: if we preserved ordering, the stride of
+    ///   ``ABI/VersionNumber`` would need to be at least as large as two
+    ///   pointers to hold the numeric components, the flags, and their
+    ///   ordering.
+    struct Flags: OptionSet {
+      var rawValue: Component.Magnitude
+
+      /// The owning version number represents a development build of the
+      /// testing library.
+      static var developmentBuild: Self { .init(rawValue: 1 << 0) }
+
+#if DEBUG
+      /// Whether or not the testing library was built as a debug build.
+      ///
+      /// - Note: We only ever use this flag in our own debug builds to allow
+      ///   for testing the logic in this file.
+      static var debugBuild: Self { .init(rawValue: 1 << (RawValue.bitWidth - 1)) }
+#endif
+    }
+
+    /// Flags for this instance.
+    var flags: Flags = []
   }
 }
 
 extension ABI.VersionNumber {
-  init(_ majorComponent: _const Component, _ minorComponent: _const Component, _ patchComponent: _const Component = 0) {
-    self.init(majorComponent: majorComponent, minorComponent: minorComponent, patchComponent: patchComponent)
+  init(_ majorComponent: _const Component, _ minorComponent: _const Component, _ patchComponent: _const Component = 0, flags: Flags = []) {
+    self.init(majorComponent: majorComponent, minorComponent: minorComponent, patchComponent: patchComponent, flags: flags)
   }
 }
 
@@ -69,6 +101,11 @@ extension ABI.VersionNumber: CustomStringConvertible {
   ///   `VersionTupleSyntax` type here because we cannot link to swift-syntax
   ///   in this target.
   private static func _parse(_ string: String) -> Self? {
+    // The empty string is obviously invalid.
+    if string.isEmpty {
+      return nil
+    }
+
     // Check if we've previously encountered this version number.
     let cachedValue = Self._versionNumberCache.withLock { versionNumberCache in
       versionNumberCache[string]
@@ -79,9 +116,23 @@ extension ABI.VersionNumber: CustomStringConvertible {
 
     var result: Self?
     do {
+      // Split the string on "-" once to extract any prerelease identifiers. We
+      // need to continue to support a negative major component, so if the first
+      // character is "-", we need to skip it during splitting, then insert it
+      // back into the first string.
+      var componentsThenPrereleaseIDs: [Substring]
+      if string.first == "-" {
+        componentsThenPrereleaseIDs = string.dropFirst().split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+        let allComponents = componentsThenPrereleaseIDs[0]
+        componentsThenPrereleaseIDs[0] = string[..<allComponents.endIndex]
+      } else {
+        componentsThenPrereleaseIDs = string.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+      }
+
       // Split the string on "." (assuming it is of the form "1", "1.2", or
       // "1.2.3") and parse the individual components as integers.
-      let components = string.split(separator: ".", omittingEmptySubsequences: false)
+      let allComponents = componentsThenPrereleaseIDs[0]
+      let components = allComponents.split(separator: ".", omittingEmptySubsequences: false)
       func componentValue(_ index: Int) -> Component? {
         components.count > index ? Component(components[index]) : 0
       }
@@ -89,6 +140,26 @@ extension ABI.VersionNumber: CustomStringConvertible {
          let minorComponent = componentValue(1),
          let patchComponent = componentValue(2) {
         result = Self(majorComponent: majorComponent, minorComponent: minorComponent, patchComponent: patchComponent)
+      }
+
+      if componentsThenPrereleaseIDs.count > 1 {
+        let allPrereleaseIDs = componentsThenPrereleaseIDs[1]
+        if allPrereleaseIDs.isEmpty {
+          // There was a trailing "-" which is invalid.
+          result = nil
+        } else {
+          let prereleaseIDs = allPrereleaseIDs.split(separator: ".", omittingEmptySubsequences: false)
+
+          var flags: Flags = []
+          for prereleaseID in prereleaseIDs {
+            guard let flag = Flags(prereleaseID: prereleaseID) else {
+              result = nil
+              break
+            }
+            flags.insert(flag)
+          }
+          result?.flags = flags
+        }
       }
     }
 
@@ -138,18 +209,18 @@ extension ABI.VersionNumber: CustomStringConvertible {
   }
 
   public var description: String {
-    if majorComponent <= 0 && minorComponent == 0 && patchComponent == 0 {
+    if majorComponent <= 0 && minorComponent == 0 && patchComponent == 0 && flags.isEmpty {
       // Version 0 and earlier are described as integers for compatibility with
       // Swift 6.2 and earlier.
       return String(describing: majorComponent)
     } else if patchComponent == 0 {
-      return "\(majorComponent).\(minorComponent)"
+      return "\(majorComponent).\(minorComponent)\(flags.prereleaseIDSuffix)"
     }
-    return "\(majorComponent).\(minorComponent).\(patchComponent)"
+    return "\(majorComponent).\(minorComponent).\(patchComponent)\(flags.prereleaseIDSuffix)"
   }
 }
 
-// MARK: - Equatable, Comparable
+// MARK: - Equatable, Comparable, Hashable
 
 extension ABI.VersionNumber: Equatable, Comparable {
   public static func <(lhs: Self, rhs: Self) -> Bool {
@@ -159,10 +230,27 @@ extension ABI.VersionNumber: Equatable, Comparable {
       return lhs.minorComponent < rhs.minorComponent
     } else if lhs.patchComponent != rhs.patchComponent {
       return lhs.patchComponent < rhs.patchComponent
+    } else if case let lhs = lhs.flags.rawValue.nonzeroBitCount,
+              case let rhs = rhs.flags.rawValue.nonzeroBitCount,
+              lhs != rhs {
+      if lhs == 0 {
+        return false
+      } else if rhs == 0 {
+        return true
+      }
+      return lhs < rhs
+    } else if lhs.flags != rhs.flags {
+      for (lhs, rhs) in zip(lhs.flags.prereleaseIDs, rhs.flags.prereleaseIDs) {
+        if lhs != rhs {
+          return lhs < rhs
+        }
+      }
     }
     return false
   }
 }
+
+extension ABI.VersionNumber.Flags: Equatable, Hashable {}
 
 #if !SWT_NO_CODABLE
 // MARK: - Codable
@@ -190,12 +278,12 @@ extension ABI.VersionNumber: Codable {
 
   public func encode(to encoder: any Encoder) throws {
     var container = encoder.singleValueContainer()
-    if majorComponent <= 0 && minorComponent == 0 && patchComponent == 0 {
+    if majorComponent <= 0 && minorComponent == 0 && patchComponent == 0 && flags.isEmpty {
       // Version 0 and earlier are encoded as integers for compatibility with
       // Swift 6.2 and earlier.
       try container.encode(majorComponent)
     } else {
-      try container.encode("\(majorComponent).\(minorComponent).\(patchComponent)")
+      try container.encode("\(majorComponent).\(minorComponent).\(patchComponent)\(flags.prereleaseIDSuffix)")
     }
   }
 
@@ -214,5 +302,74 @@ extension ABI.VersionNumber: Codable {
     self = try JSON.decode(MinimalRecord.self, from: recordJSON).version
   }
 #endif
+}
+
+// MARK: - Converting flags to/from semver prerelease IDs
+
+extension ABI.VersionNumber.Flags {
+  /// The set of recognized prerelease IDs keyed by their corresponding ``Flag``
+  /// values.
+  private static let _prereleaseIDsByFlag = {
+    var result: [Self: String] = [
+      .developmentBuild: "dev",
+    ]
+#if DEBUG
+    result[.debugBuild] = "debug"
+#endif
+    return result
+  }()
+
+  /// The set of recognized ``Flag`` values keyed by their corresponding
+  /// prerelease IDs.
+  ///
+  /// The keys of this dictionary are substrings to allow lookup during parsing
+  /// without needing to copy substrings of the original string.
+  private static let _flagsByPrereleaseID = Dictionary(
+    uniqueKeysWithValues: _prereleaseIDsByFlag.map { ($1[...], $0) }
+  )
+
+  /// The set of non-zero bits set in this instance's raw value.
+  ///
+  /// The order of the values in this sequence is from low bit to high bit.
+  ///
+  /// Bits are represented here as masks, not positionally. For example, the
+  /// bit `0b10` is represented here as `(1 << 1)`, not as `1`.
+  fileprivate var nonZeroBits: some Sequence<RawValue> {
+    sequence(state: rawValue) { rawValue in
+      if rawValue.nonzeroBitCount == 0 {
+        return nil
+      }
+      let lowBit = RawValue(1 << rawValue.trailingZeroBitCount)
+      rawValue &= ~lowBit
+      return lowBit
+    }
+  }
+
+  /// The set of prerelease IDs, per the semantic versioning specification,
+  /// represented by this instance.
+  ///
+  /// The order of strings in this sequence matches that of ``nonZeroBits``.
+  var prereleaseIDs: some Sequence<String> {
+    nonZeroBits.lazy
+      .map(Self.init(rawValue:))
+      .compactMap { Self._prereleaseIDsByFlag[$0] }
+  }
+
+  /// The suffix to apply to the owning instance of ``ABI/VersionNumber``
+  /// when converting it to a string.
+  fileprivate var prereleaseIDSuffix: String {
+    if self.isEmpty {
+      return ""
+    }
+    return "-" + prereleaseIDs.joined(separator: ".")
+  }
+
+  init?<S>(prereleaseID: S) where S: StringProtocol, S.SubSequence == Substring {
+    guard let flag = Self._flagsByPrereleaseID[prereleaseID[...]] else {
+      return nil
+    }
+
+    self = flag
+  }
 }
 #endif

--- a/Sources/Testing/ABI/ABI.swift
+++ b/Sources/Testing/ABI/ABI.swift
@@ -22,6 +22,10 @@ extension ABI {
     /// The numeric representation of this ABI version.
     static var versionNumber: VersionNumber { get }
 
+    /// An ABI version equivalent to this one but set to represent development
+    /// builds.
+    associatedtype Dev: Version = _DevelopmentVersion<Self>
+
 #if !SWT_NO_ABI_JSON_SCHEMA
     /// Create an event handler that encodes instances of ``Event`` as instances
     /// of ``ABI/Record`` and forwards them to a handler function.
@@ -98,6 +102,19 @@ extension ABI {
     forVersionNumber versionNumber: VersionNumber,
     givenSwiftCompilerVersion swiftCompilerVersion: @autoclosure () -> VersionNumber
   ) -> (any Version.Type)? {
+    // If the caller needs a development version, check the logic for
+    // non-development versions, then return the resulting version type's
+    // equivalent development type.
+    if versionNumber.flags.contains(.developmentBuild) {
+      var versionNumberCopy = versionNumber
+      versionNumberCopy.flags.remove(.developmentBuild)
+      let result = version(forVersionNumber: versionNumberCopy, givenSwiftCompilerVersion: swiftCompilerVersion())
+      func open<V>(_: V.Type) -> any Version.Type where V: Version {
+        return V.Dev.self
+      }
+      return result.map { open($0) }
+    }
+
     if versionNumber >= ABI.ExperimentalVersion.versionNumber {
       // The experimental ABI version is higher than any real ABI version.
       return ABI.ExperimentalVersion.self
@@ -327,6 +344,27 @@ extension ABI {
     public static var versionNumber: VersionNumber {
       VersionNumber(99, 0)
     }
+
+    public typealias Dev = Self
+  }
+}
+
+// MARK: - Development versions
+
+extension ABI {
+  /// A version type that wraps another such type and marks it as a development
+  /// build version.
+  ///
+  /// This type is used as the default value for the associated type
+  /// ``Version/Dev``. You shouldn't need to use it elsewhere.
+  public enum _DevelopmentVersion<V>: Sendable, Version where V: Version {
+    public static var versionNumber: VersionNumber {
+      var result = V.versionNumber
+      result.flags.insert(.developmentBuild)
+      return result
+    }
+
+    public typealias Dev = Self
   }
 }
 

--- a/Sources/Testing/Events/Event.Metadata.swift
+++ b/Sources/Testing/Events/Event.Metadata.swift
@@ -35,7 +35,7 @@ extension Event {
     /// - Returns: Whether or not this instance should be recorded.
     func shouldRecord(withVerbosity verbosity: Int) -> Bool {
       switch name {
-      case Self._testingLibraryVersionName, Self._targetPlatformName:
+      case Self._testingLibraryVersionName, Self._testingLibraryCommitName, Self._targetPlatformName:
         true
       default:
         verbosity > 0
@@ -60,6 +60,7 @@ extension Event.Metadata {
   private static var _swiftCompilerVersionName: String { "Swift Compiler Version" }
   private static var _gnuCLibraryVersionName: String { "GNU C Library Version" }
   private static var _testingLibraryVersionName: String { "Testing Library Version" }
+  private static var _testingLibraryCommitName: String { "Testing Library Commit" }
   private static var _targetPlatformName: String { "Target Platform" }
   private static var _simulatorOSVersionName: String { "OS Version (Simulator)" }
   private static var _hostOSVersionName: String { "OS Version (Host)" }
@@ -82,7 +83,12 @@ extension Event.Metadata {
 #if os(Linux) && canImport(Glibc)
     append(_gnuCLibraryVersionName, glibcVersion)
 #endif
-    append(_testingLibraryVersionName, testingLibraryVersion)
+    if let testingLibraryVersion {
+      append(_testingLibraryVersionName, testingLibraryVersion)
+    }
+    if let testingLibraryCommit {
+      append(_testingLibraryCommitName, testingLibraryCommit)
+    }
     if let targetTriple {
       append(_targetPlatformName, targetTriple)
     }

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -135,15 +135,20 @@ let apiLevel: String = {
 }()
 #endif
 
-/// A human-readable string describing the testing library's version.
-///
-/// This value's format is platform-specific and is not meant to be
-/// machine-readable. It is added to the output of a test run when using
-/// an event writer.
+/// The testing library's version, or `nil` if it could not be parsed or was not
+/// available at compile time.
 ///
 /// This value is not part of the public interface of the testing library.
-let testingLibraryVersion: String = {
-  var result = swt_getTestingLibraryVersion().flatMap(String.init(validatingCString:)) ?? "unknown"
+let testingLibraryVersion: VersionNumber? = {
+  swt_getTestingLibraryVersion().flatMap(VersionNumber.init(validatingCString:))
+}()
+
+/// A human-readable string describing the source control commit used to build
+/// the testing library, or `nil` if that information is not available.
+///
+/// This value is not part of the public interface of the testing library.
+let testingLibraryCommit: String? = {
+  var result: String? = nil
 
   // Get details of the git commit used when compiling the testing library.
   var commitHash: UnsafePointer<CChar>?
@@ -154,9 +159,9 @@ let testingLibraryVersion: String = {
     // Truncate to 15 characters of the hash to match `swift --version`.
     let commitHash = commitHash.prefix(15)
     if commitModified {
-      result = "\(result) (\(commitHash) - modified)"
+      result = "\(commitHash) - modified"
     } else {
-      result = "\(result) (\(commitHash))"
+      result = String(commitHash)
     }
   }
 

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -682,6 +682,60 @@ struct SwiftPMTests {
     }
     #expect(versionNumber == ABI.VersionNumber(1, 2, 3))
   }
+
+  @Test("semver prerelease IDs")
+  func preleaseIDs() throws {
+    let v123 = ABI.VersionNumber(1, 2, 3)
+
+    let v123Dev = try #require(VersionNumber("1.2.3-dev"))
+    #expect(v123Dev == ABI.VersionNumber(1, 2, 3, flags: [.developmentBuild]))
+    #expect(v123Dev < v123)
+    #expect(!(v123Dev > v123Dev))
+    #expect(!(v123Dev < v123Dev))
+    #expect(String(describing: v123Dev) == "1.2.3-dev")
+
+#if DEBUG
+    let v123Debug = try #require(VersionNumber("1.2.3-debug"))
+    #expect(v123Dev != v123Debug)
+    #expect(v123Debug == ABI.VersionNumber(1, 2, 3, flags: [.debugBuild]))
+    #expect(v123Debug < v123)
+    #expect(String(describing: v123Debug) == "1.2.3-debug")
+
+    #expect(v123Debug < v123Dev)
+    #expect(v123Dev > v123Debug)
+#endif
+
+    let v246Dev = try #require(VersionNumber("2.4.6-dev"))
+    #expect(v246Dev == ABI.VersionNumber(2, 4, 6, flags: [.developmentBuild]))
+    #expect(v246Dev < ABI.VersionNumber(2, 4, 6))
+    #expect(String(describing: v246Dev) == "2.4.6-dev")
+    #expect(v246Dev > v123Dev)
+
+#if DEBUG
+    let v246DevDebug = try #require(VersionNumber("2.4.6-debug.dev"))
+    #expect(v246DevDebug != v246Dev)
+    #expect(v246DevDebug == ABI.VersionNumber(2, 4, 6, flags: [.developmentBuild, .debugBuild]))
+    #expect(v246DevDebug < ABI.VersionNumber(2, 4, 6))
+    #expect(String(describing: v246DevDebug) == "2.4.6-dev.debug")
+    #expect(v246DevDebug > v246Dev)
+#endif
+
+    let vN1Dev = try #require(VersionNumber("-1-dev"))
+    #expect(vN1Dev.majorComponent == -1)
+    #expect(vN1Dev.flags == [.developmentBuild])
+    
+    #expect(VersionNumber("") == nil)
+    #expect(VersionNumber("1.2.3-") == nil)
+    #expect(VersionNumber("1.2.3-invalid.flags") == nil)
+    #expect(VersionNumber("1.2.3-.debug") == nil)
+
+    let v63Dev = try #require(VersionNumber("6.3.0-dev"))
+    let v63DevABI = try #require(ABI.version(forVersionNumber: v63Dev))
+    #expect(v63DevABI.versionNumber.majorComponent == 6)
+    #expect(v63DevABI.versionNumber.minorComponent == 3)
+    #expect(v63DevABI.versionNumber.patchComponent == 0)
+    #expect(v63DevABI.versionNumber.flags == [.developmentBuild])
+  }
 #endif
 #endif
 


### PR DESCRIPTION
This PR adds support for representing development versions of the JSON schema independently of release versions by specifying the `"-dev"` suffix, e.g. `--event-stream-version 6.5-dev`.

This is useful if we want to enable functionality only on a development branch, for instance. A separate PR will adopt this new logic when parsing `VERSION.txt` so we always know what our own branch is, which will make `ABI.version(forVersionNumber:)` play nicer whenever `main` moves to a new version (shout-out to @bkhouri for noticing that `"--event-stream-version 6.5"` didn't work after we branched `release/6.4` and retargetted `main` until we explicitly added `ABI.v6_5`.).

This PR adds the necessary infrastructure to support other suffixes in the future that can be used to enable or disable functionality dynamically. (No, I don't have specific ideas in mind, it's just a useful tool for the toolbox.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
