### PR TITLE
Modify `TestScoping` to work in Embedded Swift.

### DIFF
--- a/Sources/Testing/Running/Runner.swift
+++ b/Sources/Testing/Running/Runner.swift
@@ -121,8 +121,13 @@ extension Runner {
     // trait is the first one to be invoked.
     let executeAllTraits = test.traits.lazy
       .reversed()
-      .compactMap { $0.scopeProvider(for: test, testCase: testCase) }
-      .map { $0.provideScope(for:testCase:performing:) }
+      .compactMap { trait in
+#if !hasFeature(Embedded)
+        trait.scopeProvider(for: test, testCase: testCase)
+#else
+        trait.__scopeProvider(for: test, testCase: testCase)
+#endif
+      }.map { $0.provideScope(for:testCase:performing:) }
       .reduce(body) { executeAllTraits, provideScope in
         {
           try await provideScope(test, testCase, executeAllTraits)

--- a/Sources/Testing/Traits/Trait.swift
+++ b/Sources/Testing/Traits/Trait.swift
@@ -111,6 +111,13 @@ public protocol Trait: Sendable {
   func scopeProvider(for test: Test, testCase: Test.Case?) -> TestScopeProvider?
 
 #if hasFeature(Embedded)
+  /// Get this trait's scope provider for the specified test and optional test
+  /// case.
+  ///
+  /// - Warning: This function is used to implement traits under Embedded Swift.
+  ///   Do not use it or provide an implementation for it.
+  func __scopeProvider(for test: Test, testCase: Test.Case?) -> (any TestScoping)?
+
   /// Get this value as an instance of ``TestTrait``.
   ///
   /// - Warning: This function is used to implement traits under Embedded Swift.
@@ -179,6 +186,14 @@ public protocol TestScoping: Sendable {
   /// }
   func provideScope(for test: Test, testCase: Test.Case?, performing function: @Sendable () async throws -> Void) async throws
 }
+
+#if hasFeature(Embedded)
+extension Trait {
+  public func __scopeProvider(for test: Test, testCase: Test.Case?) -> (any TestScoping)? {
+    scopeProvider(for: test, testCase: testCase)
+  }
+}
+#endif
 
 extension Trait where Self: TestScoping {
   /// Get this trait's scope provider for the specified test or test case.


### PR DESCRIPTION
This PR changes how we get the test scope provider from a trait in Embedded Swift so that we're not trying to get an existential (`any TestScoping`) from an existential (`any Trait`) which the compiler does not allow. Instead, we add an underscored, default-implemented requirement to `Trait` that does the type erasure for us.

Without this change, calling `scopeProvider(for:testCase:)` produces this error:

> error: cannot specialize generic function or default protocol method in this context [#EmbeddedRestrictions]

Non-Embedded Swift is unaffected.

### Checklist:

- [x] Code and documentation should follow the style of the [Style Guide](https://github.com/apple/swift-testing/blob/main/Documentation/StyleGuide.md).
- [x] If public symbols are renamed or modified, DocC references should be updated.
