### PR TITLE
Add `withExpectedIssue` for validating the content of recorded Issues (#155)

### DIFF
--- a/Sources/Testing/Issues/ExpectedIssue.swift
+++ b/Sources/Testing/Issues/ExpectedIssue.swift
@@ -1,0 +1,236 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if canImport(Synchronization)
+private import Synchronization
+#endif
+
+/// A type that represents an active ``withExpectedIssue(_:isIntermittent:sourceLocation:_:matching:)``
+/// call.
+///
+/// When a test function calls ``withExpectedIssue(_:isIntermittent:sourceLocation:_:matching:)``,
+/// an instance of this type is pushed onto the task-local stack. Any ``Issue``
+/// recorded while this scope is active that is matched by its ``matcher`` is
+/// suppressed (not recorded as a test failure) and captured for the caller to
+/// inspect.
+struct ExpectedIssueScope: Sendable {
+  /// A function which determines whether a given issue matches this scope.
+  ///
+  /// - Parameters:
+  ///   - issue: The issue to evaluate.
+  ///
+  /// - Returns: `true` if the issue is the one expected by this scope,
+  ///   `false` otherwise.
+  typealias Matcher = @Sendable (_ issue: Issue) -> Bool
+
+  /// The matcher function for this expected issue scope.
+  var matcher: Matcher
+
+  /// The number of issues this scope has suppressed (matched).
+  fileprivate let matchCounter: Allocated<Atomic<Int>>
+
+  /// The first issue captured by this scope, if any.
+  fileprivate let capturedIssue: Allocated<Mutex<Issue?>>
+
+  /// Create a new ``ExpectedIssueScope`` with the given issue matcher.
+  ///
+  /// - Parameters:
+  ///   - issueMatcher: A function to invoke when an issue occurs that is used
+  ///     to determine if the issue is the expected one.
+  init(issueMatcher: @escaping KnownIssueMatcher) {
+    let matchCounter = Allocated(Atomic(0))
+    let capturedIssue = Allocated(Mutex<Issue?>())
+    self.matchCounter = matchCounter
+    self.capturedIssue = capturedIssue
+    matcher = { issue in
+      guard issueMatcher(issue) else {
+        return false
+      }
+      matchCounter.value.add(1, ordering: .sequentiallyConsistent)
+      capturedIssue.value.withLock { stored in
+        if stored == nil {
+          stored = issue
+        }
+      }
+      return true
+    }
+  }
+
+  /// The active expected issue scope for the current task, if any.
+  ///
+  /// If there is no call to
+  /// ``withExpectedIssue(_:isIntermittent:sourceLocation:_:matching:)``
+  /// executing on the current task, the value of this property is `nil`.
+  @TaskLocal
+  static var current: ExpectedIssueScope?
+}
+
+// MARK: -
+
+/// Invoke a function that is expected to record at least one issue during
+/// its execution.
+///
+/// - Parameters:
+///   - comment: An optional comment describing the expected issue.
+///   - isIntermittent: Whether or not the expected issue occurs intermittently.
+///     If this argument is `true` and no issue occurs, no secondary issue is
+///     recorded.
+///   - sourceLocation: The source location to which any recorded issues should
+///     be attributed.
+///   - body: The function to invoke.
+///   - issueMatcher: A function to invoke when an issue occurs that is used to
+///     determine if it is the expected issue. By default, all issues match.
+///
+/// - Returns: The first ``Issue`` that was matched and suppressed by this
+///   function, or `nil` if no matching issue was recorded. The returned
+///   issue is provided so that callers may inspect its content (e.g. its
+///   ``Issue/comments`` or ``Issue/kind``).
+///
+/// Use this function when testing a custom assertion helper or testing utility
+/// to verify that it correctly records an ``Issue``. Unlike
+/// ``withKnownIssue(_:isIntermittent:sourceLocation:_:when:matching:)``, which
+/// implies a bug that is expected to be fixed in the future,
+/// `withExpectedIssue` expresses that recording an issue is the **correct and
+/// intended behavior** of the code under test.
+///
+/// For example, suppose you have written a custom assertion helper:
+///
+/// ```swift
+/// func assertIsPositive(_ value: Int, sourceLocation: SourceLocation = #Testing::sourceLocation) {
+///   if value <= 0 {
+///     Issue.record("Expected a positive value, but got \(value)", sourceLocation: sourceLocation)
+///   }
+/// }
+/// ```
+///
+/// You can test that this helper correctly records an issue using
+/// `withExpectedIssue`:
+///
+/// ```swift
+/// @Test func assertIsPositiveRecordsIssueForNegativeValue() {
+///   let issue = withExpectedIssue {
+///     assertIsPositive(-1)
+///   }
+///   #expect(issue?.comments.first?.rawValue.contains("positive") == true)
+/// }
+/// ```
+///
+/// If `body` does not record any matching issue, and `isIntermittent` is
+/// `false`, an ``Issue`` of kind ``Issue/Kind/knownIssueNotRecorded`` is
+/// recorded for the current test, indicating that the expected issue was
+/// missing.
+///
+/// - Note: `issueMatcher` may be invoked more than once for the same issue.
+@_spi(Experimental)
+@discardableResult
+public func withExpectedIssue(
+  _ comment: Comment? = nil,
+  isIntermittent: Bool = false,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
+  _ body: () throws -> Void,
+  matching issueMatcher: @escaping KnownIssueMatcher = { _ in true }
+) -> Issue? {
+  let scope = ExpectedIssueScope(issueMatcher: issueMatcher)
+  ExpectedIssueScope.$current.withValue(scope) {
+    do {
+      try body()
+    } catch is ExpectationFailedError {
+      // ExpectationFailedError is thrown by #require() when a condition
+      // fails. The expectation checking function already records its own
+      // issue, which will be matched by the scope's matcher if applicable.
+    } catch {
+      // For other thrown errors, create an issue and run it through the
+      // scope's matcher. If it matches, it is suppressed; otherwise it is
+      // recorded normally.
+      let sourceContext = SourceContext(backtrace: Backtrace(forFirstThrowOf: error), sourceLocation: sourceLocation)
+      let issue = Issue(kind: .errorCaught(error), comments: [], sourceContext: sourceContext)
+      if !scope.matcher(issue) {
+        issue.record()
+      }
+    }
+  }
+  if !isIntermittent && scope.matchCounter.value.load(ordering: .sequentiallyConsistent) == 0 {
+    let issue = Issue(
+      kind: .knownIssueNotRecorded,
+      comments: Array(comment),
+      sourceContext: .init(backtrace: nil, sourceLocation: sourceLocation)
+    )
+    issue.record()
+  }
+  return scope.capturedIssue.value.withLock { $0 }
+}
+
+/// Invoke an async function that is expected to record at least one issue
+/// during its execution.
+///
+/// - Parameters:
+///   - comment: An optional comment describing the expected issue.
+///   - isIntermittent: Whether or not the expected issue occurs intermittently.
+///     If this argument is `true` and no issue occurs, no secondary issue is
+///     recorded.
+///   - isolation: The actor to which `body` is isolated, if any.
+///   - sourceLocation: The source location to which any recorded issues should
+///     be attributed.
+///   - body: The async function to invoke.
+///   - issueMatcher: A function to invoke when an issue occurs that is used to
+///     determine if it is the expected issue. By default, all issues match.
+///
+/// - Returns: The first ``Issue`` that was matched and suppressed by this
+///   function, or `nil` if no matching issue was recorded. The returned
+///   issue is provided so that callers may inspect its content (e.g. its
+///   ``Issue/comments`` or ``Issue/kind``).
+///
+/// Use this function when testing a custom assertion helper or testing utility
+/// to verify that it correctly records an ``Issue``. Unlike
+/// ``withKnownIssue(_:isIntermittent:isolation:sourceLocation:_:when:matching:)``,
+/// which implies a bug that is expected to be fixed in the future,
+/// `withExpectedIssue` expresses that recording an issue is the **correct and
+/// intended behavior** of the code under test.
+///
+/// - Note: `issueMatcher` may be invoked more than once for the same issue.
+@_spi(Experimental)
+@discardableResult
+public func withExpectedIssue(
+  _ comment: Comment? = nil,
+  isIntermittent: Bool = false,
+  isolation: isolated (any Actor)? = #isolation,
+  sourceLocation: SourceLocation = #Testing::sourceLocation,
+  _ body: () async throws -> Void,
+  matching issueMatcher: @escaping KnownIssueMatcher = { _ in true }
+) async -> Issue? {
+  let scope = ExpectedIssueScope(issueMatcher: issueMatcher)
+  await ExpectedIssueScope.$current.withValue(scope) {
+    do {
+      try await body()
+    } catch is ExpectationFailedError {
+      // ExpectationFailedError is thrown by #require() when a condition
+      // fails. The expectation checking function already records its own
+      // issue, which will be matched by the scope's matcher if applicable.
+    } catch {
+      // For other thrown errors, create an issue and run it through the
+      // scope's matcher. If it matches, it is suppressed; otherwise it is
+      // recorded normally.
+      let sourceContext = SourceContext(backtrace: Backtrace(forFirstThrowOf: error), sourceLocation: sourceLocation)
+      let issue = Issue(kind: .errorCaught(error), comments: [], sourceContext: sourceContext)
+      if !scope.matcher(issue) {
+        issue.record()
+      }
+    }
+  }
+  if !isIntermittent && scope.matchCounter.value.load(ordering: .sequentiallyConsistent) == 0 {
+    let issue = Issue(
+      kind: .knownIssueNotRecorded,
+      comments: Array(comment),
+      sourceContext: .init(backtrace: nil, sourceLocation: sourceLocation)
+    )
+    issue.record()
+  }
+  return scope.capturedIssue.value.withLock { $0 }
+}

--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -36,6 +36,14 @@ extension Issue {
       return selfCopy.record(configuration: configuration)
     }
 
+    // If this issue is matched by an active withExpectedIssue scope, suppress
+    // it: the issue was intentionally expected by the caller, so it should not
+    // be forwarded to the event handler or trigger a failure breakpoint. The
+    // scope captures the issue internally so the caller can inspect it.
+    if let scope = ExpectedIssueScope.current, scope.matcher(self) {
+      return self
+    }
+
     Event.post(.issueRecorded(self), configuration: configuration)
 
     if !isKnown {

--- a/Tests/TestingTests/ExpectedIssueTests.swift
+++ b/Tests/TestingTests/ExpectedIssueTests.swift
@@ -1,0 +1,317 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if canImport(XCTest)
+import XCTest
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+final class ExpectedIssueTests: XCTestCase {
+
+  // MARK: - Basic capture
+
+  func testExpectedIssueIsCaptured() async {
+    // An issue recorded via Issue.record() inside withExpectedIssue should be
+    // suppressed (not forwarded to the event handler) and returned to the caller.
+    let unexpectedIssue = expectation(description: "unexpected issue recorded")
+    unexpectedIssue.isInverted = true
+
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      if case .issueRecorded = event.kind {
+        unexpectedIssue.fulfill()
+      }
+    }
+
+    var capturedIssue: Issue?
+    await Test {
+      capturedIssue = withExpectedIssue {
+        Issue.record("hello from expected issue")
+      }
+    }.run(configuration: configuration)
+
+    // The issue must have been captured by withExpectedIssue.
+    XCTAssertNotNil(capturedIssue)
+    // And it must NOT have been forwarded to the event handler.
+    await fulfillment(of: [unexpectedIssue], timeout: 0.0)
+  }
+
+  // MARK: - Issue content validation
+
+  func testCapturedIssueContentIsAccessible() async {
+    var capturedIssue: Issue?
+    await Test {
+      capturedIssue = withExpectedIssue {
+        Issue.record("a specific message")
+      }
+    }.run(configuration: .init())
+
+    XCTAssertNotNil(capturedIssue)
+    XCTAssertEqual(capturedIssue?.comments, ["a specific message"])
+    guard case .unconditional = capturedIssue?.kind else {
+      XCTFail("Expected issue kind .unconditional")
+      return
+    }
+  }
+
+  // MARK: - Expectation failure issued correctly when body records no issue
+
+  func testIssueRecordedWhenExpectedIssueDoesNotOccur() async {
+    // If body records no issue, withExpectedIssue itself records a
+    // .knownIssueNotRecorded issue so the test fails visibly.
+    let missingIssueRecorded = expectation(description: "knownIssueNotRecorded issue recorded")
+
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      guard case let .issueRecorded(issue) = event.kind,
+            case .knownIssueNotRecorded = issue.kind else {
+        return
+      }
+      missingIssueRecorded.fulfill()
+    }
+
+    await Test {
+      withExpectedIssue {
+        // body records nothing — withExpectedIssue should record a failure
+      }
+    }.run(configuration: configuration)
+
+    await fulfillment(of: [missingIssueRecorded], timeout: 0.0)
+  }
+
+  // MARK: - isIntermittent suppresses missing-issue failure
+
+  func testIntermittentExpectedIssueDoesNotFailWhenIssueAbsent() async {
+    let unexpectedIssue = expectation(description: "unexpected issue recorded")
+    unexpectedIssue.isInverted = true
+
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      if case .issueRecorded = event.kind {
+        unexpectedIssue.fulfill()
+      }
+    }
+
+    await Test {
+      withExpectedIssue(isIntermittent: true) {
+        // body records nothing — but isIntermittent: true means no failure
+      }
+    }.run(configuration: configuration)
+
+    await fulfillment(of: [unexpectedIssue], timeout: 0.0)
+  }
+
+  // MARK: - Custom matcher
+
+  func testCustomMatcherFiltersIssues() async {
+    // Only issues whose comment contains "match me" should be captured;
+    // all others should still be recorded normally.
+    let unmatchedIssueRecorded = expectation(description: "unmatched issue forwarded")
+
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      guard case let .issueRecorded(issue) = event.kind else { return }
+      if issue.comments.contains(where: { $0.rawValue.contains("do not match") }) {
+        unmatchedIssueRecorded.fulfill()
+      }
+    }
+
+    var capturedIssue: Issue?
+    await Test {
+      capturedIssue = withExpectedIssue(
+        matching: { issue in
+          issue.comments.contains { $0.rawValue.contains("match me") }
+        }
+      ) {
+        Issue.record("match me")
+        Issue.record("do not match")
+      }
+    }.run(configuration: configuration)
+
+    // The matching issue should be captured.
+    XCTAssertNotNil(capturedIssue)
+    XCTAssertTrue(capturedIssue?.comments.first?.rawValue.contains("match me") == true)
+    // The non-matching issue should have been forwarded to the event handler.
+    await fulfillment(of: [unmatchedIssueRecorded], timeout: 0.0)
+  }
+
+  // MARK: - Only first matching issue is returned
+
+  func testOnlyFirstMatchingIssueIsReturned() async {
+    var capturedIssue: Issue?
+    await Test {
+      capturedIssue = withExpectedIssue {
+        Issue.record("first")
+        Issue.record("second")
+      }
+    }.run(configuration: .init())
+
+    XCTAssertEqual(capturedIssue?.comments, ["first"])
+  }
+
+  // MARK: - Async version
+
+  func testAsyncExpectedIssueIsCaptured() async {
+    let unexpectedIssue = expectation(description: "unexpected issue recorded")
+    unexpectedIssue.isInverted = true
+
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      if case .issueRecorded = event.kind {
+        unexpectedIssue.fulfill()
+      }
+    }
+
+    var capturedIssue: Issue?
+    await Test {
+      capturedIssue = await withExpectedIssue { () async in
+        Issue.record("async expected issue")
+      }
+    }.run(configuration: configuration)
+
+    XCTAssertNotNil(capturedIssue)
+    await fulfillment(of: [unexpectedIssue], timeout: 0.0)
+  }
+
+  // MARK: - Thrown errors are matched
+
+  func testThrownErrorIsMatchedByExpectedIssueScope() async {
+    struct MyError: Error {}
+
+    let unexpectedIssue = expectation(description: "unexpected issue recorded")
+    unexpectedIssue.isInverted = true
+
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      if case .issueRecorded = event.kind {
+        unexpectedIssue.fulfill()
+      }
+    }
+
+    var capturedIssue: Issue?
+    await Test {
+      capturedIssue = withExpectedIssue(
+        matching: { $0.error is MyError }
+      ) {
+        throw MyError()
+      }
+    }.run(configuration: configuration)
+
+    XCTAssertNotNil(capturedIssue)
+    XCTAssertTrue(capturedIssue?.error is MyError)
+    await fulfillment(of: [unexpectedIssue], timeout: 0.0)
+  }
+
+  // MARK: - withExpectedIssue does not interfere with withKnownIssue
+
+  func testExpectedIssueDoesNotInterfereWithKnownIssue() async {
+    // A withKnownIssue inside withExpectedIssue: the known issue is handled by
+    // KnownIssueScope first, so ExpectedIssueScope should NOT capture it.
+    let knownIssueRecorded = expectation(description: "known issue recorded")
+
+    var configuration = Configuration()
+    configuration.eventHandler = { event, _ in
+      guard case let .issueRecorded(issue) = event.kind,
+            issue.isKnown else { return }
+      knownIssueRecorded.fulfill()
+    }
+
+    var capturedIssue: Issue?
+    await Test {
+      capturedIssue = withExpectedIssue {
+        withKnownIssue {
+          Issue.record("this is the known issue")
+        }
+      }
+    }.run(configuration: configuration)
+
+    // The known issue was consumed by withKnownIssue, so withExpectedIssue
+    // saw nothing and must report a missing-issue failure.
+    // (capturedIssue should be nil and a knownIssueNotRecorded issue recorded.)
+    XCTAssertNil(capturedIssue)
+    // The known issue itself should still be forwarded with isKnown = true.
+    await fulfillment(of: [knownIssueRecorded], timeout: 0.0)
+  }
+
+  // MARK: - #expect failure captured via ExpectationFailed kind
+
+  func testExpectationFailureIsCaptured() async {
+    var capturedIssue: Issue?
+    await Test {
+      capturedIssue = withExpectedIssue(
+        matching: { issue in
+          if case .expectationFailed = issue.kind { return true }
+          return false
+        }
+      ) {
+        #expect(Bool(false))
+      }
+    }.run(configuration: .init())
+
+    XCTAssertNotNil(capturedIssue)
+    guard case .expectationFailed = capturedIssue?.kind else {
+      XCTFail("Expected .expectationFailed kind")
+      return
+    }
+  }
+}
+
+// MARK: - Swift Testing style tests
+
+@Suite("withExpectedIssue")
+@_spi(Experimental)
+struct WithExpectedIssueTests {
+
+  @Test("Basic: issue is suppressed and returned")
+  func basicIssueCapture() async {
+    var configuration = Configuration()
+    var issueWasForwarded = false
+    configuration.eventHandler = { event, _ in
+      if case .issueRecorded = event.kind { issueWasForwarded = true }
+    }
+    var capturedIssue: Issue?
+    await Test {
+      capturedIssue = withExpectedIssue {
+        Issue.record("expected failure")
+      }
+    }.run(configuration: configuration)
+
+    #expect(capturedIssue != nil)
+    #expect(!issueWasForwarded)
+    #expect(capturedIssue?.comments == ["expected failure"])
+  }
+
+  @Test("Async: issue is suppressed and returned")
+  func asyncIssueCapture() async {
+    var capturedIssue: Issue?
+    await Test {
+      capturedIssue = await withExpectedIssue { () async in
+        Issue.record("async expected failure")
+      }
+    }.run(configuration: .init())
+
+    #expect(capturedIssue != nil)
+    #expect(capturedIssue?.comments == ["async expected failure"])
+  }
+
+  @Test("isIntermittent: no failure when body records no issue")
+  func intermittentNoFailure() async {
+    var configuration = Configuration()
+    var issueWasForwarded = false
+    configuration.eventHandler = { event, _ in
+      if case .issueRecorded = event.kind { issueWasForwarded = true }
+    }
+    await Test {
+      withExpectedIssue(isIntermittent: true) { /* no issue */ }
+    }.run(configuration: configuration)
+
+    #expect(!issueWasForwarded)
+  }
+}
+#endif


### PR DESCRIPTION
Introduce `withExpectedIssue(_:isIntermittent:sourceLocation:_:matching:)` and its async counterpart as `@_spi(Experimental)` API.

### Motivation :- 

When writing tests for custom testing utilities (e.g. a helper that calls `Issue.record()`), there was no first-class way to assert that the helper correctly records an `Issue` and to inspect the recorded content.

`withKnownIssue()` is semantically wrong for this purpose because it implies a bug to be fixed in the future, whereas the intent here is that recording an issue is the **correct and intended behavior** of the code under test. This is the use case tracked in #155.

### Modifications:

The new API follows the same `@TaskLocal` scope pattern as `KnownIssueScope`:

- **`ExpectedIssueScope`** (internal) is pushed onto the task-local stack by `withExpectedIssue`. Any `Issue` that passes the caller-supplied matcher is suppressed (not forwarded to the event handler or `failureBreakpoint`) and the first captured issue is returned to the caller for content inspection.

- **`Issue.record()`** gains an 8-line guard that checks `ExpectedIssueScope.current` before posting the event, mirroring the existing `KnownIssueScope` check. No other existing logic is modified.

- If no matching issue is recorded and `isIntermittent` is `false`, a `.knownIssueNotRecorded` issue is recorded so the test fails visibly consistent with `withKnownIssue` behavior.

**Files changed:**
- `Sources/Testing/Issues/ExpectedIssue.swift` - new file with `ExpectedIssueScope` + sync/async `withExpectedIssue`
- `Sources/Testing/Issues/Issue+Recording.swift` - +8 lines in `record()`
- `Tests/TestingTests/ExpectedIssueTests.swift` - new file with 12 tests covering all behaviors

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated....