### PR TITLE
Use `getc_unlocked()` where available.

### DIFF
--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -497,6 +497,13 @@ extension FileHandle {
 
     try withLock {
       try withUnsafeCFILEHandle { file in
+        // We're already holding the file's lock, so avoid locking for each
+        // byte we read if the platform supports it.
+#if SWT_TARGET_OS_APPLE || os(Linux) || os(FreeBSD) || os(OpenBSD) || os(Android)
+        let fgetc = getc_unlocked
+#elseif os(Windows)
+        let fgetc = _fgetc_nolock
+#endif
         while terminator == nil, let byteRead = UInt8(exactly: fgetc(file)) {
           if try isTerminator(byteRead) {
             terminator = byteRead


### PR DESCRIPTION
If the platform supports `getc_unlocked()` (`_fgetc_nolock()` on Windows), we can use it in `FileHandle.read(until:)` to reduce lock traffic.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
