### PR TITLE
Fix stringification of `TestContentRecord` in Embedded Swift.

### DIFF
--- a/Sources/_TestDiscovery/TestContentRecord.swift
+++ b/Sources/_TestDiscovery/TestContentRecord.swift
@@ -196,6 +196,14 @@ extension TestContentRecord: Sendable where Context: Sendable {}
 
 extension TestContentRecord: CustomStringConvertible {
   public var description: String {
+    func desc(_ address: UnsafeRawPointer) -> String {
+#if !hasFeature(Embedded)
+      String(describing: address)
+#else
+      "0x\(String(UInt(bitPattern: address), radix: 16))"
+#endif
+    }
+
 #if !hasFeature(Embedded)
     let typeName = String(describing: Self.self)
 #else
@@ -203,9 +211,14 @@ extension TestContentRecord: CustomStringConvertible {
 #endif
     let recordAddress = imageAddress.map { imageAddress in
       let recordAddressDelta = UnsafeRawPointer(_recordAddress) - imageAddress
-      return "\(imageAddress)+0x\(String(recordAddressDelta, radix: 16))"
-    } ?? "\(_recordAddress)"
+      return "\(desc(imageAddress))+0x\(String(recordAddressDelta, radix: 16))"
+    } ?? desc(_recordAddress)
+#if !hasFeature(Embedded)
     return "<\(typeName) \(recordAddress)> { kind: \(kind), context: \(context) }"
+#else
+    let context = unsafeBitCast(_recordAddress.pointee.context, to: UnsafeRawPointer.self)
+    return "<\(typeName) \(recordAddress)> { kind: \(kind), context: \(desc(context)) }"
+#endif
   }
 }
 


### PR DESCRIPTION
The `description` property of `TestContentRecord` in Embedded Swift does not produce the expected value:

> <TestContentRecord (cannot print value in embedded Swift)> { kind: 'test' (0x74657374), context: (cannot print value in embedded Swift) }

Although this string is not presented to users, it is very useful for debugging test discovery, so I ought to fix it.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
