### PR TITLE
Add a "console capabilities" check to the Platform Abstraction Layer.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -68,7 +68,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, forSwiftPackageManager
       if useExperimentalConsoleOutput {
         // Use experimental AdvancedConsoleOutputRecorder
         var advancedOptions = Event.AdvancedConsoleOutputRecorder<ABI.ExperimentalVersion>.Options()
-        advancedOptions.base = .for(.stderr)
+        advancedOptions.base = .forCurrentSystemConsole
 
         let eventRecorder = Event.AdvancedConsoleOutputRecorder<ABI.ExperimentalVersion>(options: advancedOptions) { string in
           writeToConsole(string)
@@ -85,7 +85,7 @@ func entryPoint(passing args: __CommandLineArguments_v0?, forSwiftPackageManager
 
       if !useExperimentalConsoleOutput {
         // Use the standard console output recorder (default behavior)
-        let eventRecorder = Event.ConsoleOutputRecorder(options: .for(.stderr)) { string in
+        let eventRecorder = Event.ConsoleOutputRecorder(options: .forCurrentSystemConsole) { string in
           writeToConsole(string)
         }
         configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
@@ -677,7 +677,7 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0, emi
         if emitWarnings {
           let warning = Event.ConsoleOutputRecorder.warning(
             "Backticks aren't a valid part of a Swift symbol. Replacing '\(originalString)' with '\(string)'.",
-            options: .for(.stderr)
+            options: .forCurrentSystemConsole
           )
           writeToConsole("\(warning)\n")
         }
@@ -825,7 +825,39 @@ func eventHandlerForStreamingEvents(
 
 extension Event.ConsoleOutputRecorder.Options {
 #if !SWT_NO_FILE_IO
-  /// The set of options to use when writing to the standard error stream.
+  /// The set of options to use when writing to the current system's console.
+  ///
+  /// On non-Embedded Swift targets that support file I/O, the testing library
+  /// uses the standard error stream as the console, and this property's value
+  /// is equivalent to the result of calling `.for(.stderr)`.
+  static var forCurrentSystemConsole: Self {
+#if !hasFeature(Embedded)
+#if !SWT_NO_FILE_IO
+    .for(.stderr)
+#else
+    Self()
+#endif
+#else
+    var result = Self()
+
+    var consoleCapabilities = swift_testing_console_capabilities_t()
+    if _swift_testing_getConsoleCapabilities(&consoleCapabilities) {
+      result.useANSIEscapeCodes = consoleCapabilities.useANSIEscapeCodes != 0
+      result.ansiColorBitDepth = Int8(clamping: consoleCapabilities.ansiColorBitDepth)
+    }
+
+    return result
+#endif
+  }
+
+  /// The set of options to use when writing to the given file handle.
+  ///
+  /// - Parameters:
+  ///   - fileHandle: The file handle for which options are needed.
+  ///     Platform-specific API is used to derive options from this file handle.
+  ///
+  /// - Returns: An instance of this type representing the appropriate options
+  ///   to use when writing to `fileHandle`.
   static func `for`(_ fileHandle: borrowing FileHandle) -> Self {
     var result = Self()
 

--- a/Sources/_TestingInternals/include/Defines.h
+++ b/Sources/_TestingInternals/include/Defines.h
@@ -36,4 +36,7 @@
 /// An attribute that renames a C symbol in Swift.
 #define SWT_SWIFT_NAME(name) __attribute__((swift_name(#name)))
 
+/// An attribute that marks a function's result as non-discardable.
+#define SWT_NODISCARD __attribute__((warn_unused_result))
+
 #endif // SWT_DEFINES_H

--- a/Sources/_TestingInternals/include/EmbeddedPlatform.h
+++ b/Sources/_TestingInternals/include/EmbeddedPlatform.h
@@ -24,6 +24,71 @@ SWT_ASSUME_NONNULL_BEGIN
 
 // MARK: - Console output
 
+/// A type describing the capabilities of the current system's console output.
+typedef struct swift_testing_console_capabilities_t {
+  /// Whether or not the testing library should add ANSI escape codes to its
+  /// console output.
+  ///
+  /// ## See Also
+  ///
+  /// - ``Event/ConsoleOutputRecorder/Options/useANSIEscapeCodes``
+  unsigned int useANSIEscapeCodes : 1;
+
+  /// The bit depth of ANSI colors supported by the current system's console.
+  ///
+  /// For example, black-and-white output has a bit depth of `1`, and true color
+  /// output has a bit depth of `24`. Values of `1`, `4`, `8`, and `24` are
+  /// supported. `0` is treated as equivalent to `1`, while all other values are
+  /// rounded down to the nearest supported value.
+  ///
+  /// ## See Also
+  ///
+  /// - ``Event/ConsoleOutputRecorder/Options/ansiColorBitDepth``
+  unsigned int ansiColorBitDepth : 5;
+} swift_testing_console_capabilities_t;
+
+/// Get the capabilities of the current system's console output.
+///
+/// - Parameters:
+///   - outConsoleCapabilities: A pointer to memory large enough to hold an
+///     instance of the ``swift_testing_console_capabilities_t`` structure. On
+///     return, initialized to an instance of that type that describes the
+///     capabilities of the console `_swift_testing_writeToConsole()` writes to.
+///
+/// - Returns: Whether or not `outConsoleCapabilities` was successfully
+///   initialized. If it was not, the testing library assumes the system console
+///   has none of the supported capabilities.
+///
+/// The testing library uses this function to determine what, if any,
+/// capabilities the system console has.
+///
+/// - Important: The testing library may add additional fields to the
+///   ``swift_testing_console_capabilities_t`` structure in the future. To
+///   ensure source compatibility if the structure changes, be sure to
+///   initialize the entire structure:
+///
+///   ```c
+///   swift_testing_console_capabilities_t good = {};
+///   swift_testing_console_capabilities_t bad;
+///   ```
+///
+/// ### Reference implementations
+///
+/// This function can be implemented to simply return `false` if the current
+/// system's console has none of the supported capabilities:
+///
+/// ```c
+/// bool _swift_testing_getConsoleCapabilities(swift_testing_console_capabilities_t *outConsoleCapabilities) {
+///   return false;
+/// }
+/// ```
+///
+/// ### Concurrency support
+///
+/// This function's implementation must be concurrency-safe unless the system is
+/// single-threaded.
+SWT_EXTERN SWT_NODISCARD bool _swift_testing_getConsoleCapabilities(swift_testing_console_capabilities_t *outConsoleCapabilities);
+
 /// Writes a sequence of UTF-8 code points to the current system's console.
 ///
 /// - Parameters:
@@ -34,6 +99,12 @@ SWT_ASSUME_NONNULL_BEGIN
 /// transcript of a test run. If possible, the implementation should write
 /// output to the standard error stream. Calls to the Swift standard library's
 /// `print()` function (or similar interfaces) do not use this function.
+///
+/// - Important: If the `_swift_testing_getConsoleCapabilities()` function
+///   returns `true` and configures any of the supported capabilities, then
+///   `chars` may contain ANSI escape codes or other metacontent in addition to
+///   human-readable text. If the current system's console only supports plain
+///   text, make sure your implementation of that function returns `false`.
 ///
 /// ### Reference implementations
 ///


### PR DESCRIPTION
This PR adds a function to the PAL annex that lets a platform indicate what sort of console functionality it supports:

- Does it support ANSI escape codes?
- If so, what colour depth does it support?
- And other future questions.

We use this function in Embedded Swift to configure the console output recorder so that the output is legible. I would expect in practice that most implementations will just stub this function out, but I'd like to give them the option to do more.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
