### PR TITLE
Remove `Trait.__as()` where no longer necessary.

### DIFF
--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -142,7 +142,7 @@ extension Event.HumanReadableOutputRecorder {
   /// - Returns: A formatted string representing the comments attached to `test`,
   ///   or `nil` if there are none.
   private func _formattedComments(for test: Test) -> [Message] {
-    _formattedComments(test.traits.compactMap { $0.__as(Comment.self) })
+    _formattedComments(test.traits.compactMap { $0 as? Comment })
   }
 
   /// Get the total number of issues recorded in a graph of test data

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -155,7 +155,7 @@ extension Runner {
     // second-to-last invokes the last, etc. and ultimately the first trait is
     // the first one to be invoked.
     let executeAllTraits = test.traits.lazy
-      .compactMap { $0.__as(IssueHandlingTrait.self) }
+      .compactMap { $0 as? IssueHandlingTrait }
       .reversed()
       .map { $0.provideScope(performing:) }
       .reduce(body) { executeAllTraits, provideScope in

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -188,12 +188,6 @@ extension Comment: TestTrait, SuiteTrait {
   public var comments: [Comment] {
     [self]
   }
-
-#if hasFeature(Embedded)
-  public func __as(_: Comment.Type) -> Comment? {
-    self
-  }
-#endif
 }
 
 @_spi(Experimental)

--- a/Sources/Testing/Traits/IssueHandlingTrait.swift
+++ b/Sources/Testing/Traits/IssueHandlingTrait.swift
@@ -65,12 +65,6 @@ public struct IssueHandlingTrait: TestTrait, SuiteTrait {
   public var isRecursive: Bool {
     true
   }
-
-#if hasFeature(Embedded)
-  public func __as(_: IssueHandlingTrait.Type) -> IssueHandlingTrait? {
-    self
-  }
-#endif
 }
 
 /// @Metadata {

--- a/Sources/Testing/Traits/Tags/Tag.List.swift
+++ b/Sources/Testing/Traits/Tags/Tag.List.swift
@@ -51,12 +51,6 @@ extension Tag.List: TestTrait, SuiteTrait {
   public var isRecursive: Bool {
     true
   }
-
-#if hasFeature(Embedded)
-  public func __as(_: Tag.List.Type) -> Tag.List? {
-    self
-  }
-#endif
 }
 
 extension Trait where Self == Tag.List {

--- a/Sources/Testing/Traits/Tags/Tag.swift
+++ b/Sources/Testing/Traits/Tags/Tag.swift
@@ -143,7 +143,7 @@ extension Test {
   /// Tags are associated with tests using the ``Trait/tags(_:)`` function.
   public var tags: Set<Tag> {
     traits.lazy
-      .compactMap { $0.__as(Tag.List.self) }
+      .compactMap { $0 as? Tag.List.self }
       .map(\.tags)
       .reduce(into: []) { $0.formUnion($1) }
   }

--- a/Sources/Testing/Traits/Tags/Tag.swift
+++ b/Sources/Testing/Traits/Tags/Tag.swift
@@ -143,7 +143,7 @@ extension Test {
   /// Tags are associated with tests using the ``Trait/tags(_:)`` function.
   public var tags: Set<Tag> {
     traits.lazy
-      .compactMap { $0 as? Tag.List.self }
+      .compactMap { $0 as? Tag.List }
       .map(\.tags)
       .reduce(into: []) { $0.formUnion($1) }
   }

--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -122,24 +122,6 @@ public protocol Trait: Sendable {
   /// - Warning: This function is used to implement traits under Embedded Swift.
   ///   Do not use it or provide an implementation for it.
   func __as(_: (any SuiteTrait).Type) -> (any SuiteTrait)?
-
-  /// Get this value as an instance of ``Tag/List``.
-  ///
-  /// - Warning: This function is used to implement traits under Embedded Swift.
-  ///   Do not use it or provide an implementation for it.
-  func __as(_: Comment.Type) -> Comment?
-
-  /// Get this value as an instance of ``IssueHandlingTrait``.
-  ///
-  /// - Warning: This function is used to implement traits under Embedded Swift.
-  ///   Do not use it or provide an implementation for it.
-  func __as(_: IssueHandlingTrait.Type) -> IssueHandlingTrait?
-
-  /// Get this value as an instance of ``Tag/List``.
-  ///
-  /// - Warning: This function is used to implement traits under Embedded Swift.
-  ///   Do not use it or provide an implementation for it.
-  func __as(_: Tag.List.Type) -> Tag.List?
 #endif
 }
 
@@ -331,18 +313,6 @@ extension Trait {
   }
 
   public func __as(_: (any SuiteTrait).Type) -> (any SuiteTrait)? {
-    nil
-  }
-
-  public func __as(_: Comment.Type) -> Comment? {
-    nil
-  }
-
-  public func __as(_: IssueHandlingTrait.Type) -> IssueHandlingTrait? {
-    nil
-  }
-
-  public func __as(_: Tag.List.Type) -> Tag.List? {
     nil
   }
 }

--- a/Tests/TestingTests/RunnerTests.swift
+++ b/Tests/TestingTests/RunnerTests.swift
@@ -721,7 +721,7 @@ final class RunnerTests: XCTestCase {
     let plan = await Runner.Plan(selecting: ObsoletedTests.self)
     for step in plan.steps where !step.test.isSuite {
       let conditionComments = step.test.traits
-        .compactMap { $0.__as(ConditionTrait.self) }
+        .compactMap { $0 as? ConditionTrait }
         .flatMap(\.comments)
         .map(\.rawValue)
       XCTAssertNotNil(conditionComments.first { $0.contains("999.0") })

--- a/Tests/TestingTests/Traits/CommentTests.swift
+++ b/Tests/TestingTests/Traits/CommentTests.swift
@@ -39,7 +39,7 @@ struct CommentTests {
 
     let example3 = try #require(plan.steps.map(\.test).first { $0.name == "example3()" })
     #expect(example3.comments == ["H", "I"])
-    #expect(example3.traits.compactMap { $0.__as(Comment.self) } == ["H"])
+    #expect(example3.traits.compactMap { $0 as? Comment } == ["H"])
 
     let innerType = try #require(plan.steps.map(\.test).first { $0.name == "Inner" })
     #expect(innerType.comments == ["// J"])


### PR DESCRIPTION
Embedded Swift now supports casting existentials to concrete types, so we no longer need most of the overloads of `Trait.__as()` I added previously. We still need them for casting to other existential types (`TestTrait` and `SuiteTrait`).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
