### PR TITLE
Add missing test coverage for ConditionTrait async and property APIs

### DIFF
--- a/Tests/TestingTests/Traits/ConditionTraitTests.swift
+++ b/Tests/TestingTests/Traits/ConditionTraitTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-@testable import Testing
+@testable @_spi(ForToolsIntegrationOnly) import Testing
 
 @Suite("Condition Trait Tests", .tags(.traitRelated))
 struct ConditionTraitTests {
@@ -37,7 +37,7 @@ struct ConditionTraitTests {
     .disabled(if: false)
   )
   func disabledTraitIf() throws {}
-  
+
   @Test
   func evaluateCondition() async throws {
     let trueUnconditional = ConditionTrait(kind: .unconditional(true), comments: [], sourceLocation: #Testing::sourceLocation)
@@ -45,7 +45,7 @@ struct ConditionTraitTests {
     let enabledTrue = ConditionTrait.enabled(if: true)
     let enabledFalse = ConditionTrait.enabled(if: false)
     var result: Bool
-    
+
     result = try await trueUnconditional.evaluate()
     #expect(result)
     result = try await falseUnconditional.evaluate()
@@ -55,4 +55,163 @@ struct ConditionTraitTests {
     result = try await enabledFalse.evaluate()
     #expect(!result)
   }
+
+  // MARK: - Async closure overloads
+
+  @Test("evaluate() with async closure (.enabled)")
+  func evaluateAsyncEnabledClosure() async throws {
+    // The async closure overload of .enabled(_:sourceLocation:_:) had no
+    // dedicated test. Verify that it correctly evaluates an async condition.
+    let enabledAsync = ConditionTrait.enabled("async enabled") {
+      await Task { true }.value
+    }
+    let disabledAsync = ConditionTrait.enabled("async disabled") {
+      await Task { false }.value
+    }
+    #expect(try await enabledAsync.evaluate())
+    #expect(try await !(disabledAsync.evaluate()))
+  }
+
+  @Test("evaluate() with async closure (.disabled)")
+  func evaluateAsyncDisabledClosure() async throws {
+    // The async closure overload of .disabled(_:sourceLocation:_:) had no
+    // dedicated test. Verify that it correctly evaluates an async condition
+    // and inverts the result (disabled when condition returns true).
+    let disabledWhenTrue = ConditionTrait.disabled("async disabled") {
+      await Task { true }.value
+    }
+    let enabledWhenFalse = ConditionTrait.disabled("async enabled") {
+      await Task { false }.value
+    }
+    #expect(try await !(disabledWhenTrue.evaluate()))
+    #expect(try await enabledWhenFalse.evaluate())
+  }
+
+  // MARK: - Throwing closure
+
+  @Test("evaluate() propagates error thrown by async condition closure")
+  func evaluateThrowingClosure() async {
+    struct ConditionError: Error {}
+
+    let throwingCondition = ConditionTrait.enabled("throws") {
+      throw ConditionError()
+    }
+    // evaluate() is declared as `throws`, so a thrown error must propagate.
+    do {
+      _ = try await throwingCondition.evaluate()
+      Issue.record("Expected evaluate() to throw ConditionError")
+    } catch is ConditionError {
+      // Expected — the closure's thrown error propagated correctly.
+    } catch {
+      Issue.record("Unexpected error type: \(error)")
+    }
+  }
+
+  // MARK: - isConstant property
+
+  @Test("isConstant is true for unconditional traits (.disabled(), .enabled(if:))")
+  func isConstantForUnconditionalTraits() {
+    // .disabled() and .enabled(if: Bool) use .unconditional kind, so
+    // isConstant must be true.
+    #expect(ConditionTrait.disabled().isConstant)
+    #expect(ConditionTrait.disabled("with comment").isConstant)
+    #expect(ConditionTrait.enabled(if: true).isConstant)
+    #expect(ConditionTrait.enabled(if: false).isConstant)
+  }
+
+  @Test("isConstant is false for conditional (closure-based) traits")
+  func isConstantForConditionalTraits() {
+    // .enabled(_:_:) and .disabled(_:_:) with closures use .conditional kind,
+    // so isConstant must be false.
+    #expect(!ConditionTrait.enabled("async") { true }.isConstant)
+    #expect(!ConditionTrait.disabled("async") { false }.isConstant)
+  }
+
+  // MARK: - isRecursive property
+
+  @Test("isRecursive is true for ConditionTrait")
+  func isRecursiveIsTrue() {
+    // ConditionTrait.isRecursive must be true so that a condition applied to a
+    // suite is also inherited by all tests inside that suite.
+    #expect(ConditionTrait.disabled().isRecursive)
+    #expect(ConditionTrait.enabled(if: true).isRecursive)
+    #expect(ConditionTrait.enabled("comment") { true }.isRecursive)
+  }
+
+  // MARK: - Comments
+
+  @Test("ConditionTrait carries its comment correctly")
+  func conditionTraitComments() {
+    let trait = ConditionTrait.disabled("reason for skipping")
+    #expect(trait.comments == ["reason for skipping"])
+
+    let noComment = ConditionTrait.disabled()
+    #expect(noComment.comments.isEmpty)
+
+    let enabledWithComment = ConditionTrait.enabled(if: false, "must be enabled")
+    #expect(enabledWithComment.comments == ["must be enabled"])
+  }
+
+  // MARK: - Test skipping behaviour (end-to-end)
+
+  @Test("Test is skipped when async .enabled closure returns false")
+  func testIsSkippedByAsyncEnabledFalse() async {
+    await confirmation("test skipped") { skipped in
+      var configuration = Configuration()
+      configuration.eventHandler = { event, _ in
+        if case .testSkipped = event.kind {
+          skipped()
+        }
+      }
+      await Test(
+        .enabled("async disabled") { await Task { false }.value }
+      ) {}.run(configuration: configuration)
+    }
+  }
+
+  @Test("Test is skipped when async .disabled closure returns true")
+  func testIsSkippedByAsyncDisabledTrue() async {
+    await confirmation("test skipped") { skipped in
+      var configuration = Configuration()
+      configuration.eventHandler = { event, _ in
+        if case .testSkipped = event.kind {
+          skipped()
+        }
+      }
+      await Test(
+        .disabled("async disabled") { await Task { true }.value }
+      ) {}.run(configuration: configuration)
+    }
+  }
+
+  @Test("Test is NOT skipped when async .enabled closure returns true")
+  func testIsNotSkippedByAsyncEnabledTrue() async {
+    await confirmation("test skipped", expectedCount: 0) { skipped in
+      var configuration = Configuration()
+      configuration.eventHandler = { event, _ in
+        if case .testSkipped = event.kind {
+          skipped()
+        }
+      }
+      await Test(
+        .enabled("async enabled") { await Task { true }.value }
+      ) {}.run(configuration: configuration)
+    }
+  }
+
+  @Test("Test is NOT skipped when async .disabled closure returns false")
+  func testIsNotSkippedByAsyncDisabledFalse() async {
+    await confirmation("test skipped", expectedCount: 0) { skipped in
+      var configuration = Configuration()
+      configuration.eventHandler = { event, _ in
+        if case .testSkipped = event.kind {
+          skipped()
+        }
+      }
+      await Test(
+        .disabled("async not disabled") { await Task { false }.value }
+      ) {}.run(configuration: configuration)
+    }
+  }
 }
+


### PR DESCRIPTION
Add missing test coverage for the async closure overloads and properties of `ConditionTrait`.

### Motivation :- 

`ConditionTraitTests.swift` only exercised the synchronous `evaluate()` path (`.enabled(if:)` and `.disabled()`) and left several behaviours completely untested :- 

- The **async closure overloads** of `.enabled(_:sourceLocation:_:)` and `.disabled(_:sourceLocation:_:)` are entirely separate factory methods whose path through `evaluate()` was never exercised.
- **Error propagation** from a throwing condition closure through `evaluate()` was not tested.
- The **`isConstant` property** (`@_spi(ForToolsIntegrationOnly)`), which distinguishes compile-time-constant traits from runtime-evaluated ones, was only checked indirectly inside `RunnerTests.swift` via XCTest  not in the dedicated trait test file.
- The **`isRecursive` property** (must be `true` so a condition on a suite is inherited by all contained tests) had no test.
- **Comment retention** on `ConditionTrait` instances was not verified.
- **End-to-end skip behaviour** driven by async condition closures was not tested.

### Modifications :- 

Only `Tests/TestingTests/Traits/ConditionTraitTests.swift` is modified no source changes.

- Added `@_spi(ForToolsIntegrationOnly)` to the existing `@testable import` so `isConstant` is accessible without a separate import line.
- `evaluateAsyncEnabledClosure()` :- covers `.enabled(_:_:)` async closure overload via `evaluate()`
- `evaluateAsyncDisabledClosure()` :- covers `.disabled(_:_:)` async closure overload and verifies result inversion
- `evaluateThrowingClosure()` :- verifies that an error thrown inside a condition closure propagates through `evaluate()`
- `isConstantForUnconditionalTraits()` :- `isConstant == true` for `.disabled()` and `.enabled(if:)`
- `isConstantForConditionalTraits()` :- `isConstant == false` for closure-based variants
- `isRecursiveIsTrue()` :- `ConditionTrait.isRecursive` is `true` for all factory variants
- `conditionTraitComments()` :- comment property round-trip for all factory methods
- `testIsSkippedByAsyncEnabledFalse()` :- end-to-end: test is skipped when async `.enabled` closure returns `false`
- `testIsSkippedByAsyncDisabledTrue()` :- end-to-end: test is skipped when async `.disabled` closure returns `true`
- `testIsNotSkippedByAsyncEnabledTrue()` :- end-to-end: async `.enabled(true)` does not skip the test
- `testIsNotSkippedByAsyncDisabledFalse()` :- end-to-end: async `.disabled(false)` does not skip the test

### Checklist :- 

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.