### PR TITLE
Adjust implementation of `AttachableImageFormat` to support Embedded Swift.

### DIFF
--- a/Sources/Testing/Attachments/Images/AttachableImageFormat.swift
+++ b/Sources/Testing/Attachments/Images/AttachableImageFormat.swift
@@ -45,6 +45,13 @@ public struct AttachableImageFormat: Sendable {
     /// The (widely-supported) JPEG image format.
     case jpeg
 
+    /// A platform-specific type describing a platform-specific image format.
+#if !hasFeature(Embedded)
+    package typealias SystemValue = any Sendable & Equatable & Hashable
+#else
+    package typealias SystemValue = Never
+#endif
+
     /// A platform-specific image format.
     ///
     /// - Parameters:
@@ -54,7 +61,11 @@ public struct AttachableImageFormat: Sendable {
     ///
     /// On Apple platforms, `value` should be an instance of `UTType`. On
     /// Windows, it should be an instance of `CLSID`.
-    case systemValue(_ value: any Sendable & Equatable & Hashable)
+    ///
+    /// Support for platform-specific attachable image formats is not available
+    /// in Embedded Swift.
+    @_unavailableInEmbedded
+    case systemValue(_ value: SystemValue)
   }
 
   /// The kind of image format represented by this instance.
@@ -101,11 +112,13 @@ extension AttachableImageFormat.Kind: Equatable, Hashable {
     switch (lhs, rhs) {
     case (.png, .png), (.jpeg, .jpeg):
       return true
+#if !hasFeature(Embedded)
     case let (.systemValue(lhs), .systemValue(rhs)):
       func open<T>(_ lhs: T) -> Bool where T: Equatable {
         lhs == (rhs as? T)
       }
       return open(lhs)
+#endif
     default:
       return false
     }
@@ -117,8 +130,10 @@ extension AttachableImageFormat.Kind: Equatable, Hashable {
       hasher.combine("png")
     case .jpeg:
       hasher.combine("jpeg")
+#if !hasFeature(Embedded)
     case let .systemValue(systemValue):
       hasher.combine(systemValue)
+#endif
     }
   }
 }
@@ -156,6 +171,21 @@ extension AttachableImageFormat: CustomStringConvertible, CustomDebugStringConve
     return "\(kindDescription) at quality \(encodingQuality)"
   }
 }
+
+#if hasFeature(Embedded) && !SWT_NO_IMAGE_ATTACHMENTS
+// NOTE: In non-Embedded Swift, conformance to CustomStringConvertible is
+// provided by platform-specific cross-import overlays.
+extension AttachableImageFormat.Kind: CustomStringConvertible {
+  package var description: String {
+    switch self {
+    case .png:
+      "PNG image"
+    case .jpeg:
+      "JPEG image"
+    }
+  }
+}
+#endif
 
 // MARK: -
 


### PR DESCRIPTION
Add `#if` branches for Embedded Swift to `AttachableImageFormat`. This type has an inner `Kind` enum with a platform-specific `case systemValue(_:)` whose associated value is, by necessity, a type-erased existential. However, Embedded Swift has more constraints on existentials than regular Swift, and we need to account for them.

There are two approaches we can take:

1. Change the definition of the associated type to something we can compare and hash without needing to open the existential, e.g. `AnyObject` with pointer equality.
2. Remove `case systemValue(_:)` outright, and only nominally support output to PNG and JPEG files.

Right now, `AttachableImageFormat` is not available under Embedded Swift, but there's no reason it _can't_ be if an implementation provides a type that conforms to `AttachableAsImage` and turns off `SWT_NO_IMAGE_ATTACHMENTS`. Since such an implementation must be able to create a PNG or JPEG image _anyway_, we can choose to drop `case systemValue(_:)` as a general constraint under Embedded Swift. We can keep the case, mark it `@_unavailableInEmbedded`, and change the type of its associated value to `Never` to ensure it cannot be misused.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
