### PR TITLE
Make the FreeBSD job optional/manual for now.

### DIFF
--- a/.github/workflows/main_using_main.yml
+++ b/.github/workflows/main_using_main.yml
@@ -25,9 +25,6 @@ jobs:
       macos_xcode_versions: '["swift_6.4"]'
       enable_wasm_sdk_build: true
       wasm_sdk_versions: '["nightly-main"]'
-      enable_freebsd_checks: true
-      freebsd_swift_versions: '["nightly-main"]'
-      freebsd_os_versions: '["14.3"]'
       enable_android_sdk_build: true
       android_sdk_versions: '["nightly-main"]'
       android_ndk_versions: '["r28c", "r29"]'

--- a/.github/workflows/main_using_release.yml
+++ b/.github/workflows/main_using_release.yml
@@ -29,6 +29,3 @@ jobs:
       android_sdk_versions: '["nightly-6.4.x"]'
       android_ndk_versions: '["r28c", "r29"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'
-#       enable_freebsd_checks: true
-#       freebsd_swift_versions: '["nightly-6.4.x"]'
-#       freebsd_os_versions: '["14.3"]'

--- a/.github/workflows/manual_build_freebsd.yml
+++ b/.github/workflows/manual_build_freebsd.yml
@@ -1,0 +1,29 @@
+name: Manual FreeBSD build
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - 'main'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: Test
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.15
+    with:
+      enable_freebsd_checks: true
+      freebsd_swift_versions: '["nightly-main"]'
+      freebsd_os_versions: '["14.3"]'
+      enable_linux_checks: false
+      enable_windows_checks: false
+      enable_macos_checks: false
+      enable_ios_checks: false
+      enable_wasm_sdk_build: false
+      enable_android_sdk_build: false
+      enable_android_sdk_checks: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,9 +38,6 @@ jobs:
       android_sdk_versions: '["nightly-main", "nightly-6.4.x"]'
       android_sdk_triples: '["aarch64-unknown-linux-android33", "x86_64-unknown-linux-android28"]'
       enable_android_sdk_checks: true
-      enable_freebsd_checks: true
-      freebsd_swift_versions: '["nightly-main"]'
-      freebsd_os_versions: '["14.3"]'
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.15


### PR DESCRIPTION
The FreeBSD toolchain hasn't been updated in a while and it is now too stale to reliably build our ToT. Make it a separate manual workflow for now.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
