### PR TITLE
Conditionalize backtrace symbolication.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -558,6 +558,7 @@ extension Array where Element: _LanguageBuildSetting {
       "SWT_NO_UNSTRUCTURED_TASKS": (platforms: .none, embedded: true),
       "SWT_NO_GLOBAL_ACTORS": (platforms: .none, embedded: true),
       "SWT_NO_SUSPENDING_CLOCK": (platforms: .none, embedded: true),
+      "SWT_NO_BACKTRACE_SYMBOLICATION": (platforms: .none, embedded: true),
 
       "SWT_NO_LIBDISPATCH": (platforms: .none, embedded: true),
       "SWT_NO_FOUNDATION": (platforms: .none, embedded: true),

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedBacktrace.swift
@@ -19,15 +19,23 @@ extension ABI {
   ///
   /// - Warning: Backtraces are not yet part of the JSON schema.
   struct EncodedBacktrace<V>: Sendable where V: ABI.Version {
+#if !SWT_NO_BACKTRACE_SYMBOLICATION
     /// The frames in the backtrace.
     var symbolicatedAddresses: [Backtrace.SymbolicatedAddress]
-
+#else
+    /// The frames in the backtrace.
+    var addresses: [Backtrace.Address]
+#endif
     init(encoding backtrace: borrowing Backtrace, in eventContext: borrowing Event.Context) {
+#if !SWT_NO_BACKTRACE_SYMBOLICATION
       if let symbolicationMode = eventContext.configuration?.backtraceSymbolicationMode {
         symbolicatedAddresses = backtrace.symbolicate(symbolicationMode)
       } else {
         symbolicatedAddresses = backtrace.addresses.map { Backtrace.SymbolicatedAddress(address: $0) }
       }
+#else
+      addresses = backtrace.addresses
+#endif
     }
   }
 }
@@ -36,11 +44,21 @@ extension ABI {
 
 extension ABI.EncodedBacktrace: Codable {
   func encode(to encoder: any Encoder) throws {
-    try symbolicatedAddresses.encode(to: encoder)
+    var container = encoder.singleValueContainer()
+#if !SWT_NO_BACKTRACE_SYMBOLICATION
+    try container.encode(symbolicatedAddresses)
+#else
+    try container.encode(addresses)
+#endif
   }
 
   init(from decoder: any Decoder) throws {
-    self.symbolicatedAddresses = try [Backtrace.SymbolicatedAddress](from: decoder)
+    let container = try decoder.singleValueContainer()
+#if !SWT_NO_BACKTRACE_SYMBOLICATION
+    symbolicatedAddresses = try container.decode([Backtrace.SymbolicatedAddress].self)
+#else
+    addresses = try container.decode([Backtrace.Address].self)
+#endif
   }
 }
 #endif

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedIssue.swift
@@ -176,10 +176,13 @@ extension Issue {
       // Prior to 6.3, all Issues are errors
         .error
     }
-    let sourceContext = SourceContext(
-      backtrace: issue._backtrace.map { Backtrace(addresses: $0.symbolicatedAddresses.map(\.address)) },
-      sourceLocation: issue.sourceLocation.flatMap(SourceLocation.init)
-    )
+#if !SWT_NO_BACKTRACE_SYMBOLICATION
+    let backtrace = issue._backtrace.map { Backtrace(addresses: $0.symbolicatedAddresses.map { $0.address }) }
+#else
+    let backtrace = issue._backtrace.map { Backtrace(addresses: $0.addresses) }
+#endif
+    let sourceLocation = issue.sourceLocation.flatMap(SourceLocation.init)
+    let sourceContext = SourceContext(backtrace: backtrace, sourceLocation: sourceLocation)
     self.init(
       kind: issueKind,
       severity: severity,

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -594,6 +594,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0, emi
     configuration.maximumParallelizationWidth = maximumParallelizationWidth
   }
 
+#if !SWT_NO_BACKTRACE_SYMBOLICATION
   // Whether or not to symbolicate backtraces in the event stream.
   if let symbolicateBacktraces = args.symbolicateBacktraces {
     switch symbolicateBacktraces.lowercased() {
@@ -606,6 +607,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0, emi
 
     }
   }
+#endif
 
 #if !SWT_NO_FILE_IO
   // XML output

--- a/Sources/Testing/Running/Configuration.swift
+++ b/Sources/Testing/Running/Configuration.swift
@@ -52,6 +52,7 @@ public struct Configuration: Sendable {
   @_spi(Experimental)
   public var maximumParallelizationWidth: Int = defaultParallelizationWidth
 
+#if !SWT_NO_BACKTRACE_SYMBOLICATION
   /// How to symbolicate backtraces captured during a test run.
   ///
   /// If the value of this property is not `nil`, symbolication will be
@@ -61,6 +62,7 @@ public struct Configuration: Sendable {
   /// Swift in-process. When handling a backtrace in Swift, use its
   /// ``Backtrace/symbolicate(_:)`` function to symbolicate it.
   public var backtraceSymbolicationMode: Backtrace.SymbolicationMode?
+#endif
 
   /// A type describing whether or not, and how, to iterate a test case
   /// repeatedly.

--- a/Sources/Testing/SourceAttribution/Backtrace+Symbolication.swift
+++ b/Sources/Testing/SourceAttribution/Backtrace+Symbolication.swift
@@ -8,6 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if !SWT_NO_BACKTRACE_SYMBOLICATION
 private import _TestingInternals
 
 /// A type representing a backtrace or stack trace.
@@ -164,4 +165,5 @@ private func _withDbgHelpLibrary(_ body: (HANDLE?) -> Void) {
     }
   }
 }
+#endif
 #endif

--- a/Tests/TestingTests/BacktraceTests.swift
+++ b/Tests/TestingTests/BacktraceTests.swift
@@ -150,7 +150,7 @@ struct BacktraceTests {
   }
 #endif
 
-#if !SWT_NO_DYNAMIC_LINKING
+#if !SWT_NO_DYNAMIC_LINKING && !SWT_NO_BACKTRACE_SYMBOLICATION
   @Test("Symbolication", arguments: [Backtrace.SymbolicationMode.mangled, .demangled])
   func symbolication(mode: Backtrace.SymbolicationMode) {
     let backtrace = Backtrace.current()

--- a/Tests/TestingTests/SwiftPMTests.swift
+++ b/Tests/TestingTests/SwiftPMTests.swift
@@ -86,6 +86,7 @@ struct SwiftPMTests {
     }
   }
 
+#if !SWT_NO_BACKTRACE_SYMBOLICATION
   @Test("--symbolicate-backtraces argument",
     arguments: [
       (String?.none, Backtrace.SymbolicationMode?.none),
@@ -101,6 +102,7 @@ struct SwiftPMTests {
     }
     #expect(configuration.backtraceSymbolicationMode == expectedMode)
   }
+#endif
 
   @Test("No --filter or --skip argument")
   func defaultFiltering() async throws {


### PR DESCRIPTION
This PR guards our experimental backtrace symbolication code behind a new `SWT_NO_BACKTRACE_SYMBOLICATION` gate. This feature isn't ready to formally support yet, and doesn't work in Embedded Swift anyway without a PAL thunk (that I don't want to write.)

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
