### PR TITLE
Start enabling writing JSON from Embedded Swift.

### DIFF
--- a/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
+++ b/Sources/Testing/ABI/EntryPoints/EntryPoint.swift
@@ -450,6 +450,7 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
     // respected (it should be the least "surprising" outcome of passing both.)
   }
 #endif
+#endif
 
   // Event stream output
   if let path = args.argumentValue(forLabel: "--event-stream-output-path") ?? args.argumentValue(forLabel: "--experimental-event-stream-output") {
@@ -485,7 +486,6 @@ func parseCommandLineArguments(from args: [String]) throws -> __CommandLineArgum
       result.eventStreamVersionNumber = eventStreamVersion
     }
   }
-#endif
 
   // XML output
   if let xunitOutputPath = args.argumentValue(forLabel: "--xunit-output") {
@@ -626,23 +626,39 @@ public func configurationForEntryPoint(from args: __CommandLineArguments_v0, emi
 #endif
     configuration.attachmentsPath = attachmentsPath
   }
+#endif
 
 #if !SWT_NO_ABI_JSON_SCHEMA
   // Event stream output
-  if let eventStreamOutputPath = args.eventStreamOutputPath {
-    let file = try FileHandle(forWritingAtPath: eventStreamOutputPath)
-    let eventHandler = try eventHandlerForStreamingEvents(withVersionNumber: args.eventStreamVersionNumber, encodeAsJSONLines: true) { json in
-      _ = try? file.withLock {
-        try file.write(json)
-        try file.write("\n")
+  do {
+    var eventHandler: Event.Handler?
+#if !hasFeature(Embedded)
+    if let eventStreamOutputPath = args.eventStreamOutputPath {
+#if !SWT_NO_FILE_IO
+      let file = try FileHandle(forWritingAtPath: eventStreamOutputPath)
+      eventHandler = try eventHandlerForStreamingEvents(withVersionNumber: args.eventStreamVersionNumber, encodeAsJSONLines: true) { json in
+        _ = try? file.withLock {
+          try file.write(json)
+          try file.write(.asciiNewlineCharacter)
+        }
+      }
+#else
+      throw _EntryPointError.featureUnavailable("--event-stream-output-path requires support for file I/O, but Swift Testing has been built without it.")
+#endif
+    }
+#else
+    eventHandler = try eventHandlerForStreamingEvents(withVersionNumber: args.eventStreamVersionNumber, encodeAsJSONLines: true) { json in
+      var newline = UInt8.asciiNewlineCharacter
+      _swift_testing_writeJSON(json.baseAddress!, json.count, &newline)
+    }
+#endif
+    if let eventHandler {
+      configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
+        eventHandler(event, context)
+        oldEventHandler(event, context)
       }
     }
-    configuration.eventHandler = { [oldEventHandler = configuration.eventHandler] event, context in
-      eventHandler(event, context)
-      oldEventHandler(event, context)
-    }
   }
-#endif
 #endif
 
 #if canImport(_StringProcessing)

--- a/Sources/Testing/ExitTests/ExitTest.swift
+++ b/Sources/Testing/ExitTests/ExitTest.swift
@@ -764,7 +764,7 @@ extension ExitTest {
     let eventHandler = ABI.BackChannelVersion.eventHandler(encodeAsJSONLines: true) { json in
       _ = try? backChannel.withLock {
         try backChannel.write(json)
-        try backChannel.write("\n")
+        try backChannel.write(.asciiNewlineCharacter)
       }
     }
     configuration.eventHandler = { event, eventContext in
@@ -961,7 +961,7 @@ extension ExitTest {
         try capturedValuesWriteEnd.withLock {
           try exitTest._withEncodedCapturedValuesForEntryPoint { capturedValuesJSON in
             try capturedValuesWriteEnd.write(capturedValuesJSON)
-            try capturedValuesWriteEnd.write("\n")
+            try capturedValuesWriteEnd.write(.asciiNewlineCharacter)
           }
         }
         capturedValuesReadEnd.close()

--- a/Sources/Testing/Support/Additions/NumericAdditions.swift
+++ b/Sources/Testing/Support/Additions/NumericAdditions.swift
@@ -31,6 +31,11 @@ extension Numeric {
 extension UInt8 {
   /// Whether or not this instance is an ASCII newline character (`\n` or `\r`).
   var isASCIINewline: Bool {
-    self == UInt8(ascii: "\r") || self == UInt8(ascii: "\n")
+    self == UInt8(ascii: "\r") || self == .asciiNewlineCharacter
+  }
+
+  /// The canonical ASCII newline character, `"\n"`.
+  @inline(always) static var asciiNewlineCharacter: Self {
+    UInt8(ascii: "\n")
   }
 }

--- a/Sources/Testing/Support/FileHandle.swift
+++ b/Sources/Testing/Support/FileHandle.swift
@@ -586,6 +586,30 @@ extension FileHandle {
     }
   }
 
+  /// Write a single byte to this file handle.
+  ///
+  /// - Parameters:
+  ///   - byte: The byte to write.
+  ///   - flushAfterward: Whether or not to flush the file (with `fflush()`)
+  ///     after writing. If `true`, `fflush()` is called even if an error
+  ///     occurred while writing.
+  ///
+  /// - Throws: Any error that occurred while writing `bytes`. If an error
+  ///   occurs while flushing the file, it is not thrown.
+  func write(_ byte: UInt8, flushAfterward: Bool = true) throws {
+    try withUnsafeCFILEHandle { file in
+      defer {
+        if flushAfterward {
+          _ = fflush(file)
+        }
+      }
+
+      if EOF == fputc(CInt(byte), file) {
+        throw CError(rawValue: swt_errno())
+      }
+    }
+  }
+
   /// Write a string to this file handle.
   ///
   /// - Parameters:
@@ -597,8 +621,7 @@ extension FileHandle {
   /// - Throws: Any error that occurred while writing `string`. If an error
   ///   occurs while flushing the file, it is not thrown.
   ///
-  /// `string` is converted to a UTF-8 C string (UTF-16 on Windows) and written
-  /// to this file handle.
+  /// `string` is converted to a UTF-8 C string and written to this file handle.
   func write(_ string: String, flushAfterward: Bool = true) throws {
     try withUnsafeCFILEHandle { file in
       defer {
@@ -607,10 +630,9 @@ extension FileHandle {
         }
       }
 
-      try string.withCString { string in
-        if EOF == fputs(string, file) {
-          throw CError(rawValue: swt_errno())
-        }
+      var string = string
+      try string.withUTF8 { string in
+        try write(string, flushAfterward: flushAfterward)
       }
     }
   }


### PR DESCRIPTION
This PR starts plumbing through the logic to write the JSON event stream under Embedded Swift. Since we don't have arbitrary file handles here, we provide a new PAL annex function `_swift_testing_writeJSON()` that is responsible for routing the JSON to the right place.

At this time, we haven't yet decoupled the JSON event stream Swift structures (`ABI.Record` etc.) from `Codable`, so this code is nonfunctional. Decoupling will come in a future PR, as will support for actually encoding JSON in the first place.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
