### PR TITLE
Enable `typeAddress` check during discovery in Embedded Swift.

### DIFF
--- a/Documentation/ABI/TestContent.md
+++ b/Documentation/ABI/TestContent.md
@@ -123,11 +123,6 @@ or a third-party library are inadvertently loaded into the same process. If the
 value at `type` does not match the test content record's expected type, the
 accessor function must return `false` and must not modify `outValue`.
 
-When building for **Embedded Swift**, the value passed as `type` by Swift
-Testing is unspecified because type metadata pointers are not available in that
-environment.
-<!-- TODO: specify what they are instead (FQN type name C strings maybe?) -->
-
 [^mightNotBeSwift]: Although this document primarily deals with Swift, the test
   content record section is generally language-agnostic. The use of languages
   other than Swift is beyond the scope of this document. With that in mind, it

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -372,12 +372,10 @@ extension ExitTest {
     asTypeAt typeAddress: UnsafeRawPointer,
     withHintAt hintAddress: UnsafeRawPointer? = nil
   ) -> CBool where repeat each T: Codable & Sendable {
-#if !hasFeature(Embedded)
     // Check that the type matches.
     guard typeAddress.load(as: Any.Type.self) == Record.self else {
       return false
     }
-#endif
 
     // Check that the ID matches if provided.
     let id = ID(id)

--- a/Sources/Testing/Test+Discovery.swift
+++ b/Sources/Testing/Test+Discovery.swift
@@ -44,11 +44,9 @@ extension Test {
     into outValue: UnsafeMutableRawPointer,
     asTypeAt typeAddress: UnsafeRawPointer
   ) -> CBool {
-#if !hasFeature(Embedded)
     guard typeAddress.load(as: Any.Type.self) == Generator.self else {
       return false
     }
-#endif
     outValue.initializeMemory(as: Generator.self, to: .init(rawValue: generator))
     return true
   }

--- a/Sources/_TestDiscovery/TestContentRecord.swift
+++ b/Sources/_TestDiscovery/TestContentRecord.swift
@@ -177,14 +177,9 @@ public struct TestContentRecord<T> where T: DiscoverableAsTestContent {
       return nil
     }
 
-#if !hasFeature(Embedded)
     return withUnsafePointer(to: T.self) { typeAddress in
       Self._load(using: accessor, withTypeAt: typeAddress, withHint: hint)
     }
-#else
-    let typeAddress = UnsafeRawPointer(bitPattern: UInt(T.testContentKind.rawValue)).unsafelyUnwrapped
-    return Self._load(using: accessor, withTypeAt: typeAddress, withHint: hint)
-#endif
   }
 }
 

--- a/Tests/TestingTests/DiscoveryTests.swift
+++ b/Tests/TestingTests/DiscoveryTests.swift
@@ -92,11 +92,9 @@ struct DiscoveryTests {
       0xABCD1234,
       0,
       { outValue, type, hint, _ in
-#if !hasFeature(Embedded)
         guard type.load(as: Any.Type.self) == MyTestContent.self else {
           return false
         }
-#endif
         if let hint, hint.load(as: TestContentAccessorHint.self) != expectedHint {
           return false
         }


### PR DESCRIPTION
Test content records' accessor functions include as an argument a pointer to a Swift metatype that the accessors can check to confirm they're returning values of the right Swift type. This logic was disabled in Embedded Swift because you couldn't form stable references to metatypes, but that's no longer the case so we can enable it now.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
