### PR TITLE
Adjust `CustomTestStringConvertible` and `CustomIssueRepresentable` for Embedded Swift.

### DIFF
--- a/Sources/Testing/Issues/Issue+Recording.swift
+++ b/Sources/Testing/Issues/Issue+Recording.swift
@@ -21,11 +21,8 @@ extension Issue {
   func record(configuration: Configuration? = nil) -> Self {
     // If this issue is a caught error that has a custom issue representation,
     // perform that customization now.
-    if case let .errorCaught(error) = kind {
-      if let error = error as? any CustomIssueRepresentable {
-        let selfCopy = error.customize(self)
-        return selfCopy.record(configuration: configuration)
-      }
+    if let selfCopy = customizeIssueIfNeeded(self) {
+      return selfCopy.record(configuration: configuration)
     }
 
     // If this issue matches via the known issue matcher, set a copy of it to be
@@ -216,12 +213,14 @@ extension Issue {
     configuration: Configuration? = nil,
     _ body: () throws -> Void
   ) -> (any Error)? {
+#if !hasFeature(Embedded)
     // Ensure that we are capturing backtraces for errors before we start
     // expecting to see them.
     Backtrace.startCachingForThrownErrors()
     defer {
       Backtrace.flushThrownErrorCache()
     }
+#endif
 
     do {
       try body()
@@ -261,12 +260,14 @@ extension Issue {
     isolation: isolated (any Actor)? = #isolation,
     _ body: () async throws -> Void
   ) async -> (any Error)? {
+#if !hasFeature(Embedded)
     // Ensure that we are capturing backtraces for errors before we start
     // expecting to see them.
     Backtrace.startCachingForThrownErrors()
     defer {
       Backtrace.flushThrownErrorCache()
     }
+#endif
 
     do {
       try await body()

--- a/Sources/Testing/SourceAttribution/CustomTestStringConvertible.swift
+++ b/Sources/Testing/SourceAttribution/CustomTestStringConvertible.swift
@@ -80,7 +80,7 @@ extension String {
   }
 
   public init(describingForTest value: borrowing some CustomStringConvertible) {
-    self.init(describing: value)
+    self = value.description
   }
 
   public init(describingForTest value: borrowing some CustomDebugStringConvertible & CustomTestStringConvertible) {
@@ -88,7 +88,7 @@ extension String {
   }
 
   public init(describingForTest value: borrowing some CustomDebugStringConvertible) {
-    self = value.debugDescription // FIXME: use init(reflecting:) in Embedded Swift
+    self = value.debugDescription
   }
 
   public init(describingForTest value: borrowing some CustomStringConvertible & CustomDebugStringConvertible & CustomTestStringConvertible) {
@@ -96,7 +96,7 @@ extension String {
   }
 
   public init(describingForTest value: borrowing some CustomStringConvertible & CustomDebugStringConvertible) {
-    self.init(describing: value)
+    self = value.description
   }
 
   @_disfavoredOverload

--- a/Sources/Testing/Support/CustomIssueRepresentable.swift
+++ b/Sources/Testing/Support/CustomIssueRepresentable.swift
@@ -32,6 +32,38 @@ protocol CustomIssueRepresentable: Error {
   func customize(_ issue: consuming Issue) -> Issue
 }
 
+/// Customize the given issue if its type conforms to ``CustomIssueRepresentable``.
+///
+/// - Parameters:
+///   - issue: The issue to customize. The function consumes this value.
+///
+/// - Returns: A customized copy of `issue`, or `nil` if its type does not
+///   conform to ``CustomIssueRepresentable``.
+func customizeIssueIfNeeded(_ issue: Issue) -> Issue? {
+  guard case let .errorCaught(error) = issue.kind else {
+    return nil
+  }
+
+  lazy var issue = issue
+#if !hasFeature(Embedded)
+  if let error = error as? any CustomIssueRepresentable {
+    return error.customize(issue)
+  }
+#else
+  // We can't dynamically cast to `any CustomIssueRepresentable`, so hard-code
+  // all conformances to `CustomIssueRepresentable` we know about.
+  if let error = error as? SystemError {
+    return error.customize(issue)
+  } else if let error = error as? APIMisuseError {
+    return error.customize(issue)
+  } else if let error = error as? ExpectationFailedError {
+    return error.customize(issue)
+  }
+#endif
+
+  return nil
+}
+
 // MARK: - Internal error types
 
 /// A type representing an error in the testing library or its underlying
@@ -100,7 +132,11 @@ extension ExpectationFailedError: CustomIssueRepresentable {
     // this error does not generate a new issue, but code that passes this error
     // to Issue.record() is misbehaving.
     issue.kind = .apiMisused
+#if !hasFeature(Embedded)
     issue.comments.append("Recorded an error of type \(Self.self) representing an expectation that failed and was already recorded: \(expectation)")
+#else
+    issue.comments.append("Recorded an error of type \(Self.self) representing an expectation that failed and was already recorded at \(expectation.sourceLocation)")
+#endif
     return issue
   }
 }


### PR DESCRIPTION
Adjusts the implementations of these two protocols to work in Embedded Swift. The former needs to explicitly access `description` instead of calling `String(describing:)` because that's implemented generically in Embedded Swift (and you can't open an existential there nor cast between generic types). The latter needs to hard-code the list of conforming types, but only for Embedded Swift.

`CustomTestReflectable` is already unavailable in Embedded Swift. `CustomTestArgumentEncodable` will be hidden from Embedded Swift in its entirety in a future PR as it's not possible to implement it there.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
