### PR TITLE
Fix some stray `print()` calls.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -573,6 +573,7 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
 ///
 /// - Parameters:
 ///   - args: A previously-parsed command-line arguments structure to interpret.
+///   - emitWarnings: Whether or not to emit validation warnings to `stderr`.
 ///
 /// - Returns: An instance of ``Configuration``. Note that the caller is
 ///   responsible for setting this instance's ``Configuration/eventHandler``
@@ -580,7 +581,7 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
 ///
 /// - Throws: If an argument is invalid, such as a malformed regular expression.
 @_spi(ForToolsIntegrationOnly)
-public func configurationForEntryPoint(from args: __CommandLineArguments_v0) throws -> Configuration {
+public func configurationForEntryPoint(from args: __CommandLineArguments_v0, emitWarnings: Bool = true) throws -> Configuration {
   var configuration = Configuration()
 
   // Parallelization (on by default)
@@ -679,7 +680,13 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0) thr
         let originalString = string
         string = String(string.dropFirst().dropLast())
 #if !SWT_NO_FILE_IO
-        try? FileHandle.stderr.write("Backticks aren't a valid part of a Swift symbol. Replacing '\(originalString)' with '\(string)'.\n")
+        if emitWarnings {
+          let warning = Event.ConsoleOutputRecorder.warning(
+            "Backticks aren't a valid part of a Swift symbol. Replacing '\(originalString)' with '\(string)'.",
+            options: .for(.stderr)
+          )
+          try? FileHandle.stderr.write("\(warning)\n")
+        }
 #endif
       }
     }

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -527,7 +527,6 @@ struct AttachmentTests {
       #expect(bytes[0] == UInt8(ascii: "<"))
     }
     let ext = (attachment.preferredName as NSString).pathExtension
-    print(attachment.preferredName)
     #expect(ext.caseInsensitiveCompare("xml") == .orderedSame)
   }
 

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -16,7 +16,7 @@ private import Foundation
 
 private func configurationForEntryPoint(withArguments args: [String], emitWarnings: Bool = true) throws -> Configuration {
   let args = try parseCommandLineArguments(from: args)
-  return try configurationForEntryPoint(from: args)
+  return try configurationForEntryPoint(from: args, emitWarnings: emitWarnings)
 }
 
 #if !SWT_NO_ABI_JSON_SCHEMA

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -14,7 +14,7 @@ private import _TestingInternals
 private import Foundation
 #endif
 
-private func configurationForEntryPoint(withArguments args: [String]) throws -> Configuration {
+private func configurationForEntryPoint(withArguments args: [String], emitWarnings: Bool = true) throws -> Configuration {
   let args = try parseCommandLineArguments(from: args)
   return try configurationForEntryPoint(from: args)
 }
@@ -207,7 +207,7 @@ struct SwiftPMTests {
 
   @Test("--filter tag: argument strips backticks around tag names")
   func filterByTagStripsBackticks() async throws {
-    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:`testTag`"])
+    let configuration = try configurationForEntryPoint(withArguments: ["PATH", "--filter", "tag:`testTag`"], emitWarnings: false)
     let test1 = Test(.tags(.testTag), name: "hello") {}
     let test2 = Test(name: "goodbye") {}
     let plan = await Runner.Plan(tests: [test1, test2], configuration: configuration)
@@ -418,7 +418,6 @@ struct SwiftPMTests {
         Issue.record("Test setup failure.  Could not create file at \(attachmentPath).")
       }
       defer {
-        print("removing \(attachmentPath) ...")
         _ = remove(attachmentPath)
       }
       #expect(throws: (any Error).self, "Attachment path is: \(attachmentPath)") {


### PR DESCRIPTION
This fixes some stray `print()` calls in our console output, as well as ensures the "no backticks please" message is formatted nicely (and suppressed in our own tests!)

<img width="760" height="126" alt="Screenshot 2026-08-31 at 1 13 53 PM" src="https://github.com/user-attachments/assets/f6f57d39-278c-4fab-a87a-defb94e80d45" />

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
