### PR TITLE
Handle multiple `.sw5test` sections in COFF images.

### DIFF
--- a/Sources/_TestDiscovery/SectionBounds.swift
+++ b/Sources/_TestDiscovery/SectionBounds.swift
@@ -213,10 +213,10 @@ private func _sectionBounds(_ kind: SectionBounds.Kind) -> [SectionBounds] {
 ///
 /// - Returns: A structure describing the given section, or `nil` if the section
 ///   could not be found.
-private func _findSection(named sectionName: String, in hModule: HMODULE) -> some LazySequenceProtocol & Sequence<SectionBounds> {
+private func _findSection(named sectionName: String, in hModule: HMODULE) -> [SectionBounds] {
   hModule.withNTHeader { ntHeader in
     guard let ntHeader else {
-      return nil
+      return []
     }
 
     let sectionHeaders = UnsafeBufferPointer(

--- a/Sources/_TestDiscovery/SectionBounds.swift
+++ b/Sources/_TestDiscovery/SectionBounds.swift
@@ -213,7 +213,7 @@ private func _sectionBounds(_ kind: SectionBounds.Kind) -> [SectionBounds] {
 ///
 /// - Returns: A structure describing the given section, or `nil` if the section
 ///   could not be found.
-private func _findSection(named sectionName: String, in hModule: HMODULE) -> SectionBounds? {
+private func _findSection(named sectionName: String, in hModule: HMODULE) -> some LazySequenceProtocol & Sequence<SectionBounds> {
   hModule.withNTHeader { ntHeader in
     guard let ntHeader else {
       return nil
@@ -255,7 +255,7 @@ private func _findSection(named sectionName: String, in hModule: HMODULE) -> Sec
         }
 
         return SectionBounds(imageAddress: hModule, buffer: buffer)
-      }.first
+      }
   }
 }
 
@@ -274,7 +274,9 @@ private func _sectionBounds(_ kind: SectionBounds.Kind) -> some Sequence<Section
   case .testContent:
     ".sw5test"
   }
-  return HMODULE.all.lazy.compactMap { _findSection(named: sectionName, in: $0) }
+  return HMODULE.all.lazy
+    .compactMap { _findSection(named: sectionName, in: $0) }
+    .joined()
 }
 
 #elseif !SWT_NO_DYNAMIC_LINKING


### PR DESCRIPTION
The current Swift toolchain produces test targets that may contain more than one section named `.sw5test` and which the linker doesn't coalesce due to differing section flags. Work around the issue by enumerating all such sections we find, not just the first we find per image.

I haven't seen us actually drop any test content, so this may be benign, but `dumpbin` is reporting the problem and I want to code defensively.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
