### PR TITLE
Abstract calls to `FileHandle.stderr.write()`.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -71,7 +71,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, forSwiftPackageManager
         advancedOptions.base = .for(.stderr)
 
         let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.ExperimentalVersion>(options: advancedOptions) { string in
-          try? FileHandle.stderr.write(string)
+          writeToConsole(string)
         }
 
         configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
@@ -86,7 +86,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, forSwiftPackageManager
       if !useExperimentalConsoleOutput {
         // Use the standard console output recorder (default behavior)
         let eventRecorder = Event.ConsoleOutputRecorder(options: .for(.stderr)) { string in
-          try? FileHandle.stderr.write(string)
+          writeToConsole(string)
         }
         configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
           if consoleOutputEnabled.load(ordering: .sequentiallyConsistent) {
@@ -161,10 +161,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, forSwiftPackageManager
       )
     }
   } catch {
-#if !SWT_NO_FILE_IO
-    try? FileHandle.stderr.write("\(String(describingForTest: error))\n")
-#endif
-
+    writeToConsole("\(String(describingForTest: error))\n")
     exitCode.store(EXIT_FAILURE, ordering: .sequentiallyConsistent)
   }
 
@@ -628,14 +625,13 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0, emi
 
   // Attachment output.
   if let attachmentsPath = args.attachmentsPath {
-
-    #if !SWT_NO_FOUNDATION
+#if !SWT_NO_FOUNDATION
       try FileManager().createDirectory(atPath: attachmentsPath, withIntermediateDirectories: true)
-    #else
+#else
       guard fileExists(atPath: attachmentsPath) else {
         throw _EntryPointError.invalidArgument("---attachments-path", value: attachmentsPath)
       }
-    #endif
+#endif
     configuration.attachmentsPath = attachmentsPath
   }
 
@@ -687,7 +683,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0, emi
             "Backticks aren't a valid part of a Swift symbol. Replacing '\(originalString)' with '\(string)'.",
             options: .for(.stderr)
           )
-          try? FileHandle.stderr.write("\(warning)\n")
+          writeToConsole("\(warning)\n")
         }
 #endif
       }

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -116,11 +116,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, forSwiftPackageManager
       if args.verbosity > .min {
         for testID in listTestsForEntryPoint(tests, verbosity: args.verbosity) {
           // Print the test ID to stdout (classical CLI behavior.)
-#if SWT_TARGET_OS_APPLE && !SWT_NO_FILE_IO
-          try? FileHandle.stdout.write("\(testID)\n")
-#else
-          print(testID)
-#endif
+          writeToConsole("\(testID)\n", useStandardOutputIfAvailable: true)
         }
       }
 

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(Testing
   Support/VersionNumber.swift
   Support/Versions.swift
   Discovery+Macro.swift
+  EmbeddedPlatform.swift
   Test.ID.Selection.swift
   Test.ID.swift
   Test.swift

--- a/Sources/Testing/EmbeddedPlatform.swift
+++ b/Sources/Testing/EmbeddedPlatform.swift
@@ -1,0 +1,42 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+internal import _TestingInternals
+
+/// This file contains abstractions over functionality that, under Embedded
+/// Swift, is provided by Swift Testing's Platform Abstraction Layer annex.
+
+/// Writes a Swift string as UTF-8 to the current system's console.
+///
+/// - Parameters:
+///   - string: The string to write.
+///
+/// The testing library uses this function to write a _human-readable_
+/// transcript of a test run. This function is a convenience over
+/// `_swift_testing_writeToConsole()`, which Platform Abstraction Layer authors
+/// must implement instead of this function.
+@inline(always) func writeToConsole(_ string: String) {
+  if string.isEmpty {
+    return
+  }
+
+#if !hasFeature(Embedded)
+#if !SWT_NO_FILE_IO
+  try? FileHandle.stderr.write(string)
+#else
+  // TODO: determine whether we can reliably call `print()` here or something else
+#endif
+#else
+  var string = string
+  string.withUTF8 { string in
+    _swift_testing_writeToConsole(string.baseAddress!, string.count)
+  }
+#endif
+}

--- a/Sources/Testing/EmbeddedPlatform.swift
+++ b/Sources/Testing/EmbeddedPlatform.swift
@@ -17,21 +17,29 @@ internal import _TestingInternals
 ///
 /// - Parameters:
 ///   - string: The string to write.
+///   - useStandardOutputIfAvailable: If the platform supports full file I/O
+///     then write to `stdout` instead of `stderr`. The default is to write to
+///     `stderr`.
 ///
 /// The testing library uses this function to write a _human-readable_
 /// transcript of a test run. This function is a convenience over
 /// `_swift_testing_writeToConsole()`, which Platform Abstraction Layer authors
 /// must implement instead of this function.
-@inline(always) func writeToConsole(_ string: String) {
+@inline(always) func writeToConsole(_ string: String, useStandardOutputIfAvailable: Bool = false) {
   if string.isEmpty {
     return
   }
 
 #if !hasFeature(Embedded)
 #if !SWT_NO_FILE_IO
-  try? FileHandle.stderr.write(string)
+  let file = useStandardOutputIfAvailable ? FileHandle.stdout : FileHandle.stderr
+  try? file.write(string)
 #else
-  // TODO: determine whether we can reliably call `print()` here or something else
+  if useStandardOutputIfAvailable {
+    print(string, terminator: "")
+  } else {
+    // TODO: determine whether we can reliably call `print()` here or something else
+  }
 #endif
 #else
   var string = string

--- a/Sources/Testing/EmbeddedPlatform.swift
+++ b/Sources/Testing/EmbeddedPlatform.swift
@@ -22,9 +22,9 @@ internal import _TestingInternals
 ///     `stderr`.
 ///
 /// The testing library uses this function to write a _human-readable_
-/// transcript of a test run. This function is a convenience over
-/// `_swift_testing_writeToConsole()`, which Platform Abstraction Layer authors
-/// must implement instead of this function.
+/// transcript of a test run. This function abstracts away the destination of
+/// console output which differs between non-Embedded Swift and Embedded Swift
+/// builds.
 @inline(always) func writeToConsole(_ string: String, useStandardOutputIfAvailable: Bool = false) {
   if string.isEmpty {
     return

--- a/Sources/_TestingInternals/include/EmbeddedPlatform.h
+++ b/Sources/_TestingInternals/include/EmbeddedPlatform.h
@@ -1,0 +1,91 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+#if !defined(SWT_EMBEDDED_PLATFORM_H)
+#define SWT_EMBEDDED_PLATFORM_H
+
+#include "Defines.h"
+#include "Includes.h"
+
+SWT_ASSUME_NONNULL_BEGIN
+
+/// This header includes declarations, but not definitions, of functions that
+/// the testing library needs defined when built for Embedded Swift.
+///
+/// This header augments the set of declarations in the Swift runtime's Platform
+/// Abstraction Layer, which can be found [here](https://github.com/swiftlang/swift/blob/main/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h).
+
+// MARK: - Console output
+
+/// Writes a sequence of UTF-8 code points to the current system's console.
+///
+/// - Parameters:
+///   - chars: The UTF-8 code points to write. It is not `NULL`-terminated.
+///   - count: The number of UTF-8 code points at `chars`.
+///
+/// The testing library uses this function to write a _human-readable_
+/// transcript of a test run. If possible, the implementation should write
+/// output to the standard error stream. Calls to the Swift standard library's
+/// `print()` function (or similar interfaces) do not use this function.
+///
+/// ### Reference implementations
+///
+/// This function can be implemented as a call to `fwrite()`:
+///
+/// ```c
+/// void _swift_testing_writeToConsole(const uint8_t *chars, size_t count) {
+///   fwrite(chars, 1, count, stderr);
+/// }
+/// ```
+///
+/// If you want to redirect output from the testing library to the same place
+/// that the standard library directs output from `print()`, you can call
+/// `_swift_writeToStandardOutput()`:
+///
+/// ```c
+/// extern void _swift_writeToStandardOutput(const unsigned char *, size_t);
+///
+/// void _swift_testing_writeToConsole(const uint8_t *chars, size_t count) {
+///   _swift_writeToStandardOutput(chars, count);
+/// }
+/// ```
+///
+/// If the current system's console only supports ASCII output rather than
+/// UTF-8, the implementation must take care to filter out or transform
+/// non-ASCII code points:
+///
+/// ```c
+/// void _swift_testing_writeToConsole(const uint8_t *chars, size_t count) {
+///   flockfile(stderr); {
+///     for (size_t i = 0; i < count; i++) {
+///       char c = chars[i];
+///       if (isascii(c)) {
+///         fputc(c, stderr);
+///       } else {
+///         fputc('?', stderr);
+///       }
+///     }
+///   } funlockfile(stderr);
+/// }
+/// ```
+///
+/// If your platform does not support any form of human-readable console output,
+/// you can implement this function as a no-op.
+///
+/// ### Concurrency support
+///
+/// This function's implementation must be concurrency-safe unless the system is
+/// single-threaded. In the reference example above, you can substitute
+/// platform-specific equivalents for `flockfile()` and `funlockfile()` if
+/// needed, or omit them entirely in single-threaded environments.
+SWT_EXTERN void _swift_testing_writeToConsole(const uint8_t *chars, size_t count);
+
+SWT_ASSUME_NONNULL_END
+#endif


### PR DESCRIPTION
This PR abstracts our console output, which we currently do by writing to `stderr`, so that they can be implemented with a different destination. Embedded Swift in particular does not guarantee the existence of `stderr`.

We accomplish this noble goal by introducing what I'm terming an _annex_[^annexWat] to the Platform Abstraction Layer introduced [here](https://forums.swift.org/t/introducing-the-embedded-swift-platform-abstraction-layer/89248). The Platform Abstraction Layer testing annex ("Annex T" for short? Anybody?) will include those functions that are needed in Embedded Swift but which we cannot implement ourselves because they depend on target-specific functionality.

[^annexWat]: The C language uses the term "annex" to refer to supplemental and generally optional components of the language specification such as the infamous "Annex K" describing nominally secure interfaces that nobody implements.

The first member of the annex is `_swift_testing_writeToConsole()` which, as the name suggests, writes to the "console", whatever that might be. There's also a wrapper around this function on the Swift side, `writeToConsole(_:useStandardOutputIfAvailable:)`, that takes a Swift string; in non-Embedded Swift, when `SWT_NO_FILE_IO` is not set, this wrapper just writes to `stderr` as we did previously. Call sites then just need to pass the string to this single function.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
