### PR TITLE
Don't use keypaths as arguments to functional monady things like `map(_:)`.

### DIFF
--- a/Sources/Overlays/_Testing_AppKit/Attachments/NSImage+AttachableAsImage.swift
+++ b/Sources/Overlays/_Testing_AppKit/Attachments/NSImage+AttachableAsImage.swift
@@ -79,7 +79,7 @@ extension NSImage: AttachableAsImage, AttachableAsCGImage {
 
     // Check whether the image contains any representations that we don't think
     // are safe. If it does, then make a "safe" copy.
-    let allImageRepsAreSafe = representations.allSatisfy(\.isEffectivelySendable)
+    let allImageRepsAreSafe = representations.allSatisfy { $0.isEffectivelySendable }
     if !allImageRepsAreSafe, let safeCopy = tiffRepresentation.flatMap(Self.init(data:)) {
       // Create a "safe" copy of this image by flattening it to TIFF and then
       // creating a new NSImage instance from it.

--- a/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
+++ b/Sources/Overlays/_Testing_WinSDK/Attachments/AttachableImageFormat+CLSID.swift
@@ -137,7 +137,7 @@ extension AttachableImageFormat {
             0 == _wcsicmp(pathExtension, encoderExt)
           }
         }
-      }.map(\.key)
+      }.map { $0.key }
   }
 
   /// Get the `CLSID` value of the WIC image encoder corresponding to the same

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedEvent.swift
@@ -210,14 +210,14 @@ extension ABI {
       if V.includesExperimentalFields {
         switch event.kind {
         case let .issueRecorded(recordedIssue):
-          _comments = recordedIssue.comments.map(\.rawValue)
+          _comments = recordedIssue.comments.map { $0.rawValue }
           _sourceLocation = recordedIssue.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
         case let .valueAttached(attachment):
           _sourceLocation = EncodedSourceLocation<V>(encoding: attachment.sourceLocation)
         case let .testCaseCancelled(skipInfo),
           let .testSkipped(skipInfo),
           let .testCancelled(skipInfo):
-          _comments = Array(skipInfo.comment).map(\.rawValue)
+          _comments = Array(skipInfo.comment).map { $0.rawValue }
           _sourceLocation = skipInfo.sourceLocation.map { EncodedSourceLocation(encoding: $0) }
         default:
           break

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedExpression.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedExpression.swift
@@ -52,7 +52,7 @@ extension ABI.EncodedExpression {
   public init(encoding expression: borrowing Expression) {
     sourceCode = expression.sourceCode
     runtimeValue = expression.runtimeValue.map(String.init(describingForTest:))
-    runtimeTypeName = expression.runtimeValue.map(\.typeInfo.fullyQualifiedName)
+    runtimeTypeName = expression.runtimeValue.map { $0.typeInfo.fullyQualifiedName }
     let subexpressions = expression.subexpressions
     if !subexpressions.isEmpty {
       children = subexpressions.map(Self.init(encoding:))

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedTest.swift
@@ -137,7 +137,7 @@ extension ABI {
       // TODO: define an encodable form of Test.Case.ID
       id = String(describing: testCase.id)
       displayName = arguments.lazy
-        .map(\.value)
+        .map { $0.value }
         .map(String.init(describingForTest:))
         .joined(separator: ", ")
     }

--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -186,7 +186,7 @@ func listTestsForEntryPoint(_ tests: some Sequence<Test>, verbosity: Int) -> [St
   // Early exit for verbose output (no need to check for ambiguity.)
   if verbosity > 0 {
     return tests.lazy
-      .map(\.id)
+      .map { $0.id }
       .map(String.init(describing:))
       .sorted(by: <)
   }
@@ -195,7 +195,7 @@ func listTestsForEntryPoint(_ tests: some Sequence<Test>, verbosity: Int) -> [St
   // components of two tests' IDs are ambiguous, present their source locations
   // to disambiguate.
   let initialGroups = Dictionary(
-    grouping: tests.lazy.map(\.id),
+    grouping: tests.lazy.map { $0.id },
     by: \.nameComponents
   ).values.lazy
     .map { ($0, isAmbiguous: $0.count > 1) }
@@ -1031,7 +1031,7 @@ extension __CommandLineArguments_v0 {
   @available(*, deprecated, message: "Use eventStreamSchemaVersion instead.")
   public var eventStreamVersion: Int? {
     get {
-      eventStreamVersionNumber.map(\.majorComponent).map(Int.init)
+      eventStreamVersionNumber.map { $0.majorComponent }.map(Int.init)
     }
     set {
       eventStreamVersionNumber = newValue.map { VersionNumber(majorComponent: .init(clamping: $0), minorComponent: 0) }

--- a/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.HumanReadableOutputRecorder.swift
@@ -160,7 +160,7 @@ extension Event.HumanReadableOutputRecorder {
     }
     let errorIssueCount = graph.compactMap { $0.value?.issueCount[.error] }.reduce(into: 0, +=)
     let warningIssueCount = graph.compactMap { $0.value?.issueCount[.warning] }.reduce(into: 0, +=)
-    let knownIssueCount = graph.compactMap(\.value?.knownIssueCount).reduce(into: 0, +=)
+    let knownIssueCount = graph.compactMap { $0.value?.knownIssueCount }.reduce(into: 0, +=)
     let totalIssueCount = errorIssueCount + warningIssueCount + knownIssueCount
 
     // Construct a string describing the issue counts.

--- a/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
+++ b/Sources/Testing/Events/Recorder/Event.JUnitXMLRecorder.swift
@@ -143,10 +143,10 @@ extension Event.JUnitXMLRecorder {
     case .runEnded:
       return _context.value.withLock { context in
         let issueCount = context.testData
-          .compactMap(\.value?.issues.count)
+          .compactMap { $0.value?.issues.count }
           .reduce(into: 0, +=) + context.issuesForUnknownTests.count
         let skipCount = context.testData
-          .compactMap(\.value?.skipInfo)
+          .compactMap { $0.value?.skipInfo }
           .count
         let durationSeconds = context.runStartInstant
           .map { $0.duration(to: instant) / .seconds(1) } ?? 0.0
@@ -236,7 +236,7 @@ extension Event.JUnitXMLRecorder {
       "&amp;"
     case _ where !character.isASCII || character.isNewline:
       character.unicodeScalars.lazy
-        .map(\.value)
+        .map { $0.value }
         .map { "&#\($0);" }
         .joined()
     default:

--- a/Sources/Testing/ExitTests/SpawnProcess.swift
+++ b/Sources/Testing/ExitTests/SpawnProcess.swift
@@ -288,7 +288,7 @@ func spawnExecutable(
     for i in 0 ..< additionalFileHandles.count {
       inheritedHandles[i + 3] = try inherit(additionalFileHandles[i].pointee)
     }
-    inheritedHandles = inheritedHandles.compactMap(\.self)
+    inheritedHandles = inheritedHandles.filter { $0 != nil }
 
     return try inheritedHandles.withUnsafeMutableBufferPointer { inheritedHandles in
       _ = UpdateProcThreadAttribute(

--- a/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
+++ b/Sources/Testing/Expectations/ExpectationChecking+Macro.swift
@@ -643,8 +643,8 @@ public func __checkPropertyAccess<T, U>(
       return nil
     }
     let difference = lhs.difference(from: rhs)
-    let insertions = difference.insertions.map(\.element)
-    let removals = difference.removals.map(\.element)
+    let insertions = difference.insertions.map { $0.element }
+    let removals = difference.removals.map { $0.element }
     switch (!insertions.isEmpty, !removals.isEmpty) {
     case (true, true):
       return "inserted \(insertions), removed \(removals)"

--- a/Sources/Testing/Issues/Issue.swift
+++ b/Sources/Testing/Issues/Issue.swift
@@ -244,7 +244,7 @@ extension Issue: CustomStringConvertible, CustomDebugStringConvertible {
       ""
     } else {
       ": " + comments.lazy
-        .map(\.rawValue)
+        .map { $0.rawValue }
         .joined(separator: "\n")
     }
     return "\(kind) (\(severity))\(joinedComments)"
@@ -255,7 +255,7 @@ extension Issue: CustomStringConvertible, CustomDebugStringConvertible {
       ""
     } else {
       ": " + comments.lazy
-        .map(\.rawValue)
+        .map { $0.rawValue }
         .joined(separator: "\n")
     }
     return "\(kind)\(sourceLocation.map { " at \($0)" } ?? "") (\(severity))\(joinedComments)"
@@ -593,7 +593,7 @@ extension Issue.Snapshot: CustomStringConvertible, CustomDebugStringConvertible 
       ""
     } else {
       ": " + comments.lazy
-        .map(\.rawValue)
+        .map { $0.rawValue }
         .joined(separator: "\n")
     }
     return "\(kind) (\(severity))\(joinedComments)"
@@ -604,7 +604,7 @@ extension Issue.Snapshot: CustomStringConvertible, CustomDebugStringConvertible 
       ""
     } else {
       ": " + comments.lazy
-        .map(\.rawValue)
+        .map { $0.rawValue }
         .joined(separator: "\n")
     }
     return "\(kind)\(sourceLocation.map { " at \($0)" } ?? "") (\(severity))\(joinedComments)"

--- a/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
+++ b/Sources/Testing/Parameterization/CustomTestArgumentEncodable.swift
@@ -113,7 +113,7 @@ extension Test.Case.Argument.ID {
     if let argumentID = argumentIDs.first, argumentIDs.count == 1 {
       self = argumentID
     } else {
-      self.init(bytes: SHA256.hash(argumentIDs.flatMap(\.bytes)))
+      self.init(bytes: SHA256.hash(argumentIDs.flatMap { $0.bytes }))
     }
   }
 }

--- a/Sources/Testing/Parameterization/Test.Case.ID.swift
+++ b/Sources/Testing/Parameterization/Test.Case.ID.swift
@@ -50,7 +50,7 @@ extension Test.Case {
 
   @_spi(ForToolsIntegrationOnly)
   public var id: ID {
-    let argumentIDs = arguments.map { [Argument.ID(combining: $0.map(\.id))] }
+    let argumentIDs = arguments.map { [Argument.ID(combining: $0.map { $0.id })] }
     return ID(argumentIDs: argumentIDs, discriminator: discriminator, isStable: isStable)
   }
 }

--- a/Sources/Testing/Running/Configuration.TestFilter.swift
+++ b/Sources/Testing/Running/Configuration.TestFilter.swift
@@ -355,9 +355,9 @@ extension Configuration.TestFilter.Operation {
       // containing matching tests, then translate it into a new instance of
       // TestFilter, then finally run that test filter to modify the graph.
       let testIDs = testGraph
-        .compactMap(\.value).lazy
+        .compactMap { $0.value }.lazy
         .filter(function)
-        .map(\.test.id)
+        .map { $0.test.id }
       let selection = Test.ID.Selection(testIDs: testIDs)
       return Self.precomputed(selection, membership: membership).apply(to: testGraph)
     case let .combination(lhs, rhs, op):

--- a/Sources/Testing/Running/Runner.Plan.swift
+++ b/Sources/Testing/Running/Runner.Plan.swift
@@ -90,7 +90,9 @@ extension Runner {
 
     /// The steps of the runner plan.
     public var steps: [Step] {
-      stepGraph.compactMap(\.value).sorted { $0.test.sourceLocation < $1.test.sourceLocation }
+      stepGraph
+        .compactMap { $0.value }
+        .sorted { $0.test.sourceLocation < $1.test.sourceLocation }
     }
 
     /// Initialize an instance of this type with the specified graph of test
@@ -137,7 +139,7 @@ extension Runner.Plan {
   private static func _recursivelyApplyTraits(_ parentTraits: [any SuiteTrait] = [], to testGraph: inout Graph<String, Test?>) {
     let traits: [any SuiteTrait] = parentTraits + (testGraph.value?.traits ?? []).lazy
       .compactMap { $0.__as((any SuiteTrait).self) }
-      .filter(\.isRecursive)
+      .filter { $0.isRecursive }
 
     testGraph.children = testGraph.children.mapValues { child in
       var child = child
@@ -182,7 +184,7 @@ extension Runner.Plan {
         }
         open(&trait)
       }
-      test.traits = traits.compactMap(\.self)
+      test.traits = traits.compactMap { $0 }
 
       return test
     }
@@ -516,7 +518,7 @@ extension Runner.Plan {
 
     /// The steps of this runner plan.
     public var steps: some Collection<Step.Snapshot> {
-      _stepGraph.compactMap(\.value)
+      _stepGraph.compactMap { $0.value }
     }
   }
 }

--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -19,7 +19,7 @@ public struct Runner: Sendable {
   public var plan: Plan
 
   /// The set of tests this runner will run.
-  public var tests: [Test] { plan.steps.map(\.test) }
+  public var tests: [Test] { plan.steps.map { $0.test } }
 
   /// The runner's configuration.
   public var configuration: Configuration
@@ -393,7 +393,7 @@ extension Runner {
     }
 
     // Run the child nodes.
-    try await _forEach(in: childGraphs.lazy.map(\.value), namingTasksWith: taskNamer) { childGraph in
+    try await _forEach(in: childGraphs.lazy.map { $0.value }, namingTasksWith: taskNamer) { childGraph in
       try await _runStep(atRootOf: childGraph, context: context)
     }
   }

--- a/Sources/Testing/SourceAttribution/Expression+Macro.swift
+++ b/Sources/Testing/SourceAttribution/Expression+Macro.swift
@@ -86,7 +86,7 @@ extension __Expression {
 
     return Self(
       sourceCode,
-      subexpressions: Array(value) + arguments.map(\.value)
+      subexpressions: Array(value) + arguments.map { $0.value }
     )
   }
 

--- a/Sources/Testing/Test+Cancellation.swift
+++ b/Sources/Testing/Test+Cancellation.swift
@@ -182,7 +182,7 @@ private func _cancel<T>(_ cancellableValue: T?, for testAndTestCase: (Test?, Tes
         comments: [
           "Attempted to cancel the current test or test case, but one is not associated with the current task.",
           skipInfo.comment,
-        ].compactMap(\.self),
+        ].compactMap { $0 },
         sourceContext: skipInfo.sourceContext
       )
       issue.record()

--- a/Sources/Testing/Traits/Comment.swift
+++ b/Sources/Testing/Traits/Comment.swift
@@ -217,6 +217,6 @@ extension Trait where Self == Comment {
 extension Test {
   /// The complete set of comments about this test from all of its traits.
   public var comments: [Comment] {
-    traits.flatMap(\.comments)
+    traits.flatMap { $0.comments }
   }
 }

--- a/Sources/Testing/Traits/Tags/Tag.swift
+++ b/Sources/Testing/Traits/Tags/Tag.swift
@@ -144,7 +144,7 @@ extension Test {
   public var tags: Set<Tag> {
     traits.lazy
       .compactMap { $0 as? Tag.List }
-      .map(\.tags)
+      .map { $0.tags }
       .reduce(into: []) { $0.formUnion($1) }
   }
 }

--- a/Sources/Testing/Traits/TimeLimitTrait.swift
+++ b/Sources/Testing/Traits/TimeLimitTrait.swift
@@ -208,7 +208,7 @@ extension Test {
   public var timeLimit: Duration? {
     traits.lazy
       .compactMap { $0 as? TimeLimitTrait }
-      .map(\.timeLimit)
+      .map { $0.timeLimit }
       .min()
   }
 

--- a/Sources/TestingMacros/ConditionMacro.swift
+++ b/Sources/TestingMacros/ConditionMacro.swift
@@ -180,7 +180,7 @@ extension ConditionMacro {
         // the resulting comment array.
         checkArguments.append(Argument(
           label: "comments",
-          expression: #"(\#(commentsArrayExpr) as [Testing.Comment?]).compactMap(\.self)"#
+          expression: #"(\#(commentsArrayExpr) as [Testing.Comment?]).compactMap { $0 }"#
         ))
       } else {
         checkArguments.append(Argument(label: "comments", expression: commentsArrayExpr))


### PR DESCRIPTION
Embedded Swift does not like using keypaths as function references, so it errors on patterns like `array.map(\.whatever)`. Change these uses to `{ $0.whatever }` to satisfy the Embedded Swift compiler.

Don't bother touching the macros target since it always runs host-side.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
