### PR TITLE
[Testing] Introduce `EnvironmentTrait` for scoped environment variable overrides

### DIFF
--- a/Documentation/EnvironmentVariables.md
+++ b/Documentation/EnvironmentVariables.md
@@ -69,4 +69,11 @@ names prefixed with `SWT_`.
 | `SWT_EXPERIMENTAL_SERIALIZED_TRAIT_APPLIES_GLOBALLY` | `Bool` | Whether or not `.serialized` applies globally or just to its branch of the test graph. |
 | `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH` | `Int` | The default parallelization width when parallelized testing is enabled. |
 
+## Scoped environment variables in tests
+
+To apply custom environment variables to tests or suites, use the `Trait/environment(_:)`
+trait. Tests using this trait run serially, preventing data races in the process'
+environment block, and previous environment variable values are automatically restored
+after the test finishes.
+
 [interop-modes]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0021-targeted-interoperability-swift-testing-and-xctest.md#interoperability-modes

--- a/Sources/Testing/CMakeLists.txt
+++ b/Sources/Testing/CMakeLists.txt
@@ -138,6 +138,7 @@ add_library(Testing
   Traits/Tags/Tag+Predefined.swift
   Traits/TimeLimitTrait.swift
   Traits/TaskLocalTrait.swift
+  Traits/EnvironmentTrait.swift
   Traits/Trait.swift)
 target_link_libraries(Testing PRIVATE
   _TestDiscovery

--- a/Sources/Testing/Testing.docc/Traits.md
+++ b/Sources/Testing/Testing.docc/Traits.md
@@ -65,6 +65,7 @@ types that customize the behavior of your tests.
 - ``Bug``
 - ``Comment``
 - ``ConditionTrait``
+- ``EnvironmentTrait``
 - ``IssueHandlingTrait``
 - ``ParallelizationTrait``
 - ``Tag``

--- a/Sources/Testing/Testing.docc/Traits/Trait.md
+++ b/Sources/Testing/Testing.docc/Traits/Trait.md
@@ -43,3 +43,7 @@ See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 - ``Trait/TestScopeProvider``
 - ``Trait/prepare(for:)-3s3zo``
 - ``Trait/taskLocal(_:withValue:)``
+- ``Trait/environment(_:)-80yv4``
+- ``Trait/environment(_:)-8j89x``
+- ``Trait/environment(_:_:)``
+- ``EnvironmentTrait``

--- a/Sources/Testing/Traits/EnvironmentTrait.swift
+++ b/Sources/Testing/Traits/EnvironmentTrait.swift
@@ -1,0 +1,195 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+private import _TestingInternals
+
+/// A type that sets environment variables for the duration of a test or
+/// suite.
+///
+/// When you apply an instance of this trait to a test suite, the testing
+/// library recursively applies it to all test suites and test functions within
+/// it.
+///
+/// To add this trait to a test, use ``Trait/environment(_:)-80yv4``,
+/// ``Trait/environment(_:)-8j89x``, or ``Trait/environment(_:_:)``.
+///
+/// @Metadata {
+///   @Available(Swift, introduced: 6.5)
+/// }
+public struct EnvironmentTrait: SuiteTrait, TestTrait, Sendable {
+  /// A dictionary containing the environment variables to set or unset.
+  ///
+  /// A value of `nil` indicates that the environment variable should be unset
+  /// for the duration of the test.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public var variables: [String: String?]
+
+  /// Constructs an instance of this trait with the specified variables.
+  ///
+  /// - Parameters:
+  ///   - variables: A dictionary containing the environment variables and
+  ///     their values to set. Pass `nil` as a value to unset the variable.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public init(variables: [String: String?]) {
+    self.variables = variables
+  }
+
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public var isRecursive: Bool {
+    true
+  }
+}
+
+// MARK: - TestScoping
+
+extension EnvironmentTrait: TestScoping {
+  /// A serializer used to run environment-mutating tests in serial order,
+  /// preventing data races in the process' environment block.
+  private static let _environmentSerializer = Serializer<Void>()
+
+  /// A task-local flag indicating whether the current task is already
+  /// executing within an environment trait scope, allowing nested scopes
+  /// without deadlocking on `_environmentSerializer`.
+  @TaskLocal private static var _isInsideEnvironmentScope = false
+
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public func provideScope(
+    for test: Test,
+    testCase: Test.Case?,
+    performing function: @Sendable () async throws -> Void
+  ) async throws {
+    if Self._isInsideEnvironmentScope {
+      // Already within the serializer lock on this task tree; apply scoped overrides directly.
+      try await _withEnvironmentOverrides(performing: function)
+    } else {
+      // Acquire the global environment serializer lock, then establish the scope.
+      try await Self._environmentSerializer.run {
+        try await Self.$_isInsideEnvironmentScope.withValue(true) {
+          try await _withEnvironmentOverrides(performing: function)
+        }
+      }
+    }
+  }
+
+  /// Apply the environment overrides, execute `function`, and restore the
+  /// previous environment values in a `defer` block.
+  private func _withEnvironmentOverrides(
+    performing function: @Sendable () async throws -> Void
+  ) async throws {
+    var previousValues = [String: String?]()
+    previousValues.reserveCapacity(variables.count)
+
+    // Record current values so we can restore them later.
+    for key in variables.keys {
+      previousValues[key] = Environment.variable(named: key)
+    }
+
+    // Set the new values.
+    for (key, value) in variables {
+      Environment.setVariable(value, named: key)
+    }
+
+    defer {
+      // Restore original environment values in reverse order of mutation.
+      for (key, previousValue) in previousValues {
+        Environment.setVariable(previousValue, named: key)
+      }
+    }
+
+    try await function()
+  }
+}
+
+#if !hasFeature(Embedded)
+// MARK: - ReducibleTrait
+
+@_spi(Experimental)
+extension EnvironmentTrait: ReducibleTrait {
+  public func reduce(into other: Self) -> Self? {
+    // When multiple environment traits are applied (e.g. inherited from a suite
+    // and overridden by a test function), merge them so that the innermost/latest
+    // trait's keys take precedence over the outer trait's keys.
+    var combined = other.variables
+    for (key, value) in self.variables {
+      combined[key] = value
+    }
+    return EnvironmentTrait(variables: combined)
+  }
+}
+#endif
+
+// MARK: -
+
+extension Trait {
+  /// Constructs a trait that sets environment variables for the duration of
+  /// a test or suite.
+  ///
+  /// - Parameters:
+  ///   - variables: A dictionary of environment variable names and their
+  ///     desired values. Pass `nil` for a value to unset that variable.
+  ///
+  /// - Returns: An instance of ``EnvironmentTrait``.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public static func environment(
+    _ variables: [String: String?]
+  ) -> Self where Self == EnvironmentTrait {
+    EnvironmentTrait(variables: variables)
+  }
+
+  /// Constructs a trait that sets environment variables for the duration of
+  /// a test or suite.
+  ///
+  /// - Parameters:
+  ///   - variables: A dictionary of environment variable names and their
+  ///     desired string values.
+  ///
+  /// - Returns: An instance of ``EnvironmentTrait``.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public static func environment(
+    _ variables: [String: String]
+  ) -> Self where Self == EnvironmentTrait {
+    EnvironmentTrait(variables: variables.mapValues { $0 as String? })
+  }
+
+  /// Constructs a trait that sets a single environment variable for the
+  /// duration of a test or suite.
+  ///
+  /// - Parameters:
+  ///   - name: The name of the environment variable.
+  ///   - value: The value to set, or `nil` to unset the variable.
+  ///
+  /// - Returns: An instance of ``EnvironmentTrait``.
+  ///
+  /// @Metadata {
+  ///   @Available(Swift, introduced: 6.5)
+  /// }
+  public static func environment(
+    _ name: String,
+    _ value: String?
+  ) -> Self where Self == EnvironmentTrait {
+    EnvironmentTrait(variables: [name: value])
+  }
+}

--- a/Tests/TestingTests/Traits/EnvironmentTraitTests.swift
+++ b/Tests/TestingTests/Traits/EnvironmentTraitTests.swift
@@ -1,0 +1,108 @@
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+//
+
+@testable @_spi(Experimental) @_spi(ForToolsIntegrationOnly) import Testing
+
+@Suite("EnvironmentTrait tests", .tags(.traitRelated))
+struct EnvironmentTraitTests {
+  @Test(
+    "Single variable set",
+    .environment("SWT_TEST_SINGLE_VAR", "hello_world")
+  )
+  func singleVariableSet() throws {
+    #expect(Environment.variable(named: "SWT_TEST_SINGLE_VAR") == "hello_world")
+  }
+
+  @Test(
+    "Multiple variables set",
+    .environment(["SWT_TEST_VAR_A": "alpha", "SWT_TEST_VAR_B": "beta"])
+  )
+  func multipleVariablesSet() throws {
+    #expect(Environment.variable(named: "SWT_TEST_VAR_A") == "alpha")
+    #expect(Environment.variable(named: "SWT_TEST_VAR_B") == "beta")
+  }
+
+  @Test(
+    "Unset variable",
+    .environment(["SWT_TEST_UNSET_VAR": nil])
+  )
+  func unsetVariable() throws {
+    #expect(Environment.variable(named: "SWT_TEST_UNSET_VAR") == nil)
+  }
+
+  @Suite("Suite inheritance", .environment(["SWT_TEST_SUITE_VAR": "inherited_value"]))
+  struct SuiteInheritance {
+    @Test("Inherits from suite")
+    func inheritsFromSuite() {
+      #expect(Environment.variable(named: "SWT_TEST_SUITE_VAR") == "inherited_value")
+    }
+
+    @Test(
+      "Overrides suite variable",
+      .environment("SWT_TEST_SUITE_VAR", "overridden_value")
+    )
+    func overridesSuiteVariable() {
+      #expect(Environment.variable(named: "SWT_TEST_SUITE_VAR") == "overridden_value")
+    }
+  }
+
+#if !hasFeature(Embedded)
+  @Test("reduce(into:) combines overlapping environment variables")
+  func reduceInto() {
+    let parent = EnvironmentTrait(variables: ["KEY_A": "original", "KEY_B": "keep"])
+    let child = EnvironmentTrait(variables: ["KEY_A": "override", "KEY_C": "new"])
+    let reduced = child.reduce(into: parent)
+
+    #expect(reduced?.variables["KEY_A"] == "override")
+    #expect(reduced?.variables["KEY_B"] == "keep")
+    #expect(reduced?.variables["KEY_C"] == "new")
+  }
+#endif
+
+  @Test("Environment restoration after test execution")
+  func environmentRestoration() async throws {
+    let key = "SWT_TEST_RESTORATION_KEY"
+    let originalValue = "original_state"
+    Environment.setVariable(originalValue, named: key)
+    defer {
+      Environment.setVariable(nil, named: key)
+    }
+
+    let trait = EnvironmentTrait(variables: [key: "temporary_state"])
+    let test = Test(name: "dummy") {}
+
+    try await trait.provideScope(for: test, testCase: nil) {
+      #expect(Environment.variable(named: key) == "temporary_state")
+    }
+
+    #expect(Environment.variable(named: key) == originalValue)
+  }
+
+  @Test("Environment restoration on thrown error")
+  func environmentRestorationOnError() async throws {
+    let key = "SWT_TEST_THROW_KEY"
+    Environment.setVariable(nil, named: key)
+
+    struct DummyError: Error {}
+    let trait = EnvironmentTrait(variables: [key: "temporary_value"])
+    let test = Test(name: "dummy") {}
+
+    do {
+      try await trait.provideScope(for: test, testCase: nil) {
+        #expect(Environment.variable(named: key) == "temporary_value")
+        throw DummyError()
+      }
+    } catch is DummyError {
+      // Expected error
+    }
+
+    #expect(Environment.variable(named: key) == nil)
+  }
+}


### PR DESCRIPTION
Add `EnvironmentTrait` and `Trait.environment(_:)` factory methods to
allow test functions and suites to declare environment variable overrides
that are automatically applied before the test runs and restored
afterwards.

### Motivation

Tests that rely on environment variables today require manual setup and
teardown, which is error-prone and verbose. This change provides a
first-class, declarative way to scope environment mutations to a test or
suite, matching the ergonomics of `TaskLocalTrait`.

### Implementation

- **`EnvironmentTrait`** conforms to `SuiteTrait`, `TestTrait`, and
  `TestScoping`. Its `provideScope(for:testCase:performing:)` method
  saves the current values of the requested keys, sets the overrides,
  runs the test body, and restores original values in a `defer` block.
- **Serialization:** because POSIX `setenv`/`unsetenv` are MT-unsafe,
  all environment-scoped tests are serialized through a shared
  `Serializer<Void>`. A `@TaskLocal` flag prevents re-entrant tasks
  from deadlocking on the serializer.
- **`ReducibleTrait`:** when multiple `EnvironmentTrait` instances are
  inherited (e.g. suite trait + function trait), they are merged so the
  innermost key wins. This is gated on `!hasFeature(Embedded)` to
  match the pattern used by `ParallelizationTrait`.
- **Three factory methods** on `Trait` cover the common call-site shapes:
  - `.environment("KEY", "value")` — single key/value pair
  - `.environment(["KEY": "value"])` — dictionary of `String: String`
  - `.environment(["KEY": nil])` — dictionary of `String: String?` (for unsetting)
- Documentation and `CMakeLists.txt` are updated accordingly.

### Checklist

- [x] Code and documentation follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references are updated.