### PR TITLE
Replace `canImport(Foundation)` with `!SWT_NO_FOUNDATION`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@
 
 import PackageDescription
 import CompilerPluginSupport
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
 import Foundation
 #endif
 
@@ -560,13 +560,14 @@ extension Array where Element: _LanguageBuildSetting {
       "SWT_NO_SUSPENDING_CLOCK": (platforms: .none, embedded: true),
 
       "SWT_NO_LIBDISPATCH": (platforms: .none, embedded: true),
+      "SWT_NO_FOUNDATION": (platforms: .none, embedded: true),
     ]
 
     // Let the environment block override our settings above.
     let environmentVariables = Context.environment
       .filter { $0.key.starts(with: "SWT_NO_") }
       .compactMapValues { value in
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
         (value as NSString).boolValue
 #else
         Bool(value) ?? UInt64(value).map { $0 != 0 }

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable+NSSecureCoding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_CODABLE
+#if !SWT_NO_FOUNDATION && !SWT_NO_CODABLE
 @_spi(ForToolsIntegrationOnly) public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+Encodable.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_CODABLE
+#if !SWT_NO_FOUNDATION && !SWT_NO_CODABLE
 @_spi(ForToolsIntegrationOnly) public import Testing
 private import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachable+NSSecureCoding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
 @_spi(ForToolsIntegrationOnly) public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/AttachableEncodingFormat+Foundation.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/AttachableEncodingFormat+Foundation.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
 import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+Encodable+NSSecureCoding.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+Encodable+NSSecureCoding.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
 public import Testing
 public import Foundation
 #if canImport(Combine)

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Attachment+URL.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_FILE_IO
+#if !SWT_NO_FOUNDATION && !SWT_NO_FILE_IO
 public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/Data+Attachable.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/Data+Attachable.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
 public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/_AttachableEncodableWrapper.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/_AttachableEncodableWrapper.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_CODABLE
+#if !SWT_NO_FOUNDATION && !SWT_NO_CODABLE
 public import Testing
 import Foundation
 #if canImport(Combine)

--- a/Sources/Overlays/_Testing_Foundation/Attachments/_AttachableNSSecureCodingWrapper.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/_AttachableNSSecureCodingWrapper.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_CODABLE
+#if !SWT_NO_FOUNDATION && !SWT_NO_CODABLE
 public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Attachments/_AttachableURLWrapper.swift
+++ b/Sources/Overlays/_Testing_Foundation/Attachments/_AttachableURLWrapper.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_FILE_IO
+#if !SWT_NO_FOUNDATION && !SWT_NO_FILE_IO
 public import Testing
 public import Foundation
 

--- a/Sources/Overlays/_Testing_Foundation/Events/Clock+Date.swift
+++ b/Sources/Overlays/_Testing_Foundation/Events/Clock+Date.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_UTC_CLOCK
+#if !SWT_NO_FOUNDATION && !SWT_NO_UTC_CLOCK
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import Testing
 public import Foundation
 

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedAttachment.swift
@@ -9,7 +9,7 @@
 //
 
 #if !SWT_NO_ABI_JSON_SCHEMA
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
 private import struct Foundation.Data
 private import struct Foundation.URL
 #endif
@@ -65,7 +65,7 @@ extension ABI.EncodedAttachment: Codable {
     var container = encoder.container(keyedBy: CodingKeys.self)
 
     func encodeBytes(_ bytes: UnsafeRawBufferPointer) throws {
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
       // If possible, encode this structure as Base64 data.
       let data = Data(bytesNoCopy: .init(mutating: bytes.baseAddress!), count: bytes.count, deallocator: .none)
       try container.encode(data.base64EncodedString(), forKey: .bytes)
@@ -126,7 +126,7 @@ extension ABI.EncodedAttachment: Codable {
       }
 
       if V.includesExperimentalFields {
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
         // If possible, decode a whole Foundation Data object.
         if let data = try? container.decodeIfPresent(Data.self, forKey: .bytes) {
           return .inMemory([UInt8](data))
@@ -182,7 +182,7 @@ extension ABI.EncodedAttachment: Attachable {
     switch kind {
     case let .savedAtPath(path):
 #if !SWT_NO_FILE_IO
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
       // Leverage Foundation's file-mapping logic since we're using Data anyway.
       let url = URL(fileURLWithPath: path, isDirectory: false)
       let bytes = try Data(contentsOf: url, options: [.mappedIfSafe])

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
 private import Foundation
 #endif
 private import _TestingInternals
@@ -627,7 +627,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0, emi
   // Attachment output.
   if let attachmentsPath = args.attachmentsPath {
 
-    #if canImport(Foundation)
+    #if !SWT_NO_FOUNDATION
       try FileManager().createDirectory(atPath: attachmentsPath, withIntermediateDirectories: true)
     #else
       guard fileExists(atPath: attachmentsPath) else {

--- a/Sources/Testing/Support/JSON.swift
+++ b/Sources/Testing/Support/JSON.swift
@@ -9,7 +9,10 @@
 //
 
 #if !SWT_NO_CODABLE
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
+#if !canImport(Foundation)
+#error("Platform-specific misconfiguration: support for Foundation requires the 'Foundation' module")
+#endif
 private import Foundation
 #else
 #error("Platform-specific misconfiguration: support for JSON encoding and decoding requires the 'Foundation' module")

--- a/Tests/TestingTests/AttachmentTests.swift
+++ b/Tests/TestingTests/AttachmentTests.swift
@@ -14,7 +14,7 @@ private import _TestingInternals
 import AppKit
 import _Testing_AppKit
 #endif
-#if canImport(Foundation) && canImport(_Testing_Foundation)
+#if !SWT_NO_FOUNDATION && canImport(_Testing_Foundation)
 import Foundation
 @_spi(Experimental) import _Testing_Foundation
 #endif
@@ -299,7 +299,7 @@ struct AttachmentTests {
     }
   }
 
-#if canImport(Foundation) && canImport(_Testing_Foundation)
+#if !SWT_NO_FOUNDATION && canImport(_Testing_Foundation)
 #if !SWT_NO_FILE_IO
   @Test func attachContentsOfFileURL() async throws {
     let data = try #require("<!doctype html>".data(using: .utf8))
@@ -642,7 +642,7 @@ extension AttachmentTests {
       try test(value)
     }
 
-#if canImport(Foundation) && canImport(_Testing_Foundation)
+#if !SWT_NO_FOUNDATION && canImport(_Testing_Foundation)
     @Test func data() throws {
       let value = try #require("abc123".data(using: .utf8))
       try test(value)
@@ -1219,7 +1219,7 @@ struct MyBadTransferable: Transferable, Equatable {
 }
 #endif
 
-#if canImport(Foundation) && canImport(_Testing_Foundation)
+#if !SWT_NO_FOUNDATION && canImport(_Testing_Foundation)
 #if !SWT_NO_CODABLE
 struct MyCodableAttachable: Codable, Attachable, Sendable {
   var string: String

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -9,7 +9,7 @@
 //
 
 @testable @_spi(ForToolsIntegrationOnly) import Testing
-#if SWT_TARGET_OS_APPLE && canImport(Foundation)
+#if SWT_TARGET_OS_APPLE && !SWT_NO_FOUNDATION
 private import class Foundation.NSError
 #endif
 
@@ -72,7 +72,7 @@ struct BacktraceTests {
     }
   }
 
-#if SWT_TARGET_OS_APPLE && canImport(Foundation)
+#if SWT_TARGET_OS_APPLE && !SWT_NO_FOUNDATION
   @available(_typedThrowsAPI, *)
   @Test("Thrown NSError captures backtrace")
   func thrownNSErrorCapturesBacktrace() async throws {

--- a/Tests/TestingTests/EventRecorderTests.swift
+++ b/Tests/TestingTests/EventRecorderTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
 import Foundation // for XML API
 #endif
 #if canImport(FoundationXML)
@@ -429,7 +429,7 @@ struct EventRecorderTests {
   }
 #endif
 
-#if canImport(Foundation) || canImport(FoundationXML)
+#if !SWT_NO_FOUNDATION || canImport(FoundationXML)
   @Test(
     "JUnitXMLRecorder outputs valid XML",
     .bug("https://github.com/swiftlang/swift-testing/issues/254")

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -10,7 +10,7 @@
 
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 private import _TestingInternals
-#if canImport(Foundation)
+#if !SWT_NO_FOUNDATION
 private import Foundation
 #endif
 
@@ -388,7 +388,7 @@ struct SwiftPMTests {
     #expect(fileContents.contains(UInt8(ascii: ">")))
   }
 
-  #if canImport(Foundation)
+  #if !SWT_NO_FOUNDATION
   @Test(
     "--attachments-path argument (creates missing directory)",
     arguments: ["--attachments-path", "--experimental-attachments-path"]
@@ -407,7 +407,7 @@ struct SwiftPMTests {
   }
   #endif
 
-  #if canImport(Foundation)
+  #if !SWT_NO_FOUNDATION
   @Test("--attachments-path argument (bad path)")
   func attachmentsPathWithBadPath() throws {
       let tempDirPath = try temporaryDirectory()

--- a/Tests/TestingTests/_Testing_Foundation/FoundationTests.swift
+++ b/Tests/TestingTests/_Testing_Foundation/FoundationTests.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-#if canImport(Foundation) && !SWT_NO_UTC_CLOCK
+#if !SWT_NO_FOUNDATION && !SWT_NO_UTC_CLOCK
 @testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import _Testing_Foundation
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
 import Foundation


### PR DESCRIPTION
This PR replaces our uses of `canImport(Foundation)` with a check for a compiler conditional instead. This then allows library authors to turn off Foundation support even if the Foundation module is present (which can be useful if e.g. you're trying to build some part of Foundation itself).

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
