### PR TITLE
Fix missing specification of `tags`, `bugs`, and `timeLimit` on suites.

### DIFF
--- a/Documentation/ABI/JSON.md
+++ b/Documentation/ABI/JSON.md
@@ -152,6 +152,9 @@ additional `"testCases"` field describing the individual test cases.
   ["displayName": <string>,] ; the user-supplied custom display name
   "sourceLocation": <source-location>, ; where the test suite is defined
   "id": <test-id>,
+  ["tags": <array:tag>,] ; the tags associated with this test suite
+  ["bugs": <array:bug>,] ; the bugs associated with this test suite
+  ["timeLimit": <number>,] ; the time limit associated with this test suite
 }
 
 <test-function> ::= {
@@ -163,7 +166,7 @@ additional `"testCases"` field describing the individual test cases.
   "isParameterized": <bool>, ; is this a parameterized test function or not?
   ["tags": <array:tag>,] ; the tags associated with this test function
   ["bugs": <array:bug>,] ; the bugs associated with this test function
-  ["timeLimit": <number>] ; the time limit associated with this test function
+  ["timeLimit": <number>,] ; the time limit associated with this test function
 }
 
 <test-id> ::= <string> ; an opaque string representing the test case
@@ -173,7 +176,7 @@ additional `"testCases"` field describing the individual test cases.
 <bug> ::= {
   ["url": <string>,] ; the bug URL
   ["id": <string>,] ; the bug id
-  ["title": <string>] ; the human readable bug title
+  ["title": <string>,] ; the human readable bug title
 }
 ```
 


### PR DESCRIPTION
The JSON documentation is missing `tags`, `bugs`, and `timeLimit` on `<test-suite>`. This is an erratum. These fields are allowed for test suite records in the JSON schema and have been since they were introduced.

See also https://github.com/swiftlang/swift-evolution/pull/3475.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
