### PR TITLE
Add support for the testing clock in Embedded Swift.

### DIFF
--- a/Sources/Overlays/_Testing_Foundation/Events/Clock+Date.swift
+++ b/Sources/Overlays/_Testing_Foundation/Events/Clock+Date.swift
@@ -8,6 +8,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+#if !hasFeature(Embedded)
 #if !SWT_NO_FOUNDATION && !SWT_NO_UTC_CLOCK
 @_spi(Experimental) @_spi(ForToolsIntegrationOnly) public import Testing
 public import Foundation
@@ -45,4 +46,5 @@ extension Date {
   }
 #endif
 }
+#endif
 #endif

--- a/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
+++ b/Sources/Testing/ABI/Encoded/ABI.EncodedInstant.swift
@@ -35,11 +35,19 @@ extension ABI.EncodedInstant {
   /// - Parameters:
   ///   - instant: The instant to initialize this instance from.
   public init(encoding instant: borrowing Test.Clock.Instant) {
+#if !hasFeature(Embedded)
 #if !SWT_NO_SUSPENDING_CLOCK
     absolute = instant.suspending.rawValue / .seconds(1)
 #endif
 #if !SWT_NO_UTC_CLOCK
     since1970 = instant.wall.rawValue / .seconds(1)
+#endif
+#else
+    // The selection of the `absolute` field here is arbitrary, but based on the
+    // assumption that embedded targets are more likely to have monotonic clocks
+    // of some form (even just the CPU instruction counter times frequency) than
+    // they are to have accurate realtime wall clocks.
+    absolute = instant.sinceSystemEpoch.rawValue / .seconds(1)
 #endif
   }
 }
@@ -67,6 +75,7 @@ extension Test.Clock.Instant {
       return nil
     }
 
+#if !hasFeature(Embedded)
     switch (instant.absolute, instant.since1970) {
     case let (.some(absolute), .some(since1970)):
       let suspending = TimeValue(rawValue: .seconds(absolute))
@@ -98,10 +107,18 @@ extension Test.Clock.Instant {
       // clock (i.e. events are delivered, encoded, and decoded with zero latency).
       self = .now
     }
+#else
+    if let seconds = instant.absolute ?? instant.since1970 {
+      self.init(sinceSystemEpoch: TimeValue(rawValue: .seconds(seconds)))
+    } else {
+      self = .now
+    }
+#endif
   }
 }
 #endif
 
+#if !hasFeature(Embedded)
 #if !SWT_NO_SUSPENDING_CLOCK
 @_spi(ForToolsIntegrationOnly)
 extension SuspendingClock.Instant {
@@ -123,8 +140,11 @@ extension SuspendingClock.Instant {
 #endif
 
 // Date.init(decoding:) is in the Foundation overlay.
+#endif
 
+#if !SWT_NO_CODABLE
 // MARK: - Codable
 
 extension ABI.EncodedInstant: Codable {}
+#endif
 #endif

--- a/Sources/Testing/Events/Clock.swift
+++ b/Sources/Testing/Events/Clock.swift
@@ -20,6 +20,7 @@ extension Test {
   public struct Clock: Sendable {
     /// An instant on the testing clock.
     public struct Instant: Sendable {
+#if !hasFeature(Embedded)
 #if !SWT_NO_SUSPENDING_CLOCK
       /// The suspending-clock time corresponding to this instant.
       var suspending = TimeValue(rawValue: SuspendingClock().systemEpoch.duration(to: .now))
@@ -44,16 +45,35 @@ extension Test {
 #endif
       }()
 #endif
+#else
+      /// The time since the system's epoch.
+      ///
+      /// Because Embedded Swift targets vary widely in the set of clocks and
+      /// time APIs they support, the clock used to compute this value is
+      /// implementation-defined.
+      var sinceSystemEpoch: TimeValue = {
+        var seconds = UInt32(0)
+        var nanoseconds = UInt32(0)
+        guard _swift_testing_getTimeSinceSystemEpoch(&seconds, &nanoseconds) else {
+          return TimeValue(rawValue: .zero)
+        }
+        return TimeValue(rawValue: .seconds(seconds) + .nanoseconds(nanoseconds))
+      }()
+#endif
 
       /// The time value to use for comparison with other instances of this
       /// type.
       private var _timeValueForComparison: TimeValue {
+#if !hasFeature(Embedded)
 #if !SWT_NO_SUSPENDING_CLOCK
         suspending
 #elseif !SWT_NO_UTC_CLOCK
         wall
 #else
         TimeValue(rawValue: .zero)
+#endif
+#else
+        sinceSystemEpoch
 #endif
       }
 
@@ -95,6 +115,7 @@ extension Test {
   }
 }
 
+#if !hasFeature(Embedded)
 // MARK: -
 
 #if !SWT_NO_SUSPENDING_CLOCK
@@ -166,9 +187,7 @@ extension Test.Clock: _Concurrency.Clock {
     var ts = timespec(tv_sec: .init(duration.components.seconds), tv_nsec: .init(duration.components.attoseconds / 1_000_000_000))
     var tsRemaining = ts
     while 0 != nanosleep(&ts, &tsRemaining) {
-#if !hasFeature(Embedded)
       try Task.checkCancellation()
-#endif
       ts = tsRemaining
     }
 #else
@@ -185,6 +204,7 @@ extension Test.Clock: _Concurrency.Clock {
 #endif
   }
 }
+#endif
 
 // MARK: - Equatable, Hashable, Comparable
 
@@ -208,11 +228,15 @@ extension Test.Clock.Instant: InstantProtocol {
   public func advanced(by duration: Duration) -> Self {
     var result = self
 
+#if !hasFeature(Embedded)
 #if !SWT_NO_SUSPENDING_CLOCK
     result.suspending = TimeValue(rawValue: result.suspending.rawValue + duration)
 #endif
 #if !SWT_NO_UTC_CLOCK
     result.wall = TimeValue(rawValue: result.wall.rawValue + duration)
+#endif
+#else
+    result.sinceSystemEpoch = TimeValue(rawValue: result.sinceSystemEpoch.rawValue + duration)
 #endif
 
     return result

--- a/Sources/_TestingInternals/include/EmbeddedPlatform.h
+++ b/Sources/_TestingInternals/include/EmbeddedPlatform.h
@@ -158,5 +158,96 @@ SWT_EXTERN SWT_NODISCARD bool _swift_testing_getConsoleCapabilities(swift_testin
 /// needed, or omit them entirely in single-threaded environments.
 SWT_EXTERN void _swift_testing_writeToConsole(const uint8_t *chars, size_t count);
 
+// MARK: - Test timing
+
+/// Get the amount of time that has passed since the system's epoch.
+///
+/// - Parameters:
+///   - outSeconds: On successful return, set to the number of whole seconds
+///     since the system's epoch.
+///   - outNanoseconds: On successful return, set to the number of nanoseconds
+///     since the system's epoch (less the number of seconds returned in
+///     `outSeconds`). The value should be less than `1000000000`.
+///
+/// - Returns: Whether or not `*outSeconds` and `*outNanoseconds` were
+///   successfully initialized. If they were not, their values are undefined and
+///   the testing library assumes a time of `0`.
+///
+/// The testing library uses this function to determine how long tests take to
+/// run.
+///
+/// The system's epoch is typically the time when it booted or the time the
+/// current process started. Avoid using the UNIX epoch (1970-01-01 00:00:00 UT)
+/// or another realtime (wall-clock) epoch as the realtime clock can be adjusted
+/// at runtime and may unexpectedly decrease. The epoch time itself does not
+/// need to be representable in Swift.
+///
+/// The result of this function should have at least millisecond resolution. If
+/// the platform does not support millisecond resolution or finer, the
+/// implementation should still be as precise as possible. If the platform only
+/// supports one-second resolution or coarser, the implementation must set
+/// `*outNanoseconds` to `0` before successfully returning.
+///
+/// - Note: Where possible, the implementation should use a suspending clock
+///   rather than a continuous clock (that is, time the system spends asleep
+///   should not, ideally, count toward the result of this function).
+///
+/// ### Reference implementations
+///
+/// On systems with the POSIX `clock_gettime()`, this function can be
+/// implemented with the following algorithm:
+///
+/// ```c
+/// bool _swift_testing_getTimeSinceSystemEpoch(uint32_t *outSeconds, uint32_t *outNanoseconds) {
+///   struct timespec ts = {};
+///   if (0 != clock_gettime(CLOCK_MONOTONIC, &ts)) {
+///     return false;
+///   }
+///   *outSeconds = (uint32_t)ts.tv_sec;
+///   *outNanoseconds = (uint32_t)ts.tv_nsec;
+///   return true;
+/// }
+/// ```
+///
+/// - Note: POSIX-compliant systems implement a variety of different clocks, and
+///   they do not all implement `CLOCK_MONOTONIC`. Consult your platform's
+///   documentation to determine the correct clock constant to pass to
+///   `clock_gettime()`.
+///
+/// The implementation can also use system-specific interfaces to compute the
+/// current time. For example, if the target is an Arduino board, you could use
+/// the [`millis()`](https://docs.arduino.cc/language-reference/en/functions/time/millis/)
+/// function:
+///
+/// ```c
+/// bool _swift_testing_getTimeSinceSystemEpoch(uint32_t *outSeconds, uint32_t *outNanoseconds) {
+///   unsigned long ms = millis();
+///   *outSeconds = ms / 1000;
+///   *outNanoseconds = (ms % 1000) * 1000000; // ns per ms
+///   return true;
+/// }
+/// ```
+///
+/// If the platform does not provide any high-level interfaces for computing the
+/// current time, it may still provide lower-level interfaces for querying the
+/// system counter, which can then be divided by the CPU's frequency to get a
+/// time value. The implementation of this logic is left as an exercise for the
+/// reader.
+///
+/// This function can be implemented to simply return `false` if the platform
+/// has no way to get the current time:
+///
+/// ```c
+/// bool _swift_testing_getTimeSinceSystemEpoch(uint32_t *outSeconds, uint32_t *outNanoseconds) {
+///   return false;
+/// }
+/// ```
+///
+/// ### Concurrency support
+///
+/// This function's implementation must be concurrency-safe unless the system is
+/// single-threaded.
+SWT_EXTERN SWT_NODISCARD bool _swift_testing_getTimeSinceSystemEpoch(uint32_t *outSeconds, uint32_t *outNanoseconds);
+
 SWT_ASSUME_NONNULL_END
 #endif

--- a/Tests/TestingTests/ClockTests.swift
+++ b/Tests/TestingTests/ClockTests.swift
@@ -35,14 +35,17 @@ struct ClockTests {
     #expect(instants.count == 2)
 
     let now = Test.Clock.Instant.now
+#if !SWT_NO_SUSPENDING_CLOCK
     #expect(now.suspending.rawValue.components.seconds > 0)
     #expect(now.suspending.rawValue.components.attoseconds >= 0)
+#endif
 #if !SWT_NO_UTC_CLOCK
     #expect(now.wall.rawValue.components.seconds > 0)
     #expect(now.wall.rawValue.components.attoseconds >= 0)
 #endif
   }
 
+#if !SWT_NO_SUSPENDING_CLOCK
   @Test("Creating a SuspendingClock.Instant from Test.Clock.Instant")
   func suspendingInstantInitializer() async throws {
     let instant1 = SuspendingClock.Instant(Test.Clock.Instant.now)
@@ -51,6 +54,7 @@ struct ClockTests {
 
     #expect(instant1 < instant2)
   }
+#endif
 
   @Test("Clock.sleep(until:tolerance:) method")
   func sleepUntilTolerance() async throws {
@@ -121,7 +125,9 @@ struct ClockTests {
     let decoded = try #require(Test.Clock.Instant(decoding: encoded))
 
     // Instant -> EncodedInstant loses some precision when converting from Duration -> Double
+#if !SWT_NO_SUSPENDING_CLOCK
     #expect(abs((now.suspending.rawValue - decoded.suspending.rawValue) / .seconds(1)) < 0.001)
+#endif
 #if !SWT_NO_UTC_CLOCK
     #expect(abs((now.durationSince1970 - decoded.durationSince1970) / .seconds(1)) < 0.001)
 #endif


### PR DESCRIPTION
This PR adds `#if` cases for Embedded Swift in `Test.Case.Clock` and surrounding code. There is (as of this writing) no support for `SuspendingClock` in Embedded Swift, and many embedded targets have no realtime wall clock at all, so we provide a PAL annex function that developers can implement to provide the best available time value on their embedded system.

This function may become obsolete in the future if `SuspendingClock` is made available in Embedded Swift.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
