### PR TITLE
Abstract over `exit()` and `_swift_exit()`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -411,6 +411,10 @@ extension Array where Element == PackageDescription.SwiftSetting {
       // Enabled to allow tests to be added to ~Escapable suites.
       .enableExperimentalFeature("Lifetimes"),
 
+      // Enabled to allow us to forward-declare functions in the Platform
+      // Abstraction Layer.
+      .enableExperimentalFeature("Extern"),
+
       .enableUpcomingFeature("InferIsolatedConformances"),
 
       // When building as a package, the macro plugin always builds as an

--- a/Sources/Testing/EmbeddedPlatform.swift
+++ b/Sources/Testing/EmbeddedPlatform.swift
@@ -65,7 +65,7 @@ internal import _TestingInternals
 /// The testing library uses this function to exit the test process and exit
 /// test child processes. This function is a convenience over C's `exit()` and
 /// the Platform Abstraction Layer's `_swift_exit()`.
-@inline(always) func exit(_ exitCode: CInt) -> Never {
+func exit(_ exitCode: CInt) -> Never {
 #if !hasFeature(Embedded)
   _TestingInternals.exit(exitCode)
 #else

--- a/Sources/Testing/EmbeddedPlatform.swift
+++ b/Sources/Testing/EmbeddedPlatform.swift
@@ -13,7 +13,7 @@ internal import _TestingInternals
 /// This file contains abstractions over functionality that, under Embedded
 /// Swift, is provided by Swift Testing's Platform Abstraction Layer annex.
 
-/// Writes a Swift string as UTF-8 to the current system's console.
+/// Writes a Swift string to the current system's console.
 ///
 /// - Parameters:
 ///   - string: The string to write.
@@ -46,5 +46,30 @@ internal import _TestingInternals
   string.withUTF8 { string in
     _swift_testing_writeToConsole(string.baseAddress!, string.count)
   }
+#endif
+}
+
+#if hasFeature(Embedded)
+/// Exits the current process as if the C `exit()` function were called.
+///
+/// This declaration is provided because the function is declared in the core
+/// Platform Abstraction Layer header and is used by the testing library below.
+@_extern(c) private func _swift_exit(_ exitCode: CInt)
+#endif
+
+/// Exits the current process as if the C `exit()` function were called.
+///
+/// - Parameters:
+///   - exitCode: The exit code for the process.
+///
+/// The testing library uses this function to exit the test process and exit
+/// test child processes. This function is a convenience over C's `exit()` and
+/// the Platform Abstraction Layer's `_swift_exit()`.
+@inline(always) func exit(_ exitCode: CInt) -> Never {
+#if !hasFeature(Embedded)
+  _TestingInternals.exit(exitCode)
+#else
+  _swift_exit(exitCode)
+  swt_unreachable()
 #endif
 }

--- a/Sources/Testing/EmbeddedPlatform.swift
+++ b/Sources/Testing/EmbeddedPlatform.swift
@@ -65,7 +65,10 @@ internal import _TestingInternals
 /// The testing library uses this function to exit the test process and exit
 /// test child processes. This function is a convenience over C's `exit()` and
 /// the Platform Abstraction Layer's `_swift_exit()`.
-func exit(_ exitCode: CInt) -> Never {
+///
+/// - Bug: The extra `Void` argument works around a compiler crash on Android
+///   when verifying this function's SIL. ([swift-#92180](https://github.com/swiftlang/swift/issues/92180))
+@inline(always) func exit(_ exitCode: CInt, _: Void = ()) -> Never {
 #if !hasFeature(Embedded)
   _TestingInternals.exit(exitCode)
 #else

--- a/Sources/Testing/EmbeddedPlatform.swift
+++ b/Sources/Testing/EmbeddedPlatform.swift
@@ -65,7 +65,11 @@ internal import _TestingInternals
 /// The testing library uses this function to exit the test process and exit
 /// test child processes. This function is a convenience over C's `exit()` and
 /// the Platform Abstraction Layer's `_swift_exit()`.
-@inline(always) func exit(_ exitCode: CInt) -> Never {
+///
+/// - Bug: This symbol is declared as a constant closure rather than a function
+///   to work around a compiler crash on Android when verifying this function's
+///   SIL. ([swift-#92180](https://github.com/swiftlang/swift/issues/92180))
+let exit: @Sendable (_ exitCode: CInt) -> Never = { exitCode in
 #if !hasFeature(Embedded)
   _TestingInternals.exit(exitCode)
 #else

--- a/Sources/Testing/EmbeddedPlatform.swift
+++ b/Sources/Testing/EmbeddedPlatform.swift
@@ -65,10 +65,7 @@ internal import _TestingInternals
 /// The testing library uses this function to exit the test process and exit
 /// test child processes. This function is a convenience over C's `exit()` and
 /// the Platform Abstraction Layer's `_swift_exit()`.
-///
-/// - Bug: The extra `Void` argument works around a compiler crash on Android
-///   when verifying this function's SIL. ([swift-#92180](https://github.com/swiftlang/swift/issues/92180))
-@inline(always) func exit(_ exitCode: CInt, _: Void = ()) -> Never {
+@inline(always) func exit(_ exitCode: CInt) -> Never {
 #if !hasFeature(Embedded)
   _TestingInternals.exit(exitCode)
 #else

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -15,7 +15,9 @@ private import _TestingInternals
 // Resolve ambiguity between C's exit() and our wrapper in the PAL annex. Code
 // in Swift Testing doesn't need to do this because it prefers symbols in the
 // same module, while code outside our package can't see our declaration.
-let exit = Testing.exit
+private func exit(_ exitCode: CInt) -> Never {
+  Testing.exit(exitCode)
+}
 
 @Suite("Exit test tests") struct ExitTestTests {
   @Test("Exit code names are reported (where supported)") func exitCodeName() {

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -12,6 +12,11 @@
 private import _TestingInternals
 
 #if !SWT_NO_EXIT_TESTS
+// Resolve ambiguity between C's exit() and our wrapper in the PAL annex. Code
+// in Swift Testing doesn't need to do this because it prefers symbols in the
+// same module, while code outside our package can't see our declaration.
+let exit = Testing.exit
+
 @Suite("Exit test tests") struct ExitTestTests {
   @Test("Exit code names are reported (where supported)") func exitCodeName() {
     #expect(String(describing: ExitStatus.exitCode(EXIT_SUCCESS)) == ".exitCode(EXIT_SUCCESS)")

--- a/Tests/TestingTests/ExitTestTests.swift
+++ b/Tests/TestingTests/ExitTestTests.swift
@@ -15,9 +15,7 @@ private import _TestingInternals
 // Resolve ambiguity between C's exit() and our wrapper in the PAL annex. Code
 // in Swift Testing doesn't need to do this because it prefers symbols in the
 // same module, while code outside our package can't see our declaration.
-private func exit(_ exitCode: CInt) -> Never {
-  Testing.exit(exitCode)
-}
+private let exit = Testing.exit
 
 @Suite("Exit test tests") struct ExitTestTests {
   @Test("Exit code names are reported (where supported)") func exitCodeName() {

--- a/cmake/modules/shared/CompilerSettings.cmake
+++ b/cmake/modules/shared/CompilerSettings.cmake
@@ -16,7 +16,8 @@ add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -require-explicit-sendable>")
 add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport>"
-  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend Lifetimes>")
+  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend Lifetimes>"
+  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-experimental-feature -Xfrontend Extern>")
 add_compile_options(
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend ExistentialAny>"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -enable-upcoming-feature -Xfrontend InternalImportsByDefault>"


### PR DESCRIPTION
This PR provides an abstraction over `exit()` that calls the PAL function `_swift_exit()` under Embedded Swift.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
