### PR TITLE
Resolve issues building the `_TestingInternals` target for Embedded Swift.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -383,7 +383,7 @@ extension Array where Element == PackageDescription.SwiftSetting {
       result.append(.treatWarning("ExplicitSendable", as: .warning))
     }
 
-    if buildingForEmbedded {
+    if buildingForEmbedded && target.type != .macro {
       result.append(.enableExperimentalFeature("Embedded"))
 
       // Swift's concurrency module is not implicitly imported when building for

--- a/Sources/Testing/EmbeddedPlatform.swift
+++ b/Sources/Testing/EmbeddedPlatform.swift
@@ -77,3 +77,9 @@ let exit: @Sendable (_ exitCode: CInt) -> Never = { exitCode in
   swt_unreachable()
 #endif
 }
+
+#if hasFeature(Embedded)
+/// Workaround `_swift_willThrow()` not being declared in the runtime when
+/// it is built for Embedded Swift.
+@_silgen_name("_swift_willThrow") private nonisolated(unsafe) var _swift_willThrow: UnsafeRawPointer? = nil
+#endif

--- a/Sources/_TestingInternals/ExecutablePath.cpp
+++ b/Sources/_TestingInternals/ExecutablePath.cpp
@@ -10,9 +10,9 @@
 
 #include "ExecutablePath.h"
 
+#if defined(__OpenBSD__)
 #include <atomic>
 
-#if defined(__OpenBSD__)
 /// Storage for ``swt_getEarlyCWD()``.
 static constinit std::atomic<const char *> earlyCWD { nullptr };
 

--- a/Sources/_TestingInternals/Versions.cpp
+++ b/Sources/_TestingInternals/Versions.cpp
@@ -10,10 +10,10 @@
 
 #include "Versions.h"
 
-#include <array>
-#include <algorithm>
-#include <iterator>
-#include <mutex>
+template <size_t count>
+struct SWTCString {
+  char rawValue[count];
+};
 
 const char *swt_getTestingLibraryVersion(void) {
 #if defined(SWT_TESTING_LIBRARY_VERSION)
@@ -22,7 +22,7 @@ const char *swt_getTestingLibraryVersion(void) {
   return SWT_TESTING_LIBRARY_VERSION;
 #elif __clang_major__ >= 17 && defined(__has_embed)
 #if __has_embed("../../VERSION.txt")
-  static constexpr std::array result = [] () {
+  static constexpr SWTCString result = [] () {
     // Read the version from version.txt at the root of the package's repo.
     constexpr const char version[] = {
 #pragma clang diagnostic push
@@ -31,20 +31,21 @@ const char *swt_getTestingLibraryVersion(void) {
 #pragma clang diagnostic pop
     };
 
-    // Copy from the C string into a C++ array, stopping at the first newline if
-    // one is present.
-    std::array<char, std::size(version)> result {};
-    for (size_t i = 0; i < std::size(version); i++) {
+    // Copy from the C string into a wrapper structure, stopping at the first
+    // newline if one is present. We use a custom type instead of std::array
+    // because libc++ (or equivalent) may not be available in Embedded Swift.
+    SWTCString<sizeof(version)> result {};
+    for (size_t i = 0; i < sizeof(version); i++) {
       char c = version[i];
       if (c == '\r' || c == '\n') {
         break;
       }
-      result[i] = c;
+      result.rawValue[i] = c;
     }
     return result;
   }();
 
-  return result.data();
+  return result.rawValue;
 #else
 #warning SWT_TESTING_LIBRARY_VERSION not defined and VERSION.txt not found: testing library version is unavailable
   return nullptr;

--- a/Sources/_TestingInternals/Versions.cpp
+++ b/Sources/_TestingInternals/Versions.cpp
@@ -10,10 +10,10 @@
 
 #include "Versions.h"
 
-template <size_t count>
-struct SWTCString {
-  char rawValue[count];
-};
+#include <array>
+#include <algorithm>
+#include <iterator>
+#include <mutex>
 
 const char *swt_getTestingLibraryVersion(void) {
 #if defined(SWT_TESTING_LIBRARY_VERSION)
@@ -22,7 +22,7 @@ const char *swt_getTestingLibraryVersion(void) {
   return SWT_TESTING_LIBRARY_VERSION;
 #elif __clang_major__ >= 17 && defined(__has_embed)
 #if __has_embed("../../VERSION.txt")
-  static constexpr SWTCString result = [] () {
+  static constexpr std::array result = [] () {
     // Read the version from version.txt at the root of the package's repo.
     constexpr const char version[] = {
 #pragma clang diagnostic push
@@ -31,21 +31,20 @@ const char *swt_getTestingLibraryVersion(void) {
 #pragma clang diagnostic pop
     };
 
-    // Copy from the C string into a wrapper structure, stopping at the first
-    // newline if one is present. We use a custom type instead of std::array
-    // because libc++ (or equivalent) may not be available in Embedded Swift.
-    SWTCString<sizeof(version)> result {};
-    for (size_t i = 0; i < sizeof(version); i++) {
+    // Copy from the C string into a C++ array, stopping at the first newline if
+    // one is present.
+    std::array<char, std::size(version)> result {};
+    for (size_t i = 0; i < std::size(version); i++) {
       char c = version[i];
       if (c == '\r' || c == '\n') {
         break;
       }
-      result.rawValue[i] = c;
+      result[i] = c;
     }
     return result;
   }();
 
-  return result.rawValue;
+  return result.data();
 #else
 #warning SWT_TESTING_LIBRARY_VERSION not defined and VERSION.txt not found: testing library version is unavailable
   return nullptr;

--- a/Sources/_TestingInternals/WillThrow.cpp
+++ b/Sources/_TestingInternals/WillThrow.cpp
@@ -10,23 +10,33 @@
 
 #include "WillThrow.h"
 
+#if __has_include(<atomic>)
 #include <atomic>
 
 /// The Swift runtime error-handling hook.
 SWT_IMPORT_FROM_STDLIB std::atomic<SWTWillThrowHandler> _swift_willThrow;
 
-SWTWillThrowHandler swt_setWillThrowHandler(SWTWillThrowHandler handler) {
-  return _swift_willThrow.exchange(handler, std::memory_order_acq_rel);
-}
-
 /// The Swift runtime typed-error-handling hook.
 SWT_IMPORT_FROM_STDLIB __attribute__((weak_import)) std::atomic<SWTWillThrowTypedHandler> _swift_willThrowTypedImpl;
+#endif
+
+SWTWillThrowHandler swt_setWillThrowHandler(SWTWillThrowHandler handler) {
+#if __has_include(<atomic>)
+  return _swift_willThrow.exchange(handler, std::memory_order_acq_rel);
+#else
+  return nullptr;
+#endif
+}
 
 SWTWillThrowTypedHandler swt_setWillThrowTypedHandler(SWTWillThrowTypedHandler handler) {
+#if __has_include(<atomic>)
 #if defined(__APPLE__)
   if (&_swift_willThrowTypedImpl == nullptr) {
     return nullptr;
   }
 #endif
   return _swift_willThrowTypedImpl.exchange(handler, std::memory_order_acq_rel);
+#else
+  return nullptr;
+#endif
 }

--- a/Sources/_TestingInternals/include/Stubs.h
+++ b/Sources/_TestingInternals/include/Stubs.h
@@ -273,6 +273,7 @@ static int swt_siginfo_t_si_status(const siginfo_t *siginfo) {
 #endif
 #endif
 
+#if defined(EEXIST)
 /// Get the value of `EEXIST`.
 ///
 /// This function is provided because `EEXIST` is a complex macro in wasi-libc
@@ -280,6 +281,7 @@ static int swt_siginfo_t_si_status(const siginfo_t *siginfo) {
 static int swt_EEXIST(void) {
   return EEXIST;
 }
+#endif
 
 #if defined(F_GETFD)
 /// Call `fcntl(F_GETFD)`.


### PR DESCRIPTION
This resolves some issues building our C/C++ helper target, mostly around the lack of an available libc++/libstdc++ in Embedded SDKs.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
