### PR TITLE
Add an equivalent of `operatingSystemVersion` for Embedded Swift.

### DIFF
--- a/Sources/Testing/Events/Event.Metadata.swift
+++ b/Sources/Testing/Events/Event.Metadata.swift
@@ -8,8 +8,6 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
-private import _TestingInternals
-
 extension Event {
   /// A type describing metadata regarding a test run, the current environment,
   /// etc.

--- a/Sources/Testing/Events/Event.Metadata.swift
+++ b/Sources/Testing/Events/Event.Metadata.swift
@@ -8,6 +8,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 //
 
+private import _TestingInternals
+
 extension Event {
   /// A type describing metadata regarding a test run, the current environment,
   /// etc.
@@ -64,6 +66,7 @@ extension Event.Metadata {
   private static var _simulatorOSVersionName: String { "OS Version (Simulator)" }
   private static var _hostOSVersionName: String { "OS Version (Host)" }
   private static var _osVersionName: String { "OS Version" }
+  private static var _embeddedTargetInfoName: String { "Embedded Target Info" }
   private static var _apiLevelName: String { "API Level" }
 
   /// All metadata that the testing library collects.
@@ -86,11 +89,17 @@ extension Event.Metadata {
     if let targetTriple {
       append(_targetPlatformName, targetTriple)
     }
+#if !hasFeature(Embedded)
 #if targetEnvironment(simulator)
     append(_simulatorOSVersionName, simulatorVersion)
     append(_hostOSVersionName, operatingSystemVersion)
 #else
     append(_osVersionName, operatingSystemVersion)
+#endif
+#else
+    if let embeddedTargetInfo {
+      append(_embeddedTargetInfoName, embeddedTargetInfo)
+    }
 #endif
 #if os(Android)
     append(_apiLevelName, apiLevel)

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -11,6 +11,7 @@
 private import _TestingInternals
 private import SwiftShims
 
+#if !hasFeature(Embedded)
 /// A human-readable string describing the current operating system's version.
 ///
 /// This value's format is platform-specific and is not meant to be
@@ -119,6 +120,16 @@ let simulatorVersion: String = {
     return "\(productVersion) (\(buildNumber))"
   }
 }()
+#endif
+#else
+/// A human-readable string describing the current Embedded Swift target.
+///
+/// This value's format is platform-specific and is not meant to be
+/// machine-readable. It is added to the output of a test run when using
+/// an event writer.
+///
+/// This value is not part of the public interface of the testing library.
+let embeddedTargetInfo: String? = _swift_testing_getEmbeddedTargetInfo().flatMap(String.init(validatingCString:))
 #endif
 
 #if os(Android)
@@ -233,7 +244,7 @@ let glibcVersion: VersionNumber = {
 
 // MARK: - sysctlbyname() Wrapper
 
-#if !SWT_NO_SYSCTL && SWT_TARGET_OS_APPLE
+#if !hasFeature(Embedded) && !SWT_NO_SYSCTL && SWT_TARGET_OS_APPLE
 /// Get a string value by calling `sysctlbyname()`.
 ///
 /// - Parameters:

--- a/Sources/Testing/Support/Versions.swift
+++ b/Sources/Testing/Support/Versions.swift
@@ -122,6 +122,14 @@ let simulatorVersion: String = {
 }()
 #endif
 #else
+/// A human-readable C string describing the current Embedded Swift target.
+///
+/// We keep a reference directly to the C string in order to avoid an apparent
+/// memory leak if the implementation heap-allocates it.
+///
+/// For more information, see ``embeddedTargetInfo``.
+private let _embeddedTargetInfoCString = _swift_testing_getEmbeddedTargetInfo()
+
 /// A human-readable string describing the current Embedded Swift target.
 ///
 /// This value's format is platform-specific and is not meant to be
@@ -129,7 +137,7 @@ let simulatorVersion: String = {
 /// an event writer.
 ///
 /// This value is not part of the public interface of the testing library.
-let embeddedTargetInfo: String? = _swift_testing_getEmbeddedTargetInfo().flatMap(String.init(validatingCString:))
+let embeddedTargetInfo = _embeddedTargetInfoCString.flatMap(String.init(validatingCString:))
 #endif
 
 #if os(Android)

--- a/Sources/_TestingInternals/include/EmbeddedPlatform.h
+++ b/Sources/_TestingInternals/include/EmbeddedPlatform.h
@@ -22,6 +22,54 @@ SWT_ASSUME_NONNULL_BEGIN
 /// This header augments the set of declarations in the Swift runtime's Platform
 /// Abstraction Layer, which can be found [here](https://github.com/swiftlang/swift/blob/main/stdlib/public/EmbeddedPlatform/swift/EmbeddedPlatform.h).
 
+// MARK: - System metadata
+
+/// Get information about the embedded system on which (or for which) Swift
+/// Testing has been built and is running.
+///
+/// - Returns: A UTF-8-encoded C string representing some human-readable
+///   information identifying the current system. Whether this string represents
+///   the system's hardware, software, or other defining characteristics is
+///   implementation-defined. If no meaningful information is available, returns
+///   `NULL`. The string must remain valid for the lifetime of the process, and
+///   the caller is not responsible for deallocating it.
+///
+/// The testing library uses this function to describe the embedded system it
+/// is running on. This information is used for diagnostic purposes only.
+///
+/// An implementation may choose to return a constant string, a string stored in
+/// statically-allocated memory, or a string allocated at runtime. The return
+/// value is implementation-defined, but where possible should include useful
+/// information about the system. For example, an implementation on a
+/// 68040-based Macintosh might return something like `"Quadra 950 (System 7.5.5)"`.
+///
+/// ### Reference implementations
+///
+/// On POSIX-compliant targets, this function can be implemented as a call to
+/// `uname()`:
+///
+/// ```c
+/// const char *_swift_testing_getEmbeddedTargetInfo(void) {
+///   static const char *result = NULL;
+///
+///   if (!result) {
+///     struct utsname name {};
+///     if (0 == uname(&name)) {
+///       (void)asprintf(&result, "%s (%s)", name.release, name.version);
+///     }
+///   }
+///
+///   return result;
+/// }
+/// ```
+///
+/// ### Concurrency support
+///
+/// The testing library calls this function at most once during the lifetime of
+/// a test process. The testing library does not free the function's result, so
+/// the implementation can return the same C string more than once.
+SWT_EXTERN const char *_Nullable _swift_testing_getEmbeddedTargetInfo(void);
+
 // MARK: - Console output
 
 /// A type describing the capabilities of the current system's console output.

--- a/Sources/_TestingInternals/include/EmbeddedPlatform.h
+++ b/Sources/_TestingInternals/include/EmbeddedPlatform.h
@@ -66,8 +66,7 @@ SWT_ASSUME_NONNULL_BEGIN
 /// ### Concurrency support
 ///
 /// The testing library calls this function at most once during the lifetime of
-/// a test process. The testing library does not free the function's result, so
-/// the implementation can return the same C string more than once.
+/// a test process.
 SWT_EXTERN const char *_Nullable _swift_testing_getEmbeddedTargetInfo(void);
 
 // MARK: - Console output


### PR DESCRIPTION
We gather the user's operating system version and output it to the console in verbose mode in order to improve diagnostic quality when a bug is reported. In Embedded Swift, there may not be a meaningful value for "operating system version", so provide a PAL annex function that can be used to generate anything that would be relevant/useful here.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
