### PR TITLE
Replace our uses of `AnySequence` with a custom type-erasing box.

### DIFF
--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -93,6 +93,7 @@ add_library(Testing
   Support/Additions/MutexAdditions.swift
   Support/Additions/NumericAdditions.swift
   Support/Additions/ResultAdditions.swift
+  Support/Additions/SequenceAdditions.swift
   Support/Additions/TaskAdditions.swift
   Support/Additions/WinSDKAdditions.swift
   Support/Color/Color.swift

--- a/Sources/Testing/Support/Additions/SequenceAdditions.swift
+++ b/Sources/Testing/Support/Additions/SequenceAdditions.swift
@@ -1,0 +1,43 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023–2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+/// A type that acts much like `AnySequence` from the standard library, but
+/// which is sendable and requires its underlying sequence to be sendable too.
+struct AnySendableSequence<Element>: Sendable, Sequence where Element: Sendable {
+#if !hasFeature(Embedded) || (SWT_FIXED_186615041 && SWT_FIXED_186684136)
+  /// The underlying sequence.
+  private var _sequence: any Sequence<Element> & Sendable
+#else
+  /// A projection of the underlying sequence's `makeIterator()` function.
+  private var _makeIterator: @Sendable () -> AnyIterator<Element>
+#endif
+
+  init<S>(_ sequence: S) where S: Sequence<Element> & Sendable {
+#if !hasFeature(Embedded) || (SWT_FIXED_186615041 && SWT_FIXED_186684136)
+    _sequence = sequence
+#else
+    _makeIterator = { AnyIterator(sequence.makeIterator()) }
+#endif
+    underestimatedCount = sequence.underestimatedCount
+  }
+
+  // MARK: - Sequence
+
+  func makeIterator() -> some IteratorProtocol<Element> {
+#if !hasFeature(Embedded) || (SWT_FIXED_186615041 && SWT_FIXED_186684136)
+    let iterator = _sequence.makeIterator()
+    return AnyIterator(iterator)
+#else
+    _makeIterator()
+#endif
+  }
+
+  private(set) var underestimatedCount: Int
+}

--- a/Sources/Testing/Test.swift
+++ b/Sources/Testing/Test.swift
@@ -160,13 +160,13 @@ public struct Test: Sendable {
     /// - Parameters:
     ///   - function: The function to call to evaluate the test's cases. The
     ///     result is a sequence of test cases.
-    case unevaluated(_ function: @Sendable () async throws -> any Sequence<Test.Case> & Sendable)
+    case unevaluated(_ function: @Sendable () async throws -> AnySendableSequence<Test.Case>)
 
     /// The test's cases have been evaluated.
     ///
     /// - Parameters:
     ///   - testCases: The test's cases.
-    case evaluated(_ testCases: any Sequence<Test.Case> & Sendable)
+    case evaluated(_ testCases: AnySendableSequence<Test.Case>)
 
     /// An error was thrown when the testing library attempted to evaluate the
     /// test's cases.
@@ -209,7 +209,7 @@ public struct Test: Sendable {
         // attempt to run it, and thus never access this property.
         preconditionFailure("Attempting to access test cases with invalid state. \(fileABugMessage(context: String(reflecting: testCasesState)))")
       }
-      return AnySequence(testCases)
+      return testCases
     }
   }
 
@@ -224,7 +224,7 @@ public struct Test: Sendable {
   var uncheckedTestCases: (some Sequence<Test.Case>)? {
     testCasesState.flatMap { testCasesState in
       if case let .evaluated(testCases) = testCasesState {
-        return AnySequence(testCases)
+        return testCases
       }
       return nil
     }
@@ -352,7 +352,7 @@ public struct Test: Sendable {
       sourceBounds: sourceBounds,
       containingTypeInfo: containingTypeInfo,
       xcTestCompatibleSelector: xcTestCompatibleSelector,
-      testCasesState: .unevaluated { try await testCases() },
+      testCasesState: .unevaluated { try await AnySendableSequence(testCases()) },
       parameters: parameters,
       isSynthesized: false
     )
@@ -377,7 +377,7 @@ public struct Test: Sendable {
       sourceBounds: sourceBounds,
       containingTypeInfo: containingTypeInfo,
       xcTestCompatibleSelector: xcTestCompatibleSelector,
-      testCasesState: .evaluated(testCases),
+      testCasesState: .evaluated(AnySendableSequence(testCases)),
       parameters: parameters,
       isSynthesized: false
     )


### PR DESCRIPTION
This PR replaces our use of `AnySequence` in `Test` with a custom type `AnySendableSequence` that conforms to `Sequence` and `Sendable` and type-erases an underlying sequence type.

`AnySendableSequence` is a structure (whereas `AnySequence` is backed by a class) which saves us from having to heap-allocate the `AnySequence`. The underlying existential in `AnySendableSequence` might still heap-allocate if its concrete type is more than 24 bytes long, but it doesn't need to for smaller types and _in particular_ doesn't impose an extra heap allocation for unparameterized tests (`CollectionOfOne<Void>` has a `size` of `0` and `stride` of `1`). `Array` and `Dictionary` both also fit in an existential's inline storage (they store their contents out-of-line) so we eliminate the extra heap allocation for them too.

This also helps us in Embedded Swift where there are significantly more limits on what you can do with an existential box. The implementation of `AnySendableSequence` already has `#if` branches for Embedded Swift. That implementation has different heap allocation characteristics out of necessity, but _c'est la vie_.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
